### PR TITLE
feat: cache failed OSF uploads and retry automatically

### DIFF
--- a/components/dashboard/QueuePanel.js
+++ b/components/dashboard/QueuePanel.js
@@ -1,0 +1,142 @@
+import { useState } from "react";
+import {
+  Box,
+  Accordion,
+  Alert,
+  Table,
+  Badge,
+  IconButton,
+  Text,
+} from "@chakra-ui/react";
+import { Download } from "lucide-react";
+import { auth } from "../../lib/firebase";
+
+function statusBadge(status) {
+  const colors = {
+    pending: "orange",
+    processing: "blue",
+    failed: "red",
+  };
+  return (
+    <Badge colorPalette={colors[status] || "gray"} variant="solid" px={2}>
+      {status}
+    </Badge>
+  );
+}
+
+function formatDate(isoString) {
+  if (!isoString) return "-";
+  return new Intl.DateTimeFormat("en-GB", {
+    dateStyle: "short",
+    timeStyle: "short",
+  }).format(new Date(isoString));
+}
+
+export default function QueuePanel({ entries, experimentId }) {
+  const [downloading, setDownloading] = useState(null);
+
+  const handleDownload = async (entry) => {
+    setDownloading(entry.id);
+    try {
+      const user = auth.currentUser;
+      if (!user) return;
+      const idToken = await user.getIdToken();
+      const response = await fetch(
+        `/api/queuestatus?experimentID=${experimentId}&download=${entry.id}`,
+        {
+          headers: { Authorization: `Bearer ${idToken}` },
+        }
+      );
+      if (!response.ok) {
+        console.error("Failed to get download URL");
+        return;
+      }
+      const { url } = await response.json();
+      window.open(url, "_blank");
+    } catch (e) {
+      console.error("Download failed:", e);
+    } finally {
+      setDownloading(null);
+    }
+  };
+
+  const pendingCount = entries.filter(
+    (e) => e.status === "pending" || e.status === "processing"
+  ).length;
+  const failedCount = entries.filter((e) => e.status === "failed").length;
+
+  let alertTitle = "";
+  if (pendingCount > 0 && failedCount > 0) {
+    alertTitle = `${pendingCount} file(s) queued for upload, ${failedCount} failed.`;
+  } else if (pendingCount > 0) {
+    alertTitle = `${pendingCount} file(s) queued for upload to OSF.`;
+  } else {
+    alertTitle = `${failedCount} file(s) failed to upload to OSF.`;
+  }
+
+  return (
+    <Alert.Root status="warning" variant="solid">
+      <Alert.Indicator />
+      <Box flex="1">
+        <Alert.Title mb={1}>{alertTitle}</Alert.Title>
+        <Text fontSize="sm" mb={4}>
+          Queued files are retried automatically every hour and stored for up to
+          1 week. You can download them below.
+        </Text>
+        <Accordion.Root collapsible>
+          <Accordion.Item value="queue-list">
+            <Accordion.ItemTrigger>
+              <Box as="span" flex="1" textAlign="left">
+                See Queued Files
+              </Box>
+              <Accordion.ItemIndicator />
+            </Accordion.ItemTrigger>
+            <Accordion.ItemContent pb={4}>
+              <Table.Root variant="line" size="sm">
+                <Table.Header>
+                  <Table.Row>
+                    <Table.ColumnHeader>FILENAME</Table.ColumnHeader>
+                    <Table.ColumnHeader>STATUS</Table.ColumnHeader>
+                    <Table.ColumnHeader>QUEUED AT</Table.ColumnHeader>
+                    <Table.ColumnHeader>RETRIES</Table.ColumnHeader>
+                    <Table.ColumnHeader>DOWNLOAD</Table.ColumnHeader>
+                  </Table.Row>
+                </Table.Header>
+                <Table.Body>
+                  {entries.map((entry) => (
+                    <Table.Row key={entry.id}>
+                      <Table.Cell>
+                        {entry.filename}
+                        {entry.failureReason && (
+                          <Text fontSize="xs" color="red.300" mt={1}>
+                            {entry.failureReason}
+                          </Text>
+                        )}
+                      </Table.Cell>
+                      <Table.Cell>{statusBadge(entry.status)}</Table.Cell>
+                      <Table.Cell>{formatDate(entry.createdAt)}</Table.Cell>
+                      <Table.Cell>
+                        {entry.retryCount}/{entry.maxRetries}
+                      </Table.Cell>
+                      <Table.Cell>
+                        <IconButton
+                          aria-label="Download file"
+                          size="xs"
+                          variant="ghost"
+                          loading={downloading === entry.id}
+                          onClick={() => handleDownload(entry)}
+                        >
+                          <Download size={14} />
+                        </IconButton>
+                      </Table.Cell>
+                    </Table.Row>
+                  ))}
+                </Table.Body>
+              </Table.Root>
+            </Accordion.ItemContent>
+          </Accordion.Item>
+        </Accordion.Root>
+      </Box>
+    </Alert.Root>
+  );
+}

--- a/firebase.json
+++ b/firebase.json
@@ -1,4 +1,7 @@
 {
+  "storage": {
+    "rules": "storage.rules"
+  },
   "firestore": {
     "rules": "firestore.rules",
     "indexes": "firestore.indexes.json"

--- a/firebase.json
+++ b/firebase.json
@@ -46,6 +46,10 @@
       {
         "source": "/api/getosftoken",
         "function": "getosftoken"
+      },
+      {
+        "source": "/api/queuestatus",
+        "function": "apiqueuestatus"
       }
     ]
   },

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -7,6 +7,23 @@
         { "fieldPath": "usingPersonalToken", "order": "ASCENDING" },
         { "fieldPath": "refreshTokenExpires", "order": "ASCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "uploadQueue",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "experimentID", "order": "ASCENDING" },
+        { "fieldPath": "status", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "uploadQueue",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "status", "order": "ASCENDING" },
+        { "fieldPath": "nextRetryAt", "order": "ASCENDING" }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/firestore.rules
+++ b/firestore.rules
@@ -42,5 +42,9 @@ service cloud.firestore {
       allow create: if(request.auth.uid != null) &&
         resource.data.owner == request.auth.uid;
     }
+    match /uploadQueue/{docId} {
+      allow read: if(request.auth.uid != null) &&
+        resource.data.owner == request.auth.uid;
+    }
   }
 }

