### PR TITLE
standardize all api responses

### DIFF
--- a/functions/__tests__/get-condition-emulator.test.js
+++ b/functions/__tests__/get-condition-emulator.test.js
@@ -4,6 +4,7 @@
 
 import { initializeApp } from "firebase-admin/app";
 import { getFirestore } from "firebase-admin/firestore";
+import MESSAGES from "../api-messages";
 
 process.env.FIRESTORE_EMULATOR_HOST = 'localhost:8080';
 
@@ -19,7 +20,7 @@ async function getCondition(body) {
       body: JSON.stringify(body),
     }
   );
-  const condition = await response.text();
+  const condition = await response.json();
   return condition;
 }
 
@@ -45,25 +46,24 @@ beforeAll(async () => {
 describe("getCondition", () => {
   it("should return error message when there is no experimentID in the body", async () => {
     const condition = await getCondition({});
-    expect(condition).toBe("Missing parameter experimentID");
+    expect(condition).toEqual(MESSAGES.MISSING_PARAMETER);
   });
 
   it("should return error message when the experimentID does not match an experiment", async () => {
     const condition = await getCondition({ experimentID: "doesnotexist" });
-    expect(condition).toBe("Experiment does not exist");
+    expect(condition).toEqual(MESSAGES.EXPERIMENT_NOT_FOUND);
   });
 
   it("should return error message when condition assignment is not active", async () => {
     const condition = await getCondition({ experimentID: "testexp" });
-    expect(condition).toBe(
-      "Condition assignment is not active for this experiment"
-    );
+    expect(condition).toEqual(MESSAGES.CONDITION_ASSIGNMENT_NOT_ACTIVE);
   });
 
   it("should return sequential conditions when condition assignment is active", async () => {
     for(let i = 0; i < 8; i++) {
       const condition = await getCondition({ experimentID: "testexp-active" });
-      expect(parseInt(condition)).toBe(i % 4);
+      expect(condition.message).toBe('Success');
+      expect(condition.condition).toBe(i % 4);
     }
   });
 

--- a/functions/api-base64.js
+++ b/functions/api-base64.js
@@ -4,6 +4,7 @@ import putFileOSF from "./put-file-osf.js";
 import { db } from "./app.js";
 import writeLog from "./write-log.js";
 import isBase64 from "is-base64";
+import MESSAGES from "./api-messages.js";
 
 const corsHandler = cors({ origin: true });
 
@@ -11,16 +12,8 @@ export const apiBase64 = functions.https.onRequest(async (req, res) => {
   corsHandler(req, res, async () => {
     const { experimentID, data, filename } = req.body;
 
-    if (!experimentID) {
-      res.status(400).send("Missing parameter experimentID");
-      return;
-    }
-    if (!data) {
-      res.status(400).send("Missing parameter data");
-      return;
-    }
-    if (!filename) {
-      res.status(400).send("Missing parameter filename");
+    if (!experimentID || !data || !filename) {
+      res.status(400).json(MESSAGES.MISSING_PARAMETER);
       return;
     }
 
@@ -30,20 +23,18 @@ export const apiBase64 = functions.https.onRequest(async (req, res) => {
     const exp_doc = await exp_doc_ref.get();
 
     if (!exp_doc.exists) {
-      res.status(400).send("Experiment does not exist");
+      res.status(400).json(MESSAGES.EXPERIMENT_NOT_FOUND);
       return;
     }
 
     const exp_data = exp_doc.data();
     if (!exp_data.activeBase64) {
-      res
-        .status(400)
-        .send("Base64 data collection is not active for this experiment");
+      res.status(400).json(MESSAGES.BASE64DATA_COLLECTION_NOT_ACTIVE);
       return;
     }
 
     if(!isBase64(data)){
-      res.status(400).send("Invalid base64 data");
+      res.status(400).json(MESSAGES.INVALID_BASE64_DATA);
       return;
     }
     
@@ -51,19 +42,19 @@ export const apiBase64 = functions.https.onRequest(async (req, res) => {
     try {
       buffer = Buffer.from(data, "base64");
     } catch (e) {
-      res.status(400).send("Invalid base64 data");
+      res.status(400).json(MESSAGES.INVALID_BASE64_DATA);
       return;
     }
 
     const user_doc = await db.doc(`users/${exp_data.owner}`).get();
     if (!user_doc.exists) {
-      res.status(400).send("This experiment has an invalid owner ID");
+      res.status(400).json(MESSAGES.INVALID_OWNER);
       return;
     }
 
     const user_data = user_doc.data();
     if (!user_data.osfToken) {
-      res.status(400).send("This experiment does not have a valid OSF token");
+      res.status(400).json(MESSAGES.INVALID_OSF_TOKEN);
       return;
     }
 
@@ -85,6 +76,6 @@ export const apiBase64 = functions.https.onRequest(async (req, res) => {
       return;
     }
 
-    res.status(201).send(`Success`);
+    res.status(201).json(MESSAGES.SUCCESS);
   });
 });

--- a/functions/api-condition.js
+++ b/functions/api-condition.js
@@ -2,6 +2,7 @@ import * as functions from "firebase-functions";
 import cors from "cors";
 import { db } from "./app.js";
 import writeLog from "./write-log.js";
+import MESSAGES from "./api-messages.js";
 
 const corsHandler = cors({ origin: true });
 
@@ -10,7 +11,7 @@ export const apiCondition = functions.https.onRequest((req, res) => {
     const { experimentID } = req.body;
 
     if (!experimentID) {
-      res.status(400).send("Missing parameter experimentID");
+      res.status(400).json(MESSAGES.MISSING_PARAMETER);
       return;
     }
 
@@ -20,21 +21,19 @@ export const apiCondition = functions.https.onRequest((req, res) => {
     const exp_doc = await exp_doc_ref.get();
 
     if (!exp_doc.exists) {
-      res.status(400).send("Experiment does not exist");
+      res.status(400).json(MESSAGES.EXPERIMENT_NOT_FOUND);
       return;
     }
 
     const exp_data = exp_doc.data();
     if (!exp_data.activeConditionAssignment) {
-      res
-        .status(400)
-        .send("Condition assignment is not active for this experiment");
+      res.status(400).json(MESSAGES.CONDITION_ASSIGNMENT_NOT_ACTIVE);
       return;
     }
 
     // if there is only 1 condition, just send 0
     if (exp_data.nConditions === 1) {
-      res.status(200).send("0");
+      res.status(200).json({message: 'Success', condition: 0});
       return;
     }
 
@@ -55,11 +54,11 @@ export const apiCondition = functions.https.onRequest((req, res) => {
         return currentCondition;
       });
     } catch (error) {
-      res.status(400).send("Error getting condition");
+      res.status(400).json(MESSAGES.UNKNOWN_ERROR_GETTING_CONDITION);
       return;
     }
 
-    res.status(200).send(condition.toString());
+    res.status(200).json({ message: "Success", condition: condition });
     return;
   });
 });

--- a/functions/api-messages.js
+++ b/functions/api-messages.js
@@ -1,0 +1,51 @@
+const MESSAGES = {
+  MISSING_PARAMETER: {
+    error: "MISSING_PARAMETER",
+    message: "One or more required parameters are missing.",
+  },
+  DATA_COLLECTION_NOT_ACTIVE: {
+    error: "DATA_COLLECTION_NOT_ACTIVE",
+    message: "Data collection is not active for this experiment",
+  },
+  BASE64DATA_COLLECTION_NOT_ACTIVE: {
+    error: "BASE64DATA_COLLECTION_NOT_ACTIVE",
+    message: "Base64 data collection is not active for this experiment",
+  },
+  CONDITION_ASSIGNMENT_NOT_ACTIVE: {
+    error: "CONDITION_ASSIGNMENT_NOT_ACTIVE",
+    message: "Condition assignment is not active for this experiment",
+  },
+  EXPERIMENT_NOT_FOUND: {
+    error: "EXPERIMENT_NOT_FOUND",
+    message: "The experiment ID does not match an experiment",
+  },
+  INVALID_OWNER: {
+    error: "INVALID_OWNER",
+    message: "The owner ID of this experiment does not match a valid user",
+  },
+  INVALID_OSF_TOKEN: {
+    error: "INVALID_OSF_TOKEN",
+    message: "The OSF token for this experiment is not valid",
+  },
+  INVALID_BASE64_DATA: {
+    error: "INVALID_BASE64_DATA",
+    message: "The data are not valid base64 data",
+  },
+  INVALID_DATA: {
+    error: "INVALID_DATA",
+    message: "The data are not valid according to the validation parameters set for this experiment."
+  },
+  SESSION_LIMIT_REACHED: {
+    error: "SESSION_LIMIT_REACHED",
+    message: "The session limit for this experiment has been reached",
+  },
+  UNKNOWN_ERROR_GETTING_CONDITION: {
+    error: "UNKNOWN_ERROR_GETTING_CONDITION",
+    message: "An unknown error occurred while getting the condition for this experiment",
+  },
+  SUCCESS: {
+    message: "Success",
+  }
+};
+
+export default MESSAGES;


### PR DESCRIPTION
This changes API responses to use JSON, following the format laid out in the new `/functions/api-message.js` object.
