### PR TITLE
Fix typo in CodeHints.js documentation L181

### DIFF
--- a/components/dashboard/CodeHints.js
+++ b/components/dashboard/CodeHints.js
@@ -178,7 +178,7 @@ export default function CodeHints({ expId }) {
                   Use the static method of the pipe plugin to request the
                   condition. This is an asynchronous request so we need to wait
                   for the response before using the condition value. An easy
-                  wait to do this is to put your experiment creation code inside
+                  way to do this is to put your experiment creation code inside
                   an async function.
                 </Text>
                 <CodeBlock>


### PR DESCRIPTION
"An easy wait to do this..." → "An easy way to do this..."