--- a/functions/src/__tests__/upload-queue.test.js
+++ b/functions/src/__tests__/upload-queue.test.js
@@ -1,0 +1,212 @@
+/**
+ * @jest-environment node
+ */
+
+import { initializeApp, deleteApp, getApp } from "firebase-admin/app";
+import { getFirestore, Timestamp } from "firebase-admin/firestore";
+
+process.env.FIRESTORE_EMULATOR_HOST = "localhost:8080";
+
+const config = { projectId: "datapipe-test" };
+
+jest.setTimeout(30000);
+
+let db;
+let app;
+
+beforeAll(async () => {
+  try {
+    app = getApp("upload-queue-test");
+  } catch {
+    app = initializeApp(config, "upload-queue-test");
+  }
+  db = getFirestore(app);
+});
+
+afterEach(async () => {
+  // Clean up uploadQueue collection
+  const docs = await db.collection("uploadQueue").get();
+  const batch = db.batch();
+  docs.forEach((doc) => batch.delete(doc.ref));
+  await batch.commit();
+});
+
+describe("queueUpload deduplication", () => {
+  test("uses deterministic document ID from experimentID and filename", async () => {
+    const docId = "exp123:data.csv".replace(/[/\\]/g, "_");
+    const docRef = db.collection("uploadQueue").doc(docId);
+
+    await docRef.set({
+      experimentID: "exp123",
+      owner: "user1",
+      filename: "data.csv",
+      storagePath: `upload-queue/${docId}`,
+      dataType: "data",
+      osfFilesLink: "https://osf.io/files/",
+      status: "pending",
+      errorCode: 0,
+      retryCount: 0,
+      maxRetries: 5,
+      createdAt: Timestamp.now(),
+      lastAttemptAt: null,
+      nextRetryAt: Timestamp.fromMillis(Date.now() + 3600000),
+      completedAt: null,
+      failureReason: "Upload exception: timeout",
+      deduplicationKey: "exp123:data.csv",
+      sessionIncremented: true,
+    });
+
+    // Verify the doc exists at the expected deterministic ID
+    const doc = await docRef.get();
+    expect(doc.exists).toBe(true);
+    expect(doc.data().experimentID).toBe("exp123");
+    expect(doc.data().filename).toBe("data.csv");
+    expect(doc.data().failureReason).toBe("Upload exception: timeout");
+  });
+
+  test("deterministic ID handles filenames with slashes", async () => {
+    const docId = "exp123:subfolder/data.csv".replace(/[/\\]/g, "_");
+    expect(docId).toBe("exp123:subfolder_data.csv");
+  });
+
+  test("same deduplicationKey produces same document ID", () => {
+    const key1 = "exp123:data.csv".replace(/[/\\]/g, "_");
+    const key2 = "exp123:data.csv".replace(/[/\\]/g, "_");
+    expect(key1).toBe(key2);
+  });
+
+  test("different experiments produce different document IDs", () => {
+    const key1 = "exp123:data.csv".replace(/[/\\]/g, "_");
+    const key2 = "exp456:data.csv".replace(/[/\\]/g, "_");
+    expect(key1).not.toBe(key2);
+  });
+});
+
+describe("handleRetryFailure backoff", () => {
+  test("exponential backoff doubles each retry", () => {
+    const MAX_BACKOFF_MS = 24 * 60 * 60 * 1000;
+
+    for (let retryCount = 1; retryCount <= 5; retryCount++) {
+      const backoffMs = Math.min(
+        Math.pow(2, retryCount) * 60 * 60 * 1000,
+        MAX_BACKOFF_MS
+      );
+      const expectedHours = Math.min(Math.pow(2, retryCount), 24);
+      expect(backoffMs).toBe(expectedHours * 60 * 60 * 1000);
+    }
+  });
+
+  test("backoff is capped at 24 hours", () => {
+    const MAX_BACKOFF_MS = 24 * 60 * 60 * 1000;
+    // retryCount = 5 => 2^5 = 32 hours, should cap at 24
+    const backoffMs = Math.min(
+      Math.pow(2, 5) * 60 * 60 * 1000,
+      MAX_BACKOFF_MS
+    );
+    expect(backoffMs).toBe(24 * 60 * 60 * 1000);
+  });
+
+  test("Retry-After header is honored when provided", () => {
+    const MAX_BACKOFF_MS = 24 * 60 * 60 * 1000;
+    const retryAfterSeconds = 120; // 2 minutes
+
+    const backoffMs = Math.min(retryAfterSeconds * 1000, MAX_BACKOFF_MS);
+    expect(backoffMs).toBe(120000);
+  });
+
+  test("Retry-After is capped at MAX_BACKOFF_MS", () => {
+    const MAX_BACKOFF_MS = 24 * 60 * 60 * 1000;
+    const retryAfterSeconds = 100000; // ~27 hours
+
+    const backoffMs = Math.min(retryAfterSeconds * 1000, MAX_BACKOFF_MS);
+    expect(backoffMs).toBe(MAX_BACKOFF_MS);
+  });
+
+  test("falls back to exponential backoff when no Retry-After", () => {
+    const MAX_BACKOFF_MS = 24 * 60 * 60 * 1000;
+    const retryAfterSeconds = null;
+    const retryCount = 2;
+
+    const backoffMs = retryAfterSeconds
+      ? Math.min(retryAfterSeconds * 1000, MAX_BACKOFF_MS)
+      : Math.min(Math.pow(2, retryCount) * 60 * 60 * 1000, MAX_BACKOFF_MS);
+
+    expect(backoffMs).toBe(4 * 60 * 60 * 1000); // 4 hours
+  });
+});
+
+describe("queue entry lifecycle in Firestore", () => {
+  test("pending entry can transition to processing", async () => {
+    const docRef = db.collection("uploadQueue").doc("lifecycle-test");
+    await docRef.set({
+      status: "pending",
+      retryCount: 0,
+      maxRetries: 5,
+      createdAt: Timestamp.now(),
+    });
+
+    // Simulate atomic claim via transaction
+    await db.runTransaction(async (transaction) => {
+      const freshDoc = await transaction.get(docRef);
+      expect(freshDoc.data().status).toBe("pending");
+      transaction.update(docRef, {
+        status: "processing",
+        lastAttemptAt: Timestamp.now(),
+      });
+    });
+
+    const updated = await docRef.get();
+    expect(updated.data().status).toBe("processing");
+  });
+
+  test("processing entry cannot be claimed again", async () => {
+    const docRef = db.collection("uploadQueue").doc("double-claim-test");
+    await docRef.set({
+      status: "processing",
+      retryCount: 0,
+      maxRetries: 5,
+      createdAt: Timestamp.now(),
+    });
+
+    // Second claim should fail
+    await expect(
+      db.runTransaction(async (transaction) => {
+        const freshDoc = await transaction.get(docRef);
+        if (freshDoc.data()?.status !== "pending") {
+          throw new Error("Already claimed");
+        }
+        transaction.update(docRef, { status: "processing" });
+      })
+    ).rejects.toThrow("Already claimed");
+  });
+
+  test("failed entry with max retries reached stays failed", async () => {
+    const docRef = db.collection("uploadQueue").doc("max-retry-test");
+    await docRef.set({
+      status: "pending",
+      retryCount: 4,
+      maxRetries: 5,
+      createdAt: Timestamp.now(),
+      failureReason: null,
+    });
+
+    // Simulate handleRetryFailure logic
+    const data = (await docRef.get()).data();
+    const newRetryCount = (data.retryCount || 0) + 1;
+
+    if (newRetryCount >= data.maxRetries) {
+      await docRef.update({
+        status: "failed",
+        retryCount: newRetryCount,
+        failureReason: "OSF error 500: Internal Server Error",
+      });
+    }
+
+    const result = await docRef.get();
+    expect(result.data().status).toBe("failed");
+    expect(result.data().retryCount).toBe(5);
+    expect(result.data().failureReason).toBe(
+      "OSF error 500: Internal Server Error"
+    );
+  });
+});

