### PR TITLE
fix: fall back to valid PAT when OAuth token refresh fails

### DIFF
--- a/functions/src/metadata-block.ts
+++ b/functions/src/metadata-block.ts
@@ -30,9 +30,15 @@ if (user_data.usingPersonalToken) {
   if (Date.now() > user_data.authTokenExpires) {
     const refreshResult = await refreshAndUpdateUser(exp_data.owner, decrypt(user_data.refreshToken));
     if (!refreshResult.success) {
-      return { success: false, metadataMessage: "OAuth token refresh failed" };
+      // Fall back to PAT if available
+      if (user_data.osfTokenValid && user_data.osfToken) {
+        decryptedOsfToken = decrypt(user_data.osfToken);
+      } else {
+        return { success: false, metadataMessage: "OAuth token refresh failed" };
+      }
+    } else {
+      decryptedOsfToken = refreshResult.accessToken!;
     }
-    decryptedOsfToken = refreshResult.accessToken!;
   } else {
     decryptedOsfToken = decrypt(user_data.authToken);
   }

--- a/functions/src/resolve-token.ts
+++ b/functions/src/resolve-token.ts
@@ -11,6 +11,10 @@ type TokenResult = {
   detail: string;
 }
 
+function hasValidPAT(user_data: UserData): boolean {
+  return user_data.osfTokenValid && !!user_data.osfToken;
+}
+
 export default async function resolveToken(
   user_data: UserData,
   exp_data: ExperimentData,
@@ -22,10 +26,15 @@ export default async function resolveToken(
     return { success: true, token: decrypt(user_data.osfToken) };
   }
 
+  // OAuth path
   if (Date.now() > user_data.authTokenExpires) {
     const refreshResult = await refreshAndUpdateUser(exp_data.owner, decrypt(user_data.refreshToken));
 
     if (!refreshResult.success) {
+      // Fall back to PAT if available
+      if (hasValidPAT(user_data)) {
+        return { success: true, token: decrypt(user_data.osfToken) };
+      }
       return { success: false, error: "INVALID_REFRESH_TOKEN", detail: refreshResult.error || "Refresh token is not valid" };
     }
 


### PR DESCRIPTION
## Summary
- When a user is set to OAuth but the refresh token is invalid or missing (e.g., they switched to OAuth without completing the flow), token resolution now falls back to their personal access token if one exists and is valid
- Applied in both `resolve-token.ts` (used by `api-data` and `api-base64`) and `metadata-block.ts`

## Test plan
- [ ] Set a valid PAT, switch to OAuth without completing the flow, verify data uploads still work using the PAT
- [ ] Verify that users with working OAuth tokens are unaffected
- [ ] Verify that users with neither a valid PAT nor valid OAuth tokens still get an appropriate error

🤖 Generated with [Claude Code](https://claude.com/claude-code)