### PR TITLE
add basic json validation

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -5,6 +5,7 @@ import express from "express";
 import fetch from "node-fetch";
 import cors from "cors";
 import validateJSON from "./validate-json.js";
+import validateCSV from "./validate-csv.js";
 
 const app = initializeApp();
 const db = getFirestore(app);
@@ -49,6 +50,12 @@ api.post('/', async (req, res) => {
     if(exp_data.allowJSON){
       const validJSON = validateJSON(data);
       if(validJSON){
+        valid = true;
+      }
+    }
+    if(exp_data.allowCSV && !valid){
+      const validCSV = validateCSV(data);
+      if(validCSV){
         valid = true;
       }
     }

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -7,6 +7,7 @@
       "name": "functions",
       "dependencies": {
         "cors": "^2.8.5",
+        "csv-string": "^4.1.1",
         "express": "^4.18.2",
         "firebase-admin": "^10.0.2",
         "firebase-functions": "^4.0.2",
@@ -761,6 +762,14 @@
       "optional": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/csv-string": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/csv-string/-/csv-string-4.1.1.tgz",
+      "integrity": "sha512-KGvaJEZEdh2O/EVvczwbPLqJZtSQaWQ4cEJbiOJEG4ALq+dBBqNmBkRXTF4NV79V25+XYtiqbco1IWrmHLm5FQ==",
+      "engines": {
+        "node": ">=12.0"
       }
     },
     "node_modules/data-uri-to-buffer": {
@@ -3185,6 +3194,11 @@
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
       "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
       "optional": true
+    },
+    "csv-string": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/csv-string/-/csv-string-4.1.1.tgz",
+      "integrity": "sha512-KGvaJEZEdh2O/EVvczwbPLqJZtSQaWQ4cEJbiOJEG4ALq+dBBqNmBkRXTF4NV79V25+XYtiqbco1IWrmHLm5FQ=="
     },
     "data-uri-to-buffer": {
       "version": "4.0.0",

--- a/functions/package.json
+++ b/functions/package.json
@@ -15,6 +15,7 @@
   "type": "module",
   "dependencies": {
     "cors": "^2.8.5",
+    "csv-string": "^4.1.1",
     "express": "^4.18.2",
     "firebase-admin": "^10.0.2",
     "firebase-functions": "^4.0.2",

--- a/functions/validate-csv.js
+++ b/functions/validate-csv.js
@@ -1,0 +1,20 @@
+import * as CSV from 'csv-string';
+
+
+export default function validateCSV(csv) {
+  let parsedCSV = null;
+  try {
+    parsedCSV = CSV.parse(csv);
+    console.log(parsedCSV)
+  } catch (error) {
+    console.log(error);
+    return false;
+  }
+  if(parsedCSV[0].includes('trial_type')){
+    return true;
+  } else {
+    return false;
+  }
+
+  return true;
+}

--- a/functions/validate-json.js
+++ b/functions/validate-json.js
@@ -11,7 +11,7 @@ export default function validateJSON(json) {
   try {
     parsedJSON = JSON.parse(json);
   } catch(error) {
-    console.log(error);
+    console.log(`JSON parsing error: ${error}`);
     return false;
   }
   


### PR DESCRIPTION
This is a branch to work on #6.

So far I've added the `joi` package and implemented some basic JSON validation by checking that the incoming data is an array with a `trial_type` field in each entry. This would be a generic way of validating jsPsych data.

Would want to customize this a lot more.