--- a/functions/src/api-base64.ts
+++ b/functions/src/api-base64.ts
@@ -114,6 +114,7 @@ export const apiBase64 = onRequest({ cors: true }, async (req, res) => {
         experimentID, owner: exp_data.owner, filename, data,
         dataType: "base64", osfFilesLink: exp_data.osfFilesLink,
         errorCode: 0, sessionIncremented: false,
+        failureReason: `Upload exception: ${detail}`,
       });
       res.status(202).json(MESSAGES.OSF_UPLOAD_QUEUED);
       await writeLog(experimentID, "logError", {...MESSAGES.OSF_UPLOAD_EXCEPTION, detail});
@@ -137,6 +138,7 @@ export const apiBase64 = onRequest({ cors: true }, async (req, res) => {
         experimentID, owner: exp_data.owner, filename, data,
         dataType: "base64", osfFilesLink: exp_data.osfFilesLink,
         errorCode: result.errorCode || 0, sessionIncremented: false,
+        failureReason: `OSF error ${result.errorCode}: ${result.errorText}`,
       });
       res.status(202).json(MESSAGES.OSF_UPLOAD_QUEUED);
       await writeLog(experimentID, "logError", {...MESSAGES.OSF_UPLOAD_ERROR, osfStatus: result.errorCode, osfStatusText: result.errorText});

--- a/functions/src/api-base64.ts
+++ b/functions/src/api-base64.ts
@@ -6,6 +6,7 @@ import writeLog from "./write-log.js";
 import isBase64 from "is-base64";
 import MESSAGES from "./api-messages.js";
 import resolveToken from "./resolve-token.js";
