### PR TITLE
home page revamp

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -9,44 +9,94 @@ import {
   Text,
   Button,
   Image,
+  HStack,
 } from "@chakra-ui/react";
+import { AddIcon, EditIcon, RepeatClockIcon } from "@chakra-ui/icons";
 
 export default function Home() {
   const { user } = useContext(UserContext);
 
-  return (
-    <Stack
-      direction={["column", "row"]}
-      px={[2, 12]}
-      maxW={["95%", "1400px"]}
-      flexDirection={["column-reverse", "row"]}
-      align="center"
-    >
-      <VStack spacing={4} align="start" flexBasis="66%">
-        <Text fontSize={["2xl", "4xl"]} fontWeight="semibold">
-          Send data from your behavioral experiments to the Open Science
-          Framework, for free.
+  const Feature = ({ title, text, icon }) => {
+    return (
+      <VStack flexBasis={"33%"}>
+        {icon}
+        <Text fontSize={["xl", "2xl"]} fontWeight="semibold">
+          {title}
         </Text>
-        {user ? (
-          <Link href="/admin">
-            <Button variant={"outline"} colorScheme={"brandOrange"} size={"lg"}>
-              Go to Dashboard
-            </Button>
-          </Link>
-        ) : (
-          <Link href="/signup">
-            <Button variant={"outline"} colorScheme={"brandOrange"} size={"lg"}>
-              Create an account
-            </Button>
-          </Link>
-        )}
+        <Text>{text}</Text>
       </VStack>
-      <Image
-        src="/homepipe.png"
-        alt="Decorative illustration of a pipe with data flowing through it"
-        boxSize={["100%", "768px"]}
-        quality={100}
-      />
-    </Stack>
+    );
+  };
+
+  return (
+    <VStack maxW={["95%", "1400px"]} px={[2, 12]} spacing={["1rem", "2rem"]}>
+      <Stack
+        direction={["column", "row"]}
+        flexDirection={["column-reverse", "row"]}
+        align="center"
+      >
+        <VStack spacing={4} align="start" flexBasis="66%">
+          <Text fontSize={["2xl", "4xl"]} fontWeight="semibold">
+            Send data from your behavioral experiments to the Open Science
+            Framework, for free.
+          </Text>
+          {user ? (
+            <Link href="/admin">
+              <Button
+                variant={"outline"}
+                colorScheme={"brandOrange"}
+                size={"lg"}
+              >
+                Go to Dashboard
+              </Button>
+            </Link>
+          ) : (
+            <Link href="/signup">
+              <Button
+                variant={"outline"}
+                colorScheme={"brandOrange"}
+                size={"lg"}
+              >
+                Create an account
+              </Button>
+            </Link>
+          )}
+        </VStack>
+        <Image
+          src="/homepipe.png"
+          alt="Decorative illustration of a pipe with data flowing through it"
+          boxSize={["100%", "768px"]}
+          quality={100}
+        />
+      </Stack>
+      <Stack
+        direction={["column", "row"]}
+        w={"100%"}
+        flexDirection={["column-reverse", "row"]}
+        align="center"
+      >
+        <Feature
+          icon={<AddIcon w={8} h={8} color={"brandOrange.500"} />}
+          title={"Link your OSF Account"}
+          text={
+            "Simply create an OSF project or use an existing one, along with generating an OSF token to send files directly to it."
+          }
+        />
+        <Feature
+          icon={<EditIcon w={8} h={8} color={"brandOrange.500"} />}
+          title={"Add DataPipe Code"}
+          text={
+            "Configure your experiment parameters and add our pre-generated code snippets into your web-based experiment."
+          }
+        />
+        <Feature
+          icon={<RepeatClockIcon w={8} h={8} color={"brandOrange.500"} />}
+          title={"Publish your Experiment"}
+          text={
+            "Host your experiment on a static hosting website like Github Pages or Netlify, activate data collection, and sit back as data will be automatically sent to OSF."
+          }
+        />
+      </Stack>
+    </VStack>
   );
 }


### PR DESCRIPTION
draft until we're both satisfied with the changes!

hi all, this is a PR for some revamps to the homepage, and a small discussion for how exactly we want to organize this. currently, i think there are a couple of beneficial changes we could make that would really complete the homepage as a whole. in no particular order:

- [ ] getting started example (#52) to show how easy it is to make a new experiment
- [ ] styling changes to the current homepipe.png (cutting off top and bottom gray space?) to present first blob of info earlier w/out scrolling
- [ ] stats? maybe animated scrolling list of some static hosting websites that we can find to show compatibility

and more, if you have any ideas? @jodeleeuw 