+import queueUpload from "./queue-upload.js";
 import { ExperimentData, UserData, OSFResult } from './interfaces';
 
 export const apiBase64 = onRequest({ cors: true }, async (req, res) => {
@@ -106,10 +107,22 @@ export const apiBase64 = onRequest({ cors: true }, async (req, res) => {
       filename
     );
   } catch (e) {
+    // Network errors, timeouts, etc. — queue for retry
     const detail = e instanceof Error ? e.message : "Unknown error";
-    res.status(500).json(MESSAGES.OSF_UPLOAD_EXCEPTION);
-    await writeLog(experimentID, "logError", {...MESSAGES.OSF_UPLOAD_EXCEPTION, detail});
-    return;
+    try {
+      await queueUpload({
+        experimentID, owner: exp_data.owner, filename, data,
+        dataType: "base64", osfFilesLink: exp_data.osfFilesLink,
+        errorCode: 0, sessionIncremented: false,
+      });
+      res.status(202).json(MESSAGES.OSF_UPLOAD_QUEUED);
+      await writeLog(experimentID, "logError", {...MESSAGES.OSF_UPLOAD_EXCEPTION, detail});
+      return;
+    } catch {
+      res.status(500).json(MESSAGES.OSF_UPLOAD_EXCEPTION);
+      await writeLog(experimentID, "logError", {...MESSAGES.OSF_UPLOAD_EXCEPTION, detail});
+      return;
+    }
   }
 
   if (!result.success) {
@@ -118,9 +131,21 @@ export const apiBase64 = onRequest({ cors: true }, async (req, res) => {
       await writeLog(experimentID, "logError", MESSAGES.OSF_FILE_EXISTS);
       return;
     }
-    res.status(400).json(MESSAGES.OSF_UPLOAD_ERROR);
-    await writeLog(experimentID, "logError", {...MESSAGES.OSF_UPLOAD_ERROR, osfStatus: result.errorCode, osfStatusText: result.errorText});
-    return;
+    // Queue all other failures for retry
+    try {
+      await queueUpload({
+        experimentID, owner: exp_data.owner, filename, data,
+        dataType: "base64", osfFilesLink: exp_data.osfFilesLink,
+        errorCode: result.errorCode || 0, sessionIncremented: false,
+      });
+      res.status(202).json(MESSAGES.OSF_UPLOAD_QUEUED);
+      await writeLog(experimentID, "logError", {...MESSAGES.OSF_UPLOAD_ERROR, osfStatus: result.errorCode, osfStatusText: result.errorText});
+      return;
+    } catch {
+      res.status(400).json(MESSAGES.OSF_UPLOAD_ERROR);
+      await writeLog(experimentID, "logError", {...MESSAGES.OSF_UPLOAD_ERROR, osfStatus: result.errorCode, osfStatusText: result.errorText});
+      return;
+    }
   }
 
   res.status(201).json(MESSAGES.SUCCESS);

--- a/functions/src/api-data.ts
+++ b/functions/src/api-data.ts
@@ -8,6 +8,7 @@ import writeLog from "./write-log.js";
 import MESSAGES from "./api-messages.js";
 import blockMetadata from "./metadata-block.js";
 import resolveToken from "./resolve-token.js";
+import queueUpload from "./queue-upload.js";
 import { ExperimentData, UserData, MetadataResponse, OSFResult, RequestBody } from './interfaces';
 
 export const apiData = onRequest({ cors: true }, async (req, res) => {
@@ -133,10 +134,23 @@ export const apiData = onRequest({ cors: true }, async (req, res) => {
       filename
     );
   } catch (e) {
+    // Network errors, timeouts, etc. — queue for retry
     const detail = e instanceof Error ? e.message : "Unknown error";
-    res.status(500).json({...MESSAGES.OSF_UPLOAD_EXCEPTION, metadataMessage});
-    await writeLog(experimentID, "logError", {...MESSAGES.OSF_UPLOAD_EXCEPTION, detail});
-    return;
+    try {
+      await queueUpload({
+        experimentID, owner: exp_data.owner, filename, data,
+        dataType: "data", osfFilesLink: exp_data.osfFilesLink,
+        errorCode: 0, sessionIncremented: true,
+      });
+      await exp_doc_ref.set({ sessions: FieldValue.increment(1) }, { merge: true });
+      res.status(202).json({...MESSAGES.OSF_UPLOAD_QUEUED, metadataMessage});
+      await writeLog(experimentID, "logError", {...MESSAGES.OSF_UPLOAD_EXCEPTION, detail});
+      return;
+    } catch {
+      res.status(500).json({...MESSAGES.OSF_UPLOAD_EXCEPTION, metadataMessage});
+      await writeLog(experimentID, "logError", {...MESSAGES.OSF_UPLOAD_EXCEPTION, detail});
+      return;
+    }
   }
 
   if (!result.success) {
@@ -145,9 +159,22 @@ export const apiData = onRequest({ cors: true }, async (req, res) => {
       await writeLog(experimentID, "logError", MESSAGES.OSF_FILE_EXISTS);
       return;
     }
-    res.status(400).json({...MESSAGES.OSF_UPLOAD_ERROR, metadataMessage});
-    await writeLog(experimentID, "logError", {...MESSAGES.OSF_UPLOAD_ERROR, osfStatus: result.errorCode, osfStatusText: result.errorText});
-    return;
+    // Queue all other failures for retry
+    try {
+      await queueUpload({
+        experimentID, owner: exp_data.owner, filename, data,
+        dataType: "data", osfFilesLink: exp_data.osfFilesLink,
+        errorCode: result.errorCode || 0, sessionIncremented: true,
+      });
+      await exp_doc_ref.set({ sessions: FieldValue.increment(1) }, { merge: true });
+      res.status(202).json({...MESSAGES.OSF_UPLOAD_QUEUED, metadataMessage});
+      await writeLog(experimentID, "logError", {...MESSAGES.OSF_UPLOAD_ERROR, osfStatus: result.errorCode, osfStatusText: result.errorText});
+      return;
+    } catch {
+      res.status(400).json({...MESSAGES.OSF_UPLOAD_ERROR, metadataMessage});
+      await writeLog(experimentID, "logError", {...MESSAGES.OSF_UPLOAD_ERROR, osfStatus: result.errorCode, osfStatusText: result.errorText});
+      return;
+    }
   }
 
   await exp_doc_ref.set({ sessions: FieldValue.increment(1) }, { merge: true });

--- a/functions/src/api-data.ts
+++ b/functions/src/api-data.ts
@@ -141,6 +141,7 @@ export const apiData = onRequest({ cors: true }, async (req, res) => {
         experimentID, owner: exp_data.owner, filename, data,
         dataType: "data", osfFilesLink: exp_data.osfFilesLink,
         errorCode: 0, sessionIncremented: true,
+        failureReason: `Upload exception: ${detail}`,
       });
       await exp_doc_ref.set({ sessions: FieldValue.increment(1) }, { merge: true });
       res.status(202).json({...MESSAGES.OSF_UPLOAD_QUEUED, metadataMessage});
@@ -165,6 +166,7 @@ export const apiData = onRequest({ cors: true }, async (req, res) => {
         experimentID, owner: exp_data.owner, filename, data,
         dataType: "data", osfFilesLink: exp_data.osfFilesLink,
         errorCode: result.errorCode || 0, sessionIncremented: true,
+        failureReason: `OSF error ${result.errorCode}: ${result.errorText}`,
       });
       await exp_doc_ref.set({ sessions: FieldValue.increment(1) }, { merge: true });
       res.status(202).json({...MESSAGES.OSF_UPLOAD_QUEUED, metadataMessage});

--- a/functions/src/api-messages.ts
+++ b/functions/src/api-messages.ts
@@ -109,6 +109,10 @@ const MESSAGES = {
   METADATA_IN_OSF_AND_FIRESTORE: {
     metadataMessage : "Metadata is in OSF and in Firestore",
   },
+  OSF_UPLOAD_QUEUED: {
+    error: null,
+    message: "Data received. OSF upload will be retried automatically.",
+  },
   SUCCESS: {
     message: "Success",
   }

--- a/functions/src/api-queue-status.ts
+++ b/functions/src/api-queue-status.ts
@@ -1,0 +1,91 @@
+import { onRequest } from "firebase-functions/v2/https";
+import { db, auth, storage } from "./app.js";
+
+export const apiQueueStatus = onRequest({ cors: true }, async (req, res) => {
+  if (req.method !== "GET") {
+    res.status(405).json({ error: "Method not allowed" });
+    return;
+  }
+
+  // Verify Firebase Auth token
+  const authHeader = req.headers.authorization;
+  if (!authHeader || !authHeader.startsWith("Bearer ")) {
+    res.status(401).json({ error: "Authentication required" });
+    return;
+  }
+
+  let uid: string;
+  try {
+    const idToken = authHeader.split("Bearer ")[1];
+    const decodedToken = await auth.verifyIdToken(idToken);
+    uid = decodedToken.uid;
+  } catch {
+    res.status(401).json({ error: "Invalid authentication token" });
+    return;
+  }
+
+  const experimentID = req.query.experimentID as string;
+  if (!experimentID) {
+    res.status(400).json({ error: "experimentID query parameter is required" });
+    return;
+  }
+
+  // Verify the user owns this experiment
+  const expDoc = await db.doc(`experiments/${experimentID}`).get();
+  if (!expDoc.exists || expDoc.data()?.owner !== uid) {
+    res.status(403).json({ error: "Access denied" });
+    return;
+  }
+
+  const download = req.query.download as string | undefined;
+
+  if (download) {
+    // Return a signed download URL for a specific queue entry
+    const queueDoc = await db.doc(`uploadQueue/${download}`).get();
+    if (!queueDoc.exists || queueDoc.data()?.experimentID !== experimentID) {
+      res.status(404).json({ error: "Queue entry not found" });
+      return;
+    }
+
+    const storagePath = queueDoc.data()?.storagePath;
+    try {
+      const bucket = storage.bucket();
+      const file = bucket.file(storagePath);
+      const [url] = await file.getSignedUrl({
+        action: "read",
+        expires: Date.now() + 15 * 60 * 1000, // 15 minutes
+      });
+      res.status(200).json({ url });
+    } catch {
+      res.status(500).json({ error: "Failed to generate download URL" });
+    }
+    return;
+  }
+
+  // List queue entries for this experiment
+  const queueItems = await db
+    .collection("uploadQueue")
+    .where("experimentID", "==", experimentID)
+    .where("status", "in", ["pending", "processing", "failed"])
+    .orderBy("createdAt", "desc")
+    .get();
+
+  const entries = queueItems.docs.map((doc) => {
+    const data = doc.data();
+    return {
+      id: doc.id,
+      filename: data.filename,
+      dataType: data.dataType,
+      status: data.status,
+      errorCode: data.errorCode,
+      retryCount: data.retryCount,
+      maxRetries: data.maxRetries,
+      createdAt: data.createdAt?.toDate().toISOString(),
+      lastAttemptAt: data.lastAttemptAt?.toDate().toISOString() || null,
+      nextRetryAt: data.nextRetryAt?.toDate().toISOString() || null,
+      failureReason: data.failureReason,
+    };
+  });
+
+  res.status(200).json({ entries, count: entries.length });
+});

--- a/functions/src/app.ts
+++ b/functions/src/app.ts
@@ -1,9 +1,11 @@
 import { initializeApp } from "firebase-admin/app";
 import { getFirestore } from "firebase-admin/firestore";
 import { getAuth } from "firebase-admin/auth";
+import { getStorage } from "firebase-admin/storage";
 
 const app = initializeApp();
 const db = getFirestore(app);
 const auth = getAuth(app);
+const storage = getStorage(app);
 
-export { db, auth };
+export { db, auth, storage };

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -7,6 +7,8 @@ import { oauth2Callback } from "./oauth2-callback.js";
 import { oauth2Regenerate } from "./oauth2-regenerate.js";
 import { checkEmailConflict } from "./check-email-conflict.js";
 import { scheduledTokenRefresh } from "./scheduled-token-refresh.js";
+import { scheduledUploadRetry } from "./scheduled-upload-retry.js";
+import { apiQueueStatus } from "./api-queue-status.js";
 import { generateOAuthState } from "./generate-oauth-state.js";
 import { saveOsfToken } from "./save-osf-token.js";
 import { getOsfToken } from "./get-osf-token.js";
@@ -24,6 +26,8 @@ export {
   oauth2Regenerate as oauth2regenerate,
   checkEmailConflict as checkemailconflict,
   scheduledTokenRefresh as scheduledtokenrefresh,
+  scheduledUploadRetry as scheduleduploadretry,
+  apiQueueStatus as apiqueuestatus,
   generateOAuthState as generateoauthstate,
   saveOsfToken as saveosftoken,
   getOsfToken as getosftoken,

--- a/functions/src/interfaces.ts
+++ b/functions/src/interfaces.ts
@@ -72,6 +72,27 @@ export interface ExperimentData {
     success: boolean;
     errorCode: number | null;
     errorText: string | null;
+    retryAfter?: number | null;
+  }
+
+  export interface QueuedUpload {
+    experimentID: string;
+    owner: string;
+    filename: string;
+    storagePath: string;
+    dataType: "data" | "base64";
+    osfFilesLink: string;
+    status: "pending" | "processing" | "completed" | "failed";
+    errorCode: number;
+    retryCount: number;
+    maxRetries: number;
+    createdAt: FirebaseFirestore.Timestamp;
+    lastAttemptAt: FirebaseFirestore.Timestamp | null;
+    nextRetryAt: FirebaseFirestore.Timestamp;
+    completedAt: FirebaseFirestore.Timestamp | null;
+    failureReason: string | null;
+    deduplicationKey: string;
+    sessionIncremented: boolean;
   }
 
   export interface OSFFile{

--- a/functions/src/put-file-osf.ts
+++ b/functions/src/put-file-osf.ts
@@ -46,7 +46,9 @@ export default async function putFileOSF(
   });
 
   if (osfResult.status !== 201) {
-    return { success: false, errorCode: osfResult.status, errorText: osfResult.statusText };
+    const retryAfterHeader = osfResult.headers.get('Retry-After');
+    const retryAfter = retryAfterHeader ? parseInt(retryAfterHeader, 10) : null;
+    return { success: false, errorCode: osfResult.status, errorText: osfResult.statusText, retryAfter };
   }
 
   return { success: true, errorCode: null, errorText: null };

--- a/functions/src/queue-upload.ts
+++ b/functions/src/queue-upload.ts
@@ -10,32 +10,33 @@ interface QueueUploadParams {
   osfFilesLink: string;
   errorCode: number;
   sessionIncremented: boolean;
+  failureReason?: string;
 }
 
 const MAX_RETRIES = 5;
 
 export default async function queueUpload(params: QueueUploadParams): Promise<string> {
   const deduplicationKey = `${params.experimentID}:${params.filename}`;
+  const docId = deduplicationKey.replace(/[/\\]/g, "_");
 
-  // Check for existing pending/processing entry with same key
-  const existing = await db
-    .collection("uploadQueue")
-    .where("deduplicationKey", "==", deduplicationKey)
-    .where("status", "in", ["pending", "processing"])
-    .limit(1)
-    .get();
-
-  if (!existing.empty) {
-    return existing.docs[0].id;
-  }
+  const docRef = db.collection("uploadQueue").doc(docId);
 
   const now = Timestamp.now();
   const nextRetryAt = Timestamp.fromMillis(now.toMillis() + 60 * 60 * 1000); // 1 hour
 
-  const docRef = db.collection("uploadQueue").doc();
+  // Use set with merge:false — if the doc already exists (pending/processing),
+  // the storage write is idempotent and the Firestore write overwrites with fresh data.
+  // If it was completed/failed, we re-queue it.
+  const existingDoc = await docRef.get();
+  if (existingDoc.exists) {
+    const status = existingDoc.data()?.status;
+    if (status === "pending" || status === "processing") {
+      return docId;
+    }
+  }
 
   // Write data to Cloud Storage
-  const storagePath = `upload-queue/${docRef.id}`;
+  const storagePath = `upload-queue/${docId}`;
   const bucket = storage.bucket();
   const file = bucket.file(storagePath);
   await file.save(params.data, { contentType: "text/plain" });
@@ -56,10 +57,10 @@ export default async function queueUpload(params: QueueUploadParams): Promise<st
     lastAttemptAt: null,
     nextRetryAt,
     completedAt: null,
-    failureReason: null,
+    failureReason: params.failureReason || null,
     deduplicationKey,
     sessionIncremented: params.sessionIncremented,
   });
 
-  return docRef.id;
+  return docId;
 }

--- a/functions/src/queue-upload.ts
+++ b/functions/src/queue-upload.ts
@@ -1,0 +1,65 @@
+import { Timestamp } from "firebase-admin/firestore";
+import { db, storage } from "./app.js";
+
+interface QueueUploadParams {
+  experimentID: string;
+  owner: string;
+  filename: string;
+  data: string;
+  dataType: "data" | "base64";
+  osfFilesLink: string;
+  errorCode: number;
+  sessionIncremented: boolean;
+}
+
+const MAX_RETRIES = 5;
+
+export default async function queueUpload(params: QueueUploadParams): Promise<string> {
+  const deduplicationKey = `${params.experimentID}:${params.filename}`;
+
+  // Check for existing pending/processing entry with same key
+  const existing = await db
+    .collection("uploadQueue")
+    .where("deduplicationKey", "==", deduplicationKey)
+    .where("status", "in", ["pending", "processing"])
+    .limit(1)
+    .get();
+
+  if (!existing.empty) {
+    return existing.docs[0].id;
+  }
+
+  const now = Timestamp.now();
+  const nextRetryAt = Timestamp.fromMillis(now.toMillis() + 60 * 60 * 1000); // 1 hour
+
+  const docRef = db.collection("uploadQueue").doc();
+
+  // Write data to Cloud Storage
+  const storagePath = `upload-queue/${docRef.id}`;
+  const bucket = storage.bucket();
+  const file = bucket.file(storagePath);
+  await file.save(params.data, { contentType: "text/plain" });
+
+  // Write metadata to Firestore
+  await docRef.set({
+    experimentID: params.experimentID,
+    owner: params.owner,
+    filename: params.filename,
+    storagePath,
+    dataType: params.dataType,
+    osfFilesLink: params.osfFilesLink,
+    status: "pending",
+    errorCode: params.errorCode,
+    retryCount: 0,
+    maxRetries: MAX_RETRIES,
+    createdAt: now,
+    lastAttemptAt: null,
+    nextRetryAt,
+    completedAt: null,
+    failureReason: null,
+    deduplicationKey,
+    sessionIncremented: params.sessionIncremented,
+  });
+
+  return docRef.id;
+}

--- a/functions/src/scheduled-upload-retry.ts
+++ b/functions/src/scheduled-upload-retry.ts
@@ -150,7 +150,7 @@ async function processQueueItem(queueDoc: FirebaseFirestore.QueryDocumentSnapsho
       return;
     }
 
-    await handleRetryFailure(docRef, data, `OSF error ${result.errorCode}: ${result.errorText}`);
+    await handleRetryFailure(docRef, data, `OSF error ${result.errorCode}: ${result.errorText}`, result.retryAfter);
   } catch (e) {
     const detail = e instanceof Error ? e.message : "Unknown error";
     await handleRetryFailure(docRef, data, `Upload exception: ${detail}`);
@@ -175,7 +175,8 @@ async function markCompleted(
 async function handleRetryFailure(
   docRef: FirebaseFirestore.DocumentReference,
   data: FirebaseFirestore.DocumentData,
-  reason: string
+  reason: string,
+  retryAfterSeconds?: number | null
 ) {
   const newRetryCount = (data.retryCount || 0) + 1;
 
@@ -189,8 +190,10 @@ async function handleRetryFailure(
     return;
   }
 
-  // Exponential backoff: 2^retryCount hours, capped at 24 hours
-  const backoffMs = Math.min(Math.pow(2, newRetryCount) * 60 * 60 * 1000, MAX_BACKOFF_MS);
+  // Honor Retry-After header if provided, otherwise use exponential backoff
+  const backoffMs = retryAfterSeconds
+    ? Math.min(retryAfterSeconds * 1000, MAX_BACKOFF_MS)
+    : Math.min(Math.pow(2, newRetryCount) * 60 * 60 * 1000, MAX_BACKOFF_MS);
   const nextRetryAt = Timestamp.fromMillis(Date.now() + backoffMs);
 
   console.log(`Upload ${docRef.id} retry ${newRetryCount} failed: ${reason}. Next retry at ${nextRetryAt.toDate().toISOString()}`);

--- a/functions/src/scheduled-upload-retry.ts
+++ b/functions/src/scheduled-upload-retry.ts
@@ -1,0 +1,231 @@
+import { onSchedule } from "firebase-functions/v2/scheduler";
+import { Timestamp } from "firebase-admin/firestore";
+import { db, storage } from "./app.js";
+import putFileOSF from "./put-file-osf.js";
+import resolveToken from "./resolve-token.js";
+import { ExperimentData, UserData } from "./interfaces.js";
+
+const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
+const MAX_BACKOFF_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+/**
+ * Scheduled function that runs every hour to retry failed OSF uploads.
+ * Processes up to 10 pending items per run, applies exponential backoff,
+ * and cleans up entries older than 7 days.
+ */
+export const scheduledUploadRetry = onSchedule("0 * * * *", async () => {
+  await retryPendingUploads();
+  await cleanupOldEntries();
+});
+
+async function retryPendingUploads() {
+  const now = Timestamp.now();
+
+  const pendingItems = await db
+    .collection("uploadQueue")
+    .where("status", "==", "pending")
+    .where("nextRetryAt", "<=", now)
+    .orderBy("nextRetryAt", "asc")
+    .limit(10)
+    .get();
+
+  if (pendingItems.empty) {
+    console.log("No pending uploads to retry.");
+    return;
+  }
+
+  console.log(`Found ${pendingItems.size} pending upload(s) to retry.`);
+
+  // Group by owner to avoid hammering same user's rate limit
+  const byOwner = new Map<string, FirebaseFirestore.QueryDocumentSnapshot[]>();
+  for (const doc of pendingItems.docs) {
+    const owner = doc.data().owner;
+    if (!byOwner.has(owner)) {
+      byOwner.set(owner, []);
+    }
+    byOwner.get(owner)!.push(doc);
+  }
+
+  // Interleave: take one from each owner at a time
+  const ordered: FirebaseFirestore.QueryDocumentSnapshot[] = [];
+  let hasMore = true;
+  let index = 0;
+  while (hasMore) {
+    hasMore = false;
+    for (const docs of byOwner.values()) {
+      if (index < docs.length) {
+        ordered.push(docs[index]);
+        hasMore = true;
+      }
+    }
+    index++;
+  }
+
+  for (const queueDoc of ordered) {
+    await processQueueItem(queueDoc);
+  }
+}
+
+async function processQueueItem(queueDoc: FirebaseFirestore.QueryDocumentSnapshot) {
+  const docRef = queueDoc.ref;
+  const data = queueDoc.data();
+
+  // Atomically claim the item
+  try {
+    await db.runTransaction(async (transaction) => {
+      const freshDoc = await transaction.get(docRef);
+      if (freshDoc.data()?.status !== "pending") {
+        throw new Error("Already claimed");
+      }
+      transaction.update(docRef, { status: "processing", lastAttemptAt: Timestamp.now() });
+    });
+  } catch {
+    console.log(`Skipping ${queueDoc.id} — already claimed by another instance.`);
+    return;
+  }
+
+  // Re-resolve the OSF token
+  const userDoc = await db.doc(`users/${data.owner}`).get();
+  if (!userDoc.exists) {
+    await docRef.update({ status: "failed", failureReason: "Owner user not found" });
+    return;
+  }
+
+  const expDoc = await db.doc(`experiments/${data.experimentID}`).get();
+  if (!expDoc.exists) {
+    await docRef.update({ status: "failed", failureReason: "Experiment not found" });
+    return;
+  }
+
+  const userData = userDoc.data() as UserData;
+  const expData = expDoc.data() as ExperimentData;
+
+  let token: string;
+  try {
+    const tokenResult = await resolveToken(userData, expData);
+    if (!tokenResult.success) {
+      await handleRetryFailure(docRef, data, `Token resolution failed: ${tokenResult.error}`);
+      return;
+    }
+    token = tokenResult.token;
+  } catch (e) {
+    const detail = e instanceof Error ? e.message : "Unknown error";
+    await handleRetryFailure(docRef, data, `Token resolution exception: ${detail}`);
+    return;
+  }
+
+  // Read cached data from Cloud Storage
+  let fileData: string | Buffer;
+  try {
+    const bucket = storage.bucket();
+    const file = bucket.file(data.storagePath);
+    const [contents] = await file.download();
+    if (data.dataType === "base64") {
+      const raw = contents.toString("utf-8");
+      const split = raw.split(",");
+      fileData = split.length > 1 ? Buffer.from(split[1], "base64") : Buffer.from(raw, "base64");
+    } else {
+      fileData = contents.toString("utf-8");
+    }
+  } catch (e) {
+    const detail = e instanceof Error ? e.message : "Unknown error";
+    await docRef.update({ status: "failed", failureReason: `Failed to read cached data: ${detail}` });
+    return;
+  }
+
+  // Attempt the upload
+  try {
+    const result = await putFileOSF(data.osfFilesLink, token, fileData, data.filename);
+
+    if (result.success) {
+      await markCompleted(docRef, data);
+      console.log(`Successfully retried upload ${queueDoc.id} (${data.filename})`);
+      return;
+    }
+
+    if (result.errorCode === 409) {
+      // File already exists — treat as success (original upload may have worked)
+      await markCompleted(docRef, data);
+      console.log(`Upload ${queueDoc.id} marked complete — file already exists in OSF.`);
+      return;
+    }
+
+    await handleRetryFailure(docRef, data, `OSF error ${result.errorCode}: ${result.errorText}`);
+  } catch (e) {
+    const detail = e instanceof Error ? e.message : "Unknown error";
+    await handleRetryFailure(docRef, data, `Upload exception: ${detail}`);
+  }
+}
+
+async function markCompleted(
+  docRef: FirebaseFirestore.DocumentReference,
+  data: FirebaseFirestore.DocumentData
+) {
+  await docRef.update({ status: "completed", completedAt: Timestamp.now() });
+
+  // Clean up Cloud Storage
+  try {
+    const bucket = storage.bucket();
+    await bucket.file(data.storagePath).delete();
+  } catch {
+    // Ignore — cleanup sweep will catch it
+  }
+}
+
+async function handleRetryFailure(
+  docRef: FirebaseFirestore.DocumentReference,
+  data: FirebaseFirestore.DocumentData,
+  reason: string
+) {
+  const newRetryCount = (data.retryCount || 0) + 1;
+
+  if (newRetryCount >= data.maxRetries) {
+    console.error(`Upload ${docRef.id} permanently failed after ${newRetryCount} retries: ${reason}`);
+    await docRef.update({
+      status: "failed",
+      retryCount: newRetryCount,
+      failureReason: reason,
+    });
+    return;
+  }
+
+  // Exponential backoff: 2^retryCount hours, capped at 24 hours
+  const backoffMs = Math.min(Math.pow(2, newRetryCount) * 60 * 60 * 1000, MAX_BACKOFF_MS);
+  const nextRetryAt = Timestamp.fromMillis(Date.now() + backoffMs);
+
+  console.log(`Upload ${docRef.id} retry ${newRetryCount} failed: ${reason}. Next retry at ${nextRetryAt.toDate().toISOString()}`);
+
+  await docRef.update({
+    status: "pending",
+    retryCount: newRetryCount,
+    nextRetryAt,
+  });
+}
+
+async function cleanupOldEntries() {
+  const cutoff = Timestamp.fromMillis(Date.now() - SEVEN_DAYS_MS);
+
+  const oldEntries = await db
+    .collection("uploadQueue")
+    .where("createdAt", "<=", cutoff)
+    .limit(50)
+    .get();
+
+  if (oldEntries.empty) {
+    return;
+  }
+
+  console.log(`Cleaning up ${oldEntries.size} old queue entries.`);
+
+  const bucket = storage.bucket();
+
+  for (const doc of oldEntries.docs) {
+    const data = doc.data();
+    try {
+      await bucket.file(data.storagePath).delete();
+    } catch {
+      // File may already be deleted
+    }
+    await doc.ref.delete();
+  }
+}

--- a/pages/admin/[experiment_id].js
+++ b/pages/admin/[experiment_id].js
@@ -1,8 +1,8 @@
 import AuthCheck from "../../components/AuthCheck";
 import { useRouter } from "next/router";
-import { useDocumentData } from "react-firebase-hooks/firestore";
+import { useDocumentData, useCollectionData } from "react-firebase-hooks/firestore";
 import { db } from "../../lib/firebase";
-import { doc } from "firebase/firestore";
+import { doc, collection, query, where, orderBy } from "firebase/firestore";
 
 import { Spinner, Flex, VStack, HStack, Text, Badge, Separator } from "@chakra-ui/react";
 
@@ -13,6 +13,7 @@ import ExperimentValidation from "../../components/dashboard/ExperimentValidatio
 import MetadataControl from "../../components/dashboard/MetadataControl";
 import CodeHints from "../../components/dashboard/CodeHints";
 import ErrorPanel from "../../components/dashboard/ErrorPanel";
+import QueuePanel from "../../components/dashboard/QueuePanel";
 
 export async function getServerSideProps() {
   return { props: {} };
@@ -32,8 +33,18 @@ export default function ExperimentPage() {
 function ExperimentPageDashboard({ experiment_id }) {
   const experimentRef = experiment_id ? doc(db, `experiments/${experiment_id}`) : null;
   const logsRef = experiment_id ? doc(db, `logs/${experiment_id}`) : null;
+  const queueRef = experiment_id
+    ? query(
+        collection(db, "uploadQueue"),
+        where("experimentID", "==", experiment_id),
+        where("status", "in", ["pending", "processing", "failed"]),
+        orderBy("createdAt", "desc")
+      )
+    : null;
   const [data, loading, error, snapshot, reload] = useDocumentData(experimentRef);
   const logs = useDocumentData(logsRef)?.[0] || null;
+  const [queueData] = useCollectionData(queueRef, { idField: "id" });
+  const queueEntries = queueData || [];
 
   const uploadError = logs?.logError;
   const errorLog = logs?.errors;
@@ -57,8 +68,14 @@ function ExperimentPageDashboard({ experiment_id }) {
                 Data upload errors
               </Badge>
             )}
+            {queueEntries.length > 0 && (
+              <Badge colorPalette="orange" variant="solid" px={2} py={1}>
+                {queueEntries.filter(e => e.status === "pending" || e.status === "processing").length} pending upload{queueEntries.filter(e => e.status === "pending" || e.status === "processing").length !== 1 ? "s" : ""}
+              </Badge>
+            )}
           </HStack>
           {uploadError && <ErrorPanel errors={errorLog} />}
+          {queueEntries.length > 0 && <QueuePanel entries={queueEntries} experimentId={experiment_id} />}
           <Flex w="100%" gap={8} wrap="wrap" alignItems="flex-start">
             <VStack flex="1" minW="300px" gap={0} align="stretch">
               <ExperimentInfo data={data} />

--- a/pages/admin/[experiment_id].js
+++ b/pages/admin/[experiment_id].js
@@ -46,6 +46,7 @@ function ExperimentPageDashboard({ experiment_id }) {
   const [queueData] = useCollectionData(queueRef, { idField: "id" });
   const queueEntries = queueData || [];
 
+  const pendingUploads = queueEntries.filter(e => e.status === "pending" || e.status === "processing").length;
   const uploadError = logs?.logError;
   const errorLog = logs?.errors;
 
@@ -68,9 +69,14 @@ function ExperimentPageDashboard({ experiment_id }) {
                 Data upload errors
               </Badge>
             )}
-            {queueEntries.length > 0 && (
+            {pendingUploads > 0 && (
               <Badge colorPalette="orange" variant="solid" px={2} py={1}>
-                {queueEntries.filter(e => e.status === "pending" || e.status === "processing").length} pending upload{queueEntries.filter(e => e.status === "pending" || e.status === "processing").length !== 1 ? "s" : ""}
+                {pendingUploads} pending upload{pendingUploads !== 1 ? "s" : ""}
+              </Badge>
+            )}
+            {pendingUploads === 0 && queueEntries.length > 0 && (
+              <Badge colorPalette="red" variant="solid" px={2} py={1}>
+                {queueEntries.length} failed upload{queueEntries.length !== 1 ? "s" : ""}
               </Badge>
             )}
           </HStack>

--- a/pages/faq.js
+++ b/pages/faq.js
@@ -45,10 +45,38 @@ export default function FAQ() {
           </Text>
         </FAQItem>
         <FAQItem value="item-2" question="Will DataPipe store my data?">
+          <Text mb={2}>
+            Under normal operation, no. DataPipe routes your data to the Open
+            Science Framework but does not keep a copy. Data passes through
+            DataPipe for optional validation and is then sent directly to your
+            OSF project.
+          </Text>
           <Text>
-            No. DataPipe routes your data to the Open Science Framework but
-            does not keep a copy. Data passes through DataPipe for optional
-            validation and is then sent directly to your OSF project.
+            The one exception is when an upload to the OSF fails (for example,
+            due to a temporary OSF outage or rate limit). In that case,
+            DataPipe temporarily caches the data so it can retry the upload
+            automatically. Cached data is encrypted at rest, stored for up to
+            one week, and deleted as soon as the upload succeeds. See the
+            question below for details.
+          </Text>
+        </FAQItem>
+        <FAQItem value="item-2b" question="What happens if an upload to the OSF fails?">
+          <Text mb={2}>
+            If the OSF is temporarily unavailable or returns an error, DataPipe
+            will not lose your data. Failed uploads are automatically cached
+            and retried with increasing intervals (starting at one hour, up to
+            24 hours) for up to five attempts over approximately one week.
+          </Text>
+          <Text mb={2}>
+            Your experiment dashboard will show an orange badge for pending
+            retries or a red badge if all retries have been exhausted. You can
+            expand the queued files panel to see the status of each file,
+            including the reason for failure and the number of retry attempts.
+          </Text>
+          <Text>
+            You can also download any cached file directly from the dashboard
+            at any time, so you always have a way to recover your data even if
+            the automatic retries do not succeed.
           </Text>
         </FAQItem>
         <FAQItem value="item-3" question="How much does it cost?">

--- a/storage.rules
+++ b/storage.rules
@@ -1,0 +1,8 @@
+rules_version = '2';
+service firebase.storage {
+  match /b/{bucket}/o {
+    match /{allPaths=**} {
+      allow read, write: if false;
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- When OSF uploads fail (429 rate limits, 5xx server errors, network exceptions), data is now cached in Cloud Storage instead of being lost
- A Firestore `uploadQueue` collection tracks pending uploads with metadata (status, retry count, backoff timing)
- A scheduled function runs hourly to retry pending uploads with exponential backoff (1h, 2h, 4h, 8h, 16h), max 5 retries
- Cached files are retained for up to 1 week and automatically cleaned up
- The experiment dashboard shows an orange badge with pending upload count and a QueuePanel with file list and download buttons
- New authenticated API endpoint (`/api/queuestatus`) for listing queue entries and generating signed download URLs
- Client receives HTTP 202 (Accepted) instead of an error when uploads are queued

## Test plan

- [ ] Verify TypeScript compiles cleanly (`cd functions && npm run build`)
- [ ] Test with emulators: submit data with a misconfigured OSF endpoint to trigger upload failures
- [ ] Verify failed uploads appear in Firestore `uploadQueue` collection and Cloud Storage `upload-queue/` path
- [ ] Verify client receives 202 response with `OSF_UPLOAD_QUEUED` message
- [ ] Verify session counter is incremented when data uploads are queued
- [ ] Verify the experiment dashboard shows the orange badge and QueuePanel with queued files
- [ ] Test download button generates a working signed URL
- [ ] Test deduplication: same experiment+filename should not create duplicate queue entries
- [ ] Test scheduled retry function processes pending items and marks them completed on success
- [ ] Test 7-day cleanup removes old entries and Cloud Storage files

🤖 Generated with [Claude Code](https://claude.com/claude-code)