### PR TITLE
Upload queue retry with automatic recovery and dashboard UI

### DIFF
--- a/components/dashboard/QueuePanel.js
+++ b/components/dashboard/QueuePanel.js
@@ -33,6 +33,20 @@ function formatDate(value) {
   }).format(date);
 }
 
+function timeRemaining(createdAt) {
+  if (!createdAt) return null;
+  const created = createdAt.toDate ? createdAt.toDate() : new Date(createdAt);
+  const expiresAt = created.getTime() + 7 * 24 * 60 * 60 * 1000;
+  const msLeft = expiresAt - Date.now();
+  if (msLeft <= 0) return "expiring soon";
+  const hoursLeft = Math.floor(msLeft / (60 * 60 * 1000));
+  if (hoursLeft >= 24) {
+    const days = Math.floor(hoursLeft / 24);
+    return `${days}d ${hoursLeft % 24}h remaining`;
+  }
+  return `${hoursLeft}h remaining`;
+}
+
 export default function QueuePanel({ entries, experimentId }) {
   const [downloading, setDownloading] = useState(null);
 
@@ -98,7 +112,7 @@ export default function QueuePanel({ entries, experimentId }) {
                   <Table.Row>
                     <Table.ColumnHeader>FILENAME</Table.ColumnHeader>
                     <Table.ColumnHeader>STATUS</Table.ColumnHeader>
-                    <Table.ColumnHeader>QUEUED AT</Table.ColumnHeader>
+                    <Table.ColumnHeader>EXPIRES</Table.ColumnHeader>
                     <Table.ColumnHeader>RETRIES</Table.ColumnHeader>
                     <Table.ColumnHeader>DOWNLOAD</Table.ColumnHeader>
                   </Table.Row>
@@ -115,7 +129,7 @@ export default function QueuePanel({ entries, experimentId }) {
                         )}
                       </Table.Cell>
                       <Table.Cell>{statusBadge(entry.status)}</Table.Cell>
-                      <Table.Cell>{formatDate(entry.createdAt)}</Table.Cell>
+                      <Table.Cell>{timeRemaining(entry.createdAt)}</Table.Cell>
                       <Table.Cell>
                         {entry.retryCount}/{entry.maxRetries}
                       </Table.Cell>

--- a/components/dashboard/QueuePanel.js
+++ b/components/dashboard/QueuePanel.js
@@ -135,7 +135,8 @@ export default function QueuePanel({ entries, experimentId, errorLog }) {
         <HStack mb={4}>
           <Button
             size="sm"
-            variant="outline"
+            variant="solid"
+            colorPalette="gray"
             loading={downloadingAll}
             onClick={handleDownloadAll}
           >

--- a/components/dashboard/QueuePanel.js
+++ b/components/dashboard/QueuePanel.js
@@ -1,0 +1,142 @@
+import { useState } from "react";
+import {
+  Box,
+  Accordion,
+  Alert,
+  Table,
+  Badge,
+  IconButton,
+  Text,
+} from "@chakra-ui/react";
+import { Download } from "lucide-react";
+import { auth } from "../../lib/firebase";
+
+function statusBadge(status) {
+  const colors = {
+    pending: "orange",
+    processing: "blue",
+    failed: "red",
+  };
+  return (
+    <Badge colorPalette={colors[status] || "gray"} variant="solid" px={2}>
+      {status}
+    </Badge>
+  );
+}
+
+function formatDate(isoString) {
+  if (!isoString) return "-";
+  return new Intl.DateTimeFormat("en-GB", {
+    dateStyle: "short",
+    timeStyle: "short",
+  }).format(new Date(isoString));
+}
+
+export default function QueuePanel({ entries, experimentId }) {
+  const [downloading, setDownloading] = useState(null);
+
+  const handleDownload = async (entry) => {
+    setDownloading(entry.id);
+    try {
+      const user = auth.currentUser;
+      if (!user) return;
+      const idToken = await user.getIdToken();
+      const response = await fetch(
+        `/api/queuestatus?experimentID=${experimentId}&download=${entry.id}`,
+        {
+          headers: { Authorization: `Bearer ${idToken}` },
+        }
+      );
+      if (!response.ok) {
+        console.error("Failed to get download URL");
+        return;
+      }
+      const { url } = await response.json();
+      window.open(url, "_blank");
+    } catch (e) {
+      console.error("Download failed:", e);
+    } finally {
+      setDownloading(null);
+    }
+  };
+
+  const pendingCount = entries.filter(
+    (e) => e.status === "pending" || e.status === "processing"
+  ).length;
+  const failedCount = entries.filter((e) => e.status === "failed").length;
+
+  let alertTitle = "";
+  if (pendingCount > 0 && failedCount > 0) {
+    alertTitle = `${pendingCount} file(s) queued for upload, ${failedCount} failed.`;
+  } else if (pendingCount > 0) {
+    alertTitle = `${pendingCount} file(s) queued for upload to OSF.`;
+  } else {
+    alertTitle = `${failedCount} file(s) failed to upload to OSF.`;
+  }
+
+  return (
+    <Alert.Root status="warning" variant="solid">
+      <Alert.Indicator />
+      <Box flex="1">
+        <Alert.Title mb={1}>{alertTitle}</Alert.Title>
+        <Text fontSize="sm" mb={4}>
+          Queued files are retried automatically every hour and stored for up to
+          1 week. You can download them below.
+        </Text>
+        <Accordion.Root collapsible>
+          <Accordion.Item value="queue-list">
+            <Accordion.ItemTrigger>
+              <Box as="span" flex="1" textAlign="left">
+                See Queued Files
+              </Box>
+              <Accordion.ItemIndicator />
+            </Accordion.ItemTrigger>
+            <Accordion.ItemContent pb={4}>
+              <Table.Root variant="line" size="sm">
+                <Table.Header>
+                  <Table.Row>
+                    <Table.ColumnHeader>FILENAME</Table.ColumnHeader>
+                    <Table.ColumnHeader>STATUS</Table.ColumnHeader>
+                    <Table.ColumnHeader>QUEUED AT</Table.ColumnHeader>
+                    <Table.ColumnHeader>RETRIES</Table.ColumnHeader>
+                    <Table.ColumnHeader>DOWNLOAD</Table.ColumnHeader>
+                  </Table.Row>
+                </Table.Header>
+                <Table.Body>
+                  {entries.map((entry) => (
+                    <Table.Row key={entry.id}>
+                      <Table.Cell>
+                        {entry.filename}
+                        {entry.failureReason && (
+                          <Text fontSize="xs" color="red.300" mt={1}>
+                            {entry.failureReason}
+                          </Text>
+                        )}
+                      </Table.Cell>
+                      <Table.Cell>{statusBadge(entry.status)}</Table.Cell>
+                      <Table.Cell>{formatDate(entry.createdAt)}</Table.Cell>
+                      <Table.Cell>
+                        {entry.retryCount}/{entry.maxRetries}
+                      </Table.Cell>
+                      <Table.Cell>
+                        <IconButton
+                          aria-label="Download file"
+                          size="xs"
+                          variant="ghost"
+                          loading={downloading === entry.id}
+                          onClick={() => handleDownload(entry)}
+                        >
+                          <Download size={14} />
+                        </IconButton>
+                      </Table.Cell>
+                    </Table.Row>
+                  ))}
+                </Table.Body>
+              </Table.Root>
+            </Accordion.ItemContent>
+          </Accordion.Item>
+        </Accordion.Root>
+      </Box>
+    </Alert.Root>
+  );
+}

--- a/components/dashboard/QueuePanel.js
+++ b/components/dashboard/QueuePanel.js
@@ -12,14 +12,15 @@ import { Download } from "lucide-react";
 import { auth } from "../../lib/firebase";
 
 function statusBadge(status) {
-  const colors = {
-    pending: "orange",
-    processing: "blue",
-    failed: "red",
+  const labels = {
+    pending: { color: "orange", text: "Waiting to retry" },
+    processing: { color: "blue", text: "Retrying now" },
+    failed: { color: "red", text: "Failed" },
   };
+  const { color, text } = labels[status] || { color: "gray", text: status };
   return (
-    <Badge colorPalette={colors[status] || "gray"} variant="solid" px={2}>
-      {status}
+    <Badge colorPalette={color} variant="solid" px={2}>
+      {text}
     </Badge>
   );
 }
@@ -80,13 +81,15 @@ export default function QueuePanel({ entries, experimentId }) {
   ).length;
   const failedCount = entries.filter((e) => e.status === "failed").length;
 
+  const plural = (n, word) => `${n} ${word}${n !== 1 ? "s" : ""}`;
+
   let alertTitle = "";
   if (pendingCount > 0 && failedCount > 0) {
-    alertTitle = `${pendingCount} file(s) queued for upload, ${failedCount} failed.`;
+    alertTitle = `${plural(pendingCount, "file")} waiting to upload, ${plural(failedCount, "file")} failed.`;
   } else if (pendingCount > 0) {
-    alertTitle = `${pendingCount} file(s) queued for upload to OSF.`;
+    alertTitle = `${plural(pendingCount, "file")} waiting to upload to OSF.`;
   } else {
-    alertTitle = `${failedCount} file(s) failed to upload to OSF.`;
+    alertTitle = `${plural(failedCount, "file")} could not be uploaded to OSF.`;
   }
 
   return (
@@ -95,14 +98,15 @@ export default function QueuePanel({ entries, experimentId }) {
       <Box flex="1">
         <Alert.Title mb={1}>{alertTitle}</Alert.Title>
         <Text fontSize="sm" mb={4}>
-          Queued files are retried automatically every hour and stored for up to
-          1 week. You can download them below.
+          {failedCount > 0 && pendingCount === 0
+            ? "These files could not be delivered after multiple attempts. Download them below to avoid data loss."
+            : "DataPipe will keep retrying automatically. Files are stored for up to 1 week. You can also download them below."}
         </Text>
         <Accordion.Root collapsible>
           <Accordion.Item value="queue-list">
             <Accordion.ItemTrigger>
               <Box as="span" flex="1" textAlign="left">
-                See Queued Files
+                View file details
               </Box>
               <Accordion.ItemIndicator />
             </Accordion.ItemTrigger>
@@ -113,8 +117,8 @@ export default function QueuePanel({ entries, experimentId }) {
                     <Table.ColumnHeader>FILENAME</Table.ColumnHeader>
                     <Table.ColumnHeader>STATUS</Table.ColumnHeader>
                     <Table.ColumnHeader>EXPIRES</Table.ColumnHeader>
-                    <Table.ColumnHeader>RETRIES</Table.ColumnHeader>
-                    <Table.ColumnHeader>DOWNLOAD</Table.ColumnHeader>
+                    <Table.ColumnHeader>ATTEMPTS</Table.ColumnHeader>
+                    <Table.ColumnHeader></Table.ColumnHeader>
                   </Table.Row>
                 </Table.Header>
                 <Table.Body>

--- a/components/dashboard/QueuePanel.js
+++ b/components/dashboard/QueuePanel.js
@@ -118,7 +118,7 @@ export default function QueuePanel({ entries, experimentId }) {
                     <Table.ColumnHeader>STATUS</Table.ColumnHeader>
                     <Table.ColumnHeader>EXPIRES</Table.ColumnHeader>
                     <Table.ColumnHeader>ATTEMPTS</Table.ColumnHeader>
-                    <Table.ColumnHeader></Table.ColumnHeader>
+                    <Table.ColumnHeader>DOWNLOAD</Table.ColumnHeader>
                   </Table.Row>
                 </Table.Header>
                 <Table.Body>

--- a/components/dashboard/QueuePanel.js
+++ b/components/dashboard/QueuePanel.js
@@ -64,11 +64,16 @@ export default function QueuePanel({ entries, experimentId }) {
         }
       );
       if (!response.ok) {
-        console.error("Failed to get download URL");
+        console.error("Failed to download file");
         return;
       }
-      const { url } = await response.json();
-      window.open(url, "_blank");
+      const blob = await response.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = entry.filename;
+      a.click();
+      URL.revokeObjectURL(url);
     } catch (e) {
       console.error("Download failed:", e);
     } finally {

--- a/components/dashboard/QueuePanel.js
+++ b/components/dashboard/QueuePanel.js
@@ -24,12 +24,13 @@ function statusBadge(status) {
   );
 }
 
-function formatDate(isoString) {
-  if (!isoString) return "-";
+function formatDate(value) {
+  if (!value) return "-";
+  const date = value.toDate ? value.toDate() : new Date(value);
   return new Intl.DateTimeFormat("en-GB", {
     dateStyle: "short",
     timeStyle: "short",
-  }).format(new Date(isoString));
+  }).format(date);
 }
 
 export default function QueuePanel({ entries, experimentId }) {

--- a/components/dashboard/QueuePanel.js
+++ b/components/dashboard/QueuePanel.js
@@ -6,7 +6,9 @@ import {
   Table,
   Badge,
   IconButton,
+  Button,
   Text,
+  HStack,
 } from "@chakra-ui/react";
 import { Download } from "lucide-react";
 import { auth } from "../../lib/firebase";
@@ -25,15 +27,6 @@ function statusBadge(status) {
   );
 }
 
-function formatDate(value) {
-  if (!value) return "-";
-  const date = value.toDate ? value.toDate() : new Date(value);
-  return new Intl.DateTimeFormat("en-GB", {
-    dateStyle: "short",
-    timeStyle: "short",
-  }).format(date);
-}
-
 function timeRemaining(createdAt) {
   if (!createdAt) return null;
   const created = createdAt.toDate ? createdAt.toDate() : new Date(createdAt);
@@ -48,22 +41,25 @@ function timeRemaining(createdAt) {
   return `${hoursLeft}h remaining`;
 }
 
-export default function QueuePanel({ entries, experimentId }) {
+async function fetchFile(experimentId, entryId) {
+  const user = auth.currentUser;
+  if (!user) return;
+  const idToken = await user.getIdToken();
+  return fetch(
+    `/api/queuestatus?experimentID=${experimentId}&download=${entryId}`,
+    { headers: { Authorization: `Bearer ${idToken}` } }
+  );
+}
+
+export default function QueuePanel({ entries, experimentId, errorLog }) {
   const [downloading, setDownloading] = useState(null);
+  const [downloadingAll, setDownloadingAll] = useState(false);
 
   const handleDownload = async (entry) => {
     setDownloading(entry.id);
     try {
-      const user = auth.currentUser;
-      if (!user) return;
-      const idToken = await user.getIdToken();
-      const response = await fetch(
-        `/api/queuestatus?experimentID=${experimentId}&download=${entry.id}`,
-        {
-          headers: { Authorization: `Bearer ${idToken}` },
-        }
-      );
-      if (!response.ok) {
+      const response = await fetchFile(experimentId, entry.id);
+      if (!response || !response.ok) {
         console.error("Failed to download file");
         return;
       }
@@ -81,10 +77,39 @@ export default function QueuePanel({ entries, experimentId }) {
     }
   };
 
+  const handleDownloadAll = async () => {
+    setDownloadingAll(true);
+    try {
+      const user = auth.currentUser;
+      if (!user) return;
+      const idToken = await user.getIdToken();
+      const response = await fetch(
+        `/api/queuestatus?experimentID=${experimentId}&downloadAll=true`,
+        { headers: { Authorization: `Bearer ${idToken}` } }
+      );
+      if (!response.ok) {
+        console.error("Failed to download ZIP");
+        return;
+      }
+      const blob = await response.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `${experimentId}-queued-files.zip`;
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch (e) {
+      console.error("Download all failed:", e);
+    } finally {
+      setDownloadingAll(false);
+    }
+  };
+
   const pendingCount = entries.filter(
     (e) => e.status === "pending" || e.status === "processing"
   ).length;
   const failedCount = entries.filter((e) => e.status === "failed").length;
+  const allFailed = failedCount > 0 && pendingCount === 0;
 
   const plural = (n, word) => `${n} ${word}${n !== 1 ? "s" : ""}`;
 
@@ -98,16 +123,27 @@ export default function QueuePanel({ entries, experimentId }) {
   }
 
   return (
-    <Alert.Root status="warning" variant="solid">
+    <Alert.Root status={allFailed ? "error" : "warning"} variant="solid">
       <Alert.Indicator />
       <Box flex="1">
         <Alert.Title mb={1}>{alertTitle}</Alert.Title>
         <Text fontSize="sm" mb={4}>
-          {failedCount > 0 && pendingCount === 0
-            ? "These files could not be delivered after multiple attempts. Download them below to avoid data loss."
+          {allFailed
+            ? "These files could not be delivered after multiple attempts. Download them to avoid data loss."
             : "DataPipe will keep retrying automatically. Files are stored for up to 1 week. You can also download them below."}
         </Text>
-        <Accordion.Root collapsible>
+        <HStack mb={4}>
+          <Button
+            size="sm"
+            variant="outline"
+            loading={downloadingAll}
+            onClick={handleDownloadAll}
+          >
+            <Download size={14} />
+            Download all as ZIP
+          </Button>
+        </HStack>
+        <Accordion.Root collapsible defaultValue={allFailed ? ["queue-list"] : []}>
           <Accordion.Item value="queue-list">
             <Accordion.ItemTrigger>
               <Box as="span" flex="1" textAlign="left">
@@ -153,6 +189,24 @@ export default function QueuePanel({ entries, experimentId }) {
                           <Download size={14} />
                         </IconButton>
                       </Table.Cell>
+                    </Table.Row>
+                  ))}
+                  {errorLog && errorLog.map((error, index) => (
+                    <Table.Row key={`error-${index}`}>
+                      <Table.Cell>
+                        <Text>{error.error}</Text>
+                        <Text fontSize="xs" color="red.300" mt={1}>
+                          {error.time}
+                        </Text>
+                      </Table.Cell>
+                      <Table.Cell>
+                        <Badge colorPalette="red" variant="solid" px={2}>
+                          Error
+                        </Badge>
+                      </Table.Cell>
+                      <Table.Cell>-</Table.Cell>
+                      <Table.Cell>-</Table.Cell>
+                      <Table.Cell>-</Table.Cell>
                     </Table.Row>
                   ))}
                 </Table.Body>

--- a/components/dashboard/QueuePanel.js
+++ b/components/dashboard/QueuePanel.js
@@ -132,6 +132,29 @@ export default function QueuePanel({ entries, experimentId, errorLog }) {
             ? "These files could not be delivered after multiple attempts. Download them to avoid data loss."
             : "DataPipe will keep retrying automatically. Files are stored for up to 1 week. You can also download them below."}
         </Text>
+        <Accordion.Root collapsible size="sm" mb={4}>
+          <Accordion.Item value="why">
+            <Accordion.ItemTrigger>
+              <Box as="span" flex="1" textAlign="left" fontSize="sm">
+                Why am I seeing this?
+              </Box>
+              <Accordion.ItemIndicator />
+            </Accordion.ItemTrigger>
+            <Accordion.ItemContent>
+              <Text fontSize="sm" pb={3}>
+                When a participant submits data, DataPipe tries to upload it to
+                your OSF project immediately. If that transfer fails — for
+                example, because OSF is temporarily unavailable, rate-limiting
+                requests, or there is a configuration issue with your project —
+                DataPipe saves a copy of the data and retries automatically over
+                the next several days. The files listed here are those saved
+                copies. Once a retry succeeds the file will disappear from this
+                list. If all retries are exhausted, you can still download the
+                data and upload it to OSF manually.
+              </Text>
+            </Accordion.ItemContent>
+          </Accordion.Item>
+        </Accordion.Root>
         <HStack mb={4}>
           <Button
             size="sm"

--- a/firebase.json
+++ b/firebase.json
@@ -1,4 +1,7 @@
 {
+  "storage": {
+    "rules": "storage.rules"
+  },
   "firestore": {
     "rules": "firestore.rules",
     "indexes": "firestore.indexes.json"

--- a/firebase.json
+++ b/firebase.json
@@ -46,6 +46,10 @@
       {
         "source": "/api/getosftoken",
         "function": "getosftoken"
+      },
+      {
+        "source": "/api/queuestatus",
+        "function": "apiqueuestatus"
       }
     ]
   },

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -7,6 +7,23 @@
         { "fieldPath": "usingPersonalToken", "order": "ASCENDING" },
         { "fieldPath": "refreshTokenExpires", "order": "ASCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "uploadQueue",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "experimentID", "order": "ASCENDING" },
+        { "fieldPath": "status", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "uploadQueue",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "status", "order": "ASCENDING" },
+        { "fieldPath": "nextRetryAt", "order": "ASCENDING" }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -13,6 +13,7 @@
       "queryScope": "COLLECTION",
       "fields": [
         { "fieldPath": "experimentID", "order": "ASCENDING" },
+        { "fieldPath": "owner", "order": "ASCENDING" },
         { "fieldPath": "status", "order": "ASCENDING" },
         { "fieldPath": "createdAt", "order": "DESCENDING" }
       ]

--- a/firestore.rules
+++ b/firestore.rules
@@ -42,5 +42,9 @@ service cloud.firestore {
       allow create: if(request.auth.uid != null) &&
         resource.data.owner == request.auth.uid;
     }
+    match /uploadQueue/{docId} {
+      allow read: if(request.auth.uid != null) &&
+        resource.data.owner == request.auth.uid;
+    }
   }
 }

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -7,6 +7,7 @@
       "name": "functions",
       "dependencies": {
         "@jspsych/metadata": "file:metadata",
+        "archiver": "^7.0.1",
         "cors": "^2.8.5",
         "csv-string": "^4.1.1",
         "express": "^4.18.2",
@@ -17,6 +18,7 @@
         "node-fetch": "^3.2.10"
       },
       "devDependencies": {
+        "@types/archiver": "^7.0.0",
         "@types/is-base64": "^1.1.3",
         "firebase-functions-test": "^3.4.1"
       },
@@ -4582,6 +4584,16 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/archiver": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@types/archiver/-/archiver-7.0.0.tgz",
+      "integrity": "sha512-/3vwGwx9n+mCQdYZ2IKGGHEFL30I96UgBlk8EtRDDFQ9uxM1l4O5Ci6r00EMAkiDaTqD9DQ6nVrWRICnBPtzzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/readdir-glob": "*"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -5055,6 +5067,16 @@
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
       "license": "MIT"
     },
+    "node_modules/@types/readdir-glob": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@types/readdir-glob/-/readdir-glob-1.1.5.tgz",
+      "integrity": "sha512-raiuEPUYqXu+nvtY2Pe8s8FEmZ3x5yAH4VkLdihcPdalvsHltomrRC9BzuStrJ9yk06470hS0Crw0f1pXqD+Hg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/request": {
       "version": "2.48.13",
       "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.13.tgz",
@@ -5522,7 +5544,6 @@
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
       "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "event-target-shim": "^5.0.0"
       },
@@ -5781,6 +5802,131 @@
         "node": ">= 6.0.0"
       }
     },
+    "node_modules/archiver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-7.0.1.tgz",
+      "integrity": "sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^5.0.2",
+        "async": "^3.2.4",
+        "buffer-crc32": "^1.0.0",
+        "readable-stream": "^4.0.0",
+        "readdir-glob": "^1.1.2",
+        "tar-stream": "^3.0.0",
+        "zip-stream": "^6.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/archiver-utils": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-5.0.2.tgz",
+      "integrity": "sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==",
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^10.0.0",
+        "graceful-fs": "^4.2.0",
+        "is-stream": "^2.0.1",
+        "lazystream": "^1.0.0",
+        "lodash": "^4.17.15",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/archiver/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/archiver/node_modules/buffer-crc32": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
+      "integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/archiver/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
     "node_modules/argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -5839,6 +5985,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "license": "MIT"
     },
     "node_modules/async-done": {
       "version": "1.3.2",
@@ -5918,7 +6070,6 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.0.tgz",
       "integrity": "sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==",
-      "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {
         "react-native-b4a": "*"
@@ -6072,7 +6223,6 @@
       "version": "2.8.2",
       "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
       "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {
         "bare-abort-controller": "*"
@@ -6081,6 +6231,83 @@
         "bare-abort-controller": {
           "optional": true
         }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.5.6",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.5.6.tgz",
+      "integrity": "sha512-1QovqDrR80Pmt5HPAsMsXTCFcDYr+NSUKW6nd6WO5v0JBmnItc/irNRzm2KOQ5oZ69P37y+AMujNyNtG+1Rggw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.8.2.tgz",
+      "integrity": "sha512-lMseYRMTzMrxPGfXkDwOWym2iv9dUMlTqpjXa0M+7ymI1TJKhxQ2jkDOK7y1EGvxuqJcXOoJ/HYEBxIlWObgjQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
+      "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.11.0.tgz",
+      "integrity": "sha512-Y/+iQ49fL3rIn6w/AVxI/2+BRrpmzJvdWt5Jv8Za6Ngqc6V227c+pYjYYgLdpR3MwQ9ObVXD0ZrqoBztakM0rw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.0.tgz",
+      "integrity": "sha512-NSTU5WN+fy/L0DDenfE8SXQna4voXuW0FHM7wH8i3/q9khUSchfPbPezO4zSFMnDGIf9YE+mt/RWhZgNRKRIXA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
       }
     },
     "node_modules/base64-js": {
@@ -6786,6 +7013,62 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/compress-commons": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-6.0.2.tgz",
+      "integrity": "sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==",
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "crc32-stream": "^6.0.0",
+        "is-stream": "^2.0.1",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/compress-commons/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/compress-commons/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -6854,7 +7137,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/cors": {
@@ -6872,6 +7154,71 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/crc32-stream": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-6.0.0.tgz",
+      "integrity": "sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==",
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/crc32-stream/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/crc32-stream/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/create-jest": {
@@ -8395,16 +8742,23 @@
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
       }
     },
     "node_modules/events-universal": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
       "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "bare-events": "^2.7.0"
@@ -8592,7 +8946,6 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
       "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
@@ -9822,7 +10175,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/gtoken": {
@@ -10400,7 +10752,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -10726,7 +11077,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -10785,7 +11135,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/isexe": {
@@ -12206,6 +12555,48 @@
         "node": ">= 10.13.0"
       }
     },
+    "node_modules/lazystream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
+      "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.6.3"
+      }
+    },
+    "node_modules/lazystream/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/lazystream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/lazystream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/lead": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/lead/-/lead-4.0.0.tgz",
@@ -12274,7 +12665,6 @@
       "version": "4.17.23",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
       "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.camelcase": {
@@ -12772,7 +13162,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -13312,11 +13701,19 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/prompts": {
@@ -13500,6 +13897,27 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/readdir-glob": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
+      "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "minimatch": "^5.1.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/readdirp": {
@@ -14378,10 +14796,9 @@
       "optional": true
     },
     "node_modules/streamx": {
-      "version": "2.23.0",
-      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.23.0.tgz",
-      "integrity": "sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==",
-      "dev": true,
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.25.0.tgz",
+      "integrity": "sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==",
       "license": "MIT",
       "dependencies": {
         "events-universal": "^1.0.0",
@@ -14393,7 +14810,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
@@ -14749,6 +15165,18 @@
         "url": "https://opencollective.com/synckit"
       }
     },
+    "node_modules/tar-stream": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.8.tgz",
+      "integrity": "sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
     "node_modules/teeny-request": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-9.0.0.tgz",
@@ -14805,7 +15233,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
       "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "streamx": "^2.12.5"
@@ -14903,7 +15330,6 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
       "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "b4a": "^1.6.4"
@@ -15381,7 +15807,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/utils-merge": {
@@ -16065,6 +16490,60 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zip-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-6.0.1.tgz",
+      "integrity": "sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==",
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^5.0.0",
+        "compress-commons": "^6.0.2",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/zip-stream/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/zip-stream/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     }
   }

--- a/functions/package.json
+++ b/functions/package.json
@@ -18,6 +18,7 @@
   "type": "module",
   "dependencies": {
     "@jspsych/metadata": "file:metadata",
+    "archiver": "^7.0.1",
     "cors": "^2.8.5",
     "csv-string": "^4.1.1",
     "express": "^4.18.2",
@@ -28,6 +29,7 @@
     "node-fetch": "^3.2.10"
   },
   "devDependencies": {
+    "@types/archiver": "^7.0.0",
     "@types/is-base64": "^1.1.3",
     "firebase-functions-test": "^3.4.1"
   },

--- a/functions/src/__tests__/upload-queue.test.js
+++ b/functions/src/__tests__/upload-queue.test.js
@@ -1,0 +1,212 @@
+/**
+ * @jest-environment node
+ */
+
+import { initializeApp, deleteApp, getApp } from "firebase-admin/app";
+import { getFirestore, Timestamp } from "firebase-admin/firestore";
+
+process.env.FIRESTORE_EMULATOR_HOST = "localhost:8080";
+
+const config = { projectId: "datapipe-test" };
+
+jest.setTimeout(30000);
+
+let db;
+let app;
+
+beforeAll(async () => {
+  try {
+    app = getApp("upload-queue-test");
+  } catch {
+    app = initializeApp(config, "upload-queue-test");
+  }
+  db = getFirestore(app);
+});
+
+afterEach(async () => {
+  // Clean up uploadQueue collection
+  const docs = await db.collection("uploadQueue").get();
+  const batch = db.batch();
+  docs.forEach((doc) => batch.delete(doc.ref));
+  await batch.commit();
+});
+
+describe("queueUpload deduplication", () => {
+  test("uses deterministic document ID from experimentID and filename", async () => {
+    const docId = "exp123:data.csv".replace(/[/\\]/g, "_");
+    const docRef = db.collection("uploadQueue").doc(docId);
+
+    await docRef.set({
+      experimentID: "exp123",
+      owner: "user1",
+      filename: "data.csv",
+      storagePath: `upload-queue/${docId}`,
+      dataType: "data",
+      osfFilesLink: "https://osf.io/files/",
+      status: "pending",
+      errorCode: 0,
+      retryCount: 0,
+      maxRetries: 5,
+      createdAt: Timestamp.now(),
+      lastAttemptAt: null,
+      nextRetryAt: Timestamp.fromMillis(Date.now() + 3600000),
+      completedAt: null,
+      failureReason: "Upload exception: timeout",
+      deduplicationKey: "exp123:data.csv",
+      sessionIncremented: true,
+    });
+
+    // Verify the doc exists at the expected deterministic ID
+    const doc = await docRef.get();
+    expect(doc.exists).toBe(true);
+    expect(doc.data().experimentID).toBe("exp123");
+    expect(doc.data().filename).toBe("data.csv");
+    expect(doc.data().failureReason).toBe("Upload exception: timeout");
+  });
+
+  test("deterministic ID handles filenames with slashes", async () => {
+    const docId = "exp123:subfolder/data.csv".replace(/[/\\]/g, "_");
+    expect(docId).toBe("exp123:subfolder_data.csv");
+  });
+
+  test("same deduplicationKey produces same document ID", () => {
+    const key1 = "exp123:data.csv".replace(/[/\\]/g, "_");
+    const key2 = "exp123:data.csv".replace(/[/\\]/g, "_");
+    expect(key1).toBe(key2);
+  });
+
+  test("different experiments produce different document IDs", () => {
+    const key1 = "exp123:data.csv".replace(/[/\\]/g, "_");
+    const key2 = "exp456:data.csv".replace(/[/\\]/g, "_");
+    expect(key1).not.toBe(key2);
+  });
+});
+
+describe("handleRetryFailure backoff", () => {
+  test("exponential backoff doubles each retry", () => {
+    const MAX_BACKOFF_MS = 24 * 60 * 60 * 1000;
+
+    for (let retryCount = 1; retryCount <= 5; retryCount++) {
+      const backoffMs = Math.min(
+        Math.pow(2, retryCount) * 60 * 60 * 1000,
+        MAX_BACKOFF_MS
+      );
+      const expectedHours = Math.min(Math.pow(2, retryCount), 24);
+      expect(backoffMs).toBe(expectedHours * 60 * 60 * 1000);
+    }
+  });
+
+  test("backoff is capped at 24 hours", () => {
+    const MAX_BACKOFF_MS = 24 * 60 * 60 * 1000;
+    // retryCount = 5 => 2^5 = 32 hours, should cap at 24
+    const backoffMs = Math.min(
+      Math.pow(2, 5) * 60 * 60 * 1000,
+      MAX_BACKOFF_MS
+    );
+    expect(backoffMs).toBe(24 * 60 * 60 * 1000);
+  });
+
+  test("Retry-After header is honored when provided", () => {
+    const MAX_BACKOFF_MS = 24 * 60 * 60 * 1000;
+    const retryAfterSeconds = 120; // 2 minutes
+
+    const backoffMs = Math.min(retryAfterSeconds * 1000, MAX_BACKOFF_MS);
+    expect(backoffMs).toBe(120000);
+  });
+
+  test("Retry-After is capped at MAX_BACKOFF_MS", () => {
+    const MAX_BACKOFF_MS = 24 * 60 * 60 * 1000;
+    const retryAfterSeconds = 100000; // ~27 hours
+
+    const backoffMs = Math.min(retryAfterSeconds * 1000, MAX_BACKOFF_MS);
+    expect(backoffMs).toBe(MAX_BACKOFF_MS);
+  });
+
+  test("falls back to exponential backoff when no Retry-After", () => {
+    const MAX_BACKOFF_MS = 24 * 60 * 60 * 1000;
+    const retryAfterSeconds = null;
+    const retryCount = 2;
+
+    const backoffMs = retryAfterSeconds
+      ? Math.min(retryAfterSeconds * 1000, MAX_BACKOFF_MS)
+      : Math.min(Math.pow(2, retryCount) * 60 * 60 * 1000, MAX_BACKOFF_MS);
+
+    expect(backoffMs).toBe(4 * 60 * 60 * 1000); // 4 hours
+  });
+});
+
+describe("queue entry lifecycle in Firestore", () => {
+  test("pending entry can transition to processing", async () => {
+    const docRef = db.collection("uploadQueue").doc("lifecycle-test");
+    await docRef.set({
+      status: "pending",
+      retryCount: 0,
+      maxRetries: 5,
+      createdAt: Timestamp.now(),
+    });
+
+    // Simulate atomic claim via transaction
+    await db.runTransaction(async (transaction) => {
+      const freshDoc = await transaction.get(docRef);
+      expect(freshDoc.data().status).toBe("pending");
+      transaction.update(docRef, {
+        status: "processing",
+        lastAttemptAt: Timestamp.now(),
+      });
+    });
+
+    const updated = await docRef.get();
+    expect(updated.data().status).toBe("processing");
+  });
+
+  test("processing entry cannot be claimed again", async () => {
+    const docRef = db.collection("uploadQueue").doc("double-claim-test");
+    await docRef.set({
+      status: "processing",
+      retryCount: 0,
+      maxRetries: 5,
+      createdAt: Timestamp.now(),
+    });
+
+    // Second claim should fail
+    await expect(
+      db.runTransaction(async (transaction) => {
+        const freshDoc = await transaction.get(docRef);
+        if (freshDoc.data()?.status !== "pending") {
+          throw new Error("Already claimed");
+        }
+        transaction.update(docRef, { status: "processing" });
+      })
+    ).rejects.toThrow("Already claimed");
+  });
+
+  test("failed entry with max retries reached stays failed", async () => {
+    const docRef = db.collection("uploadQueue").doc("max-retry-test");
+    await docRef.set({
+      status: "pending",
+      retryCount: 4,
+      maxRetries: 5,
+      createdAt: Timestamp.now(),
+      failureReason: null,
+    });
+
+    // Simulate handleRetryFailure logic
+    const data = (await docRef.get()).data();
+    const newRetryCount = (data.retryCount || 0) + 1;
+
+    if (newRetryCount >= data.maxRetries) {
+      await docRef.update({
+        status: "failed",
+        retryCount: newRetryCount,
+        failureReason: "OSF error 500: Internal Server Error",
+      });
+    }
+
+    const result = await docRef.get();
+    expect(result.data().status).toBe("failed");
+    expect(result.data().retryCount).toBe(5);
+    expect(result.data().failureReason).toBe(
+      "OSF error 500: Internal Server Error"
+    );
+  });
+});

--- a/functions/src/api-base64.ts
+++ b/functions/src/api-base64.ts
@@ -114,6 +114,7 @@ export const apiBase64 = onRequest({ cors: true }, async (req, res) => {
         experimentID, owner: exp_data.owner, filename, data,
         dataType: "base64", osfFilesLink: exp_data.osfFilesLink,
         errorCode: 0, sessionIncremented: false,
+        failureReason: `Upload exception: ${detail}`,
       });
       res.status(202).json(MESSAGES.OSF_UPLOAD_QUEUED);
       await writeLog(experimentID, "logError", {...MESSAGES.OSF_UPLOAD_EXCEPTION, detail});
@@ -137,6 +138,7 @@ export const apiBase64 = onRequest({ cors: true }, async (req, res) => {
         experimentID, owner: exp_data.owner, filename, data,
         dataType: "base64", osfFilesLink: exp_data.osfFilesLink,
         errorCode: result.errorCode || 0, sessionIncremented: false,
+        failureReason: `OSF error ${result.errorCode}: ${result.errorText}`,
       });
       res.status(202).json(MESSAGES.OSF_UPLOAD_QUEUED);
       await writeLog(experimentID, "logError", {...MESSAGES.OSF_UPLOAD_ERROR, osfStatus: result.errorCode, osfStatusText: result.errorText});

--- a/functions/src/api-base64.ts
+++ b/functions/src/api-base64.ts
@@ -6,6 +6,7 @@ import writeLog from "./write-log.js";
 import isBase64 from "is-base64";
 import MESSAGES from "./api-messages.js";
 import resolveToken from "./resolve-token.js";
+import queueUpload from "./queue-upload.js";
 import { ExperimentData, UserData, OSFResult } from './interfaces';
 
 export const apiBase64 = onRequest({ cors: true }, async (req, res) => {
@@ -106,10 +107,22 @@ export const apiBase64 = onRequest({ cors: true }, async (req, res) => {
       filename
     );
   } catch (e) {
+    // Network errors, timeouts, etc. — queue for retry
     const detail = e instanceof Error ? e.message : "Unknown error";
-    res.status(500).json(MESSAGES.OSF_UPLOAD_EXCEPTION);
-    await writeLog(experimentID, "logError", {...MESSAGES.OSF_UPLOAD_EXCEPTION, detail});
-    return;
+    try {
+      await queueUpload({
+        experimentID, owner: exp_data.owner, filename, data,
+        dataType: "base64", osfFilesLink: exp_data.osfFilesLink,
+        errorCode: 0, sessionIncremented: false,
+      });
+      res.status(202).json(MESSAGES.OSF_UPLOAD_QUEUED);
+      await writeLog(experimentID, "logError", {...MESSAGES.OSF_UPLOAD_EXCEPTION, detail});
+      return;
+    } catch {
+      res.status(500).json(MESSAGES.OSF_UPLOAD_EXCEPTION);
+      await writeLog(experimentID, "logError", {...MESSAGES.OSF_UPLOAD_EXCEPTION, detail});
+      return;
+    }
   }
 
   if (!result.success) {
@@ -118,9 +131,21 @@ export const apiBase64 = onRequest({ cors: true }, async (req, res) => {
       await writeLog(experimentID, "logError", MESSAGES.OSF_FILE_EXISTS);
       return;
     }
-    res.status(400).json(MESSAGES.OSF_UPLOAD_ERROR);
-    await writeLog(experimentID, "logError", {...MESSAGES.OSF_UPLOAD_ERROR, osfStatus: result.errorCode, osfStatusText: result.errorText});
-    return;
+    // Queue all other failures for retry
+    try {
+      await queueUpload({
+        experimentID, owner: exp_data.owner, filename, data,
+        dataType: "base64", osfFilesLink: exp_data.osfFilesLink,
+        errorCode: result.errorCode || 0, sessionIncremented: false,
+      });
+      res.status(202).json(MESSAGES.OSF_UPLOAD_QUEUED);
+      await writeLog(experimentID, "logError", {...MESSAGES.OSF_UPLOAD_ERROR, osfStatus: result.errorCode, osfStatusText: result.errorText});
+      return;
+    } catch {
+      res.status(400).json(MESSAGES.OSF_UPLOAD_ERROR);
+      await writeLog(experimentID, "logError", {...MESSAGES.OSF_UPLOAD_ERROR, osfStatus: result.errorCode, osfStatusText: result.errorText});
+      return;
+    }
   }
 
   res.status(201).json(MESSAGES.SUCCESS);

--- a/functions/src/api-data.ts
+++ b/functions/src/api-data.ts
@@ -8,6 +8,7 @@ import writeLog from "./write-log.js";
 import MESSAGES from "./api-messages.js";
 import blockMetadata from "./metadata-block.js";
 import resolveToken from "./resolve-token.js";
+import queueUpload from "./queue-upload.js";
 import { ExperimentData, UserData, MetadataResponse, OSFResult, RequestBody } from './interfaces';
 
 export const apiData = onRequest({ cors: true }, async (req, res) => {
@@ -133,10 +134,23 @@ export const apiData = onRequest({ cors: true }, async (req, res) => {
       filename
     );
   } catch (e) {
+    // Network errors, timeouts, etc. — queue for retry
     const detail = e instanceof Error ? e.message : "Unknown error";
-    res.status(500).json({...MESSAGES.OSF_UPLOAD_EXCEPTION, metadataMessage});
-    await writeLog(experimentID, "logError", {...MESSAGES.OSF_UPLOAD_EXCEPTION, detail});
-    return;
+    try {
+      await queueUpload({
+        experimentID, owner: exp_data.owner, filename, data,
+        dataType: "data", osfFilesLink: exp_data.osfFilesLink,
+        errorCode: 0, sessionIncremented: true,
+      });
+      await exp_doc_ref.set({ sessions: FieldValue.increment(1) }, { merge: true });
+      res.status(202).json({...MESSAGES.OSF_UPLOAD_QUEUED, metadataMessage});
+      await writeLog(experimentID, "logError", {...MESSAGES.OSF_UPLOAD_EXCEPTION, detail});
+      return;
+    } catch {
+      res.status(500).json({...MESSAGES.OSF_UPLOAD_EXCEPTION, metadataMessage});
+      await writeLog(experimentID, "logError", {...MESSAGES.OSF_UPLOAD_EXCEPTION, detail});
+      return;
+    }
   }
 
   if (!result.success) {
@@ -145,9 +159,22 @@ export const apiData = onRequest({ cors: true }, async (req, res) => {
       await writeLog(experimentID, "logError", MESSAGES.OSF_FILE_EXISTS);
       return;
     }
-    res.status(400).json({...MESSAGES.OSF_UPLOAD_ERROR, metadataMessage});
-    await writeLog(experimentID, "logError", {...MESSAGES.OSF_UPLOAD_ERROR, osfStatus: result.errorCode, osfStatusText: result.errorText});
-    return;
+    // Queue all other failures for retry
+    try {
+      await queueUpload({
+        experimentID, owner: exp_data.owner, filename, data,
+        dataType: "data", osfFilesLink: exp_data.osfFilesLink,
+        errorCode: result.errorCode || 0, sessionIncremented: true,
+      });
+      await exp_doc_ref.set({ sessions: FieldValue.increment(1) }, { merge: true });
+      res.status(202).json({...MESSAGES.OSF_UPLOAD_QUEUED, metadataMessage});
+      await writeLog(experimentID, "logError", {...MESSAGES.OSF_UPLOAD_ERROR, osfStatus: result.errorCode, osfStatusText: result.errorText});
+      return;
+    } catch {
+      res.status(400).json({...MESSAGES.OSF_UPLOAD_ERROR, metadataMessage});
+      await writeLog(experimentID, "logError", {...MESSAGES.OSF_UPLOAD_ERROR, osfStatus: result.errorCode, osfStatusText: result.errorText});
+      return;
+    }
   }
 
   await exp_doc_ref.set({ sessions: FieldValue.increment(1) }, { merge: true });

--- a/functions/src/api-data.ts
+++ b/functions/src/api-data.ts
@@ -141,6 +141,7 @@ export const apiData = onRequest({ cors: true }, async (req, res) => {
         experimentID, owner: exp_data.owner, filename, data,
         dataType: "data", osfFilesLink: exp_data.osfFilesLink,
         errorCode: 0, sessionIncremented: true,
+        failureReason: `Upload exception: ${detail}`,
       });
       await exp_doc_ref.set({ sessions: FieldValue.increment(1) }, { merge: true });
       res.status(202).json({...MESSAGES.OSF_UPLOAD_QUEUED, metadataMessage});
@@ -165,6 +166,7 @@ export const apiData = onRequest({ cors: true }, async (req, res) => {
         experimentID, owner: exp_data.owner, filename, data,
         dataType: "data", osfFilesLink: exp_data.osfFilesLink,
         errorCode: result.errorCode || 0, sessionIncremented: true,
+        failureReason: `OSF error ${result.errorCode}: ${result.errorText}`,
       });
       await exp_doc_ref.set({ sessions: FieldValue.increment(1) }, { merge: true });
       res.status(202).json({...MESSAGES.OSF_UPLOAD_QUEUED, metadataMessage});

--- a/functions/src/api-messages.ts
+++ b/functions/src/api-messages.ts
@@ -109,6 +109,10 @@ const MESSAGES = {
   METADATA_IN_OSF_AND_FIRESTORE: {
     metadataMessage : "Metadata is in OSF and in Firestore",
   },
+  OSF_UPLOAD_QUEUED: {
+    error: null,
+    message: "Data received. OSF upload will be retried automatically.",
+  },
   SUCCESS: {
     message: "Success",
   }

--- a/functions/src/api-queue-status.ts
+++ b/functions/src/api-queue-status.ts
@@ -1,0 +1,91 @@
+import { onRequest } from "firebase-functions/v2/https";
+import { db, auth, storage } from "./app.js";
+
+export const apiQueueStatus = onRequest({ cors: true }, async (req, res) => {
+  if (req.method !== "GET") {
+    res.status(405).json({ error: "Method not allowed" });
+    return;
+  }
+
+  // Verify Firebase Auth token
+  const authHeader = req.headers.authorization;
+  if (!authHeader || !authHeader.startsWith("Bearer ")) {
+    res.status(401).json({ error: "Authentication required" });
+    return;
+  }
+
+  let uid: string;
+  try {
+    const idToken = authHeader.split("Bearer ")[1];
+    const decodedToken = await auth.verifyIdToken(idToken);
+    uid = decodedToken.uid;
+  } catch {
+    res.status(401).json({ error: "Invalid authentication token" });
+    return;
+  }
+
+  const experimentID = req.query.experimentID as string;
+  if (!experimentID) {
+    res.status(400).json({ error: "experimentID query parameter is required" });
+    return;
+  }
+
+  // Verify the user owns this experiment
+  const expDoc = await db.doc(`experiments/${experimentID}`).get();
+  if (!expDoc.exists || expDoc.data()?.owner !== uid) {
+    res.status(403).json({ error: "Access denied" });
+    return;
+  }
+
+  const download = req.query.download as string | undefined;
+
+  if (download) {
+    // Return a signed download URL for a specific queue entry
+    const queueDoc = await db.doc(`uploadQueue/${download}`).get();
+    if (!queueDoc.exists || queueDoc.data()?.experimentID !== experimentID) {
+      res.status(404).json({ error: "Queue entry not found" });
+      return;
+    }
+
+    const storagePath = queueDoc.data()?.storagePath;
+    try {
+      const bucket = storage.bucket();
+      const file = bucket.file(storagePath);
+      const [url] = await file.getSignedUrl({
+        action: "read",
+        expires: Date.now() + 15 * 60 * 1000, // 15 minutes
+      });
+      res.status(200).json({ url });
+    } catch {
+      res.status(500).json({ error: "Failed to generate download URL" });
+    }
+    return;
+  }
+
+  // List queue entries for this experiment
+  const queueItems = await db
+    .collection("uploadQueue")
+    .where("experimentID", "==", experimentID)
+    .where("status", "in", ["pending", "processing", "failed"])
+    .orderBy("createdAt", "desc")
+    .get();
+
+  const entries = queueItems.docs.map((doc) => {
+    const data = doc.data();
+    return {
+      id: doc.id,
+      filename: data.filename,
+      dataType: data.dataType,
+      status: data.status,
+      errorCode: data.errorCode,
+      retryCount: data.retryCount,
+      maxRetries: data.maxRetries,
+      createdAt: data.createdAt?.toDate().toISOString(),
+      lastAttemptAt: data.lastAttemptAt?.toDate().toISOString() || null,
+      nextRetryAt: data.nextRetryAt?.toDate().toISOString() || null,
+      failureReason: data.failureReason,
+    };
+  });
+
+  res.status(200).json({ entries, count: entries.length });
+});

--- a/functions/src/api-queue-status.ts
+++ b/functions/src/api-queue-status.ts
@@ -1,4 +1,5 @@
 import { onRequest } from "firebase-functions/v2/https";
+import archiver from "archiver";
 import { db, auth, storage } from "./app.js";
 
 export const apiQueueStatus = onRequest({ cors: true }, async (req, res) => {
@@ -86,6 +87,52 @@ export const apiQueueStatus = onRequest({ cors: true }, async (req, res) => {
       }
     } catch {
       res.status(500).json({ error: "Failed to download file" });
+    }
+    return;
+  }
+
+  const downloadAll = req.query.downloadAll as string | undefined;
+
+  if (downloadAll === "true") {
+    const queueDocs = await db
+      .collection("uploadQueue")
+      .where("experimentID", "==", experimentID)
+      .where("status", "in", ["pending", "processing", "failed"])
+      .get();
+
+    if (queueDocs.empty) {
+      res.status(404).json({ error: "No queued files found" });
+      return;
+    }
+
+    try {
+      const bucket = storage.bucket();
+      const archive = archiver("zip", { zlib: { level: 5 } });
+
+      res.setHeader("Content-Type", "application/zip");
+      res.setHeader("Content-Disposition", `attachment; filename="${experimentID}-queued-files.zip"`);
+      archive.pipe(res);
+
+      for (const doc of queueDocs.docs) {
+        const data = doc.data();
+        const file = bucket.file(data.storagePath);
+        const [contents] = await file.download();
+        const raw = contents.toString("utf-8");
+
+        if (data.dataType === "base64") {
+          const split = raw.split(",");
+          const base64Data = split.length > 1 ? split[1] : raw;
+          archive.append(Buffer.from(base64Data, "base64"), { name: data.filename });
+        } else {
+          archive.append(raw, { name: data.filename });
+        }
+      }
+
+      await archive.finalize();
+    } catch {
+      if (!res.headersSent) {
+        res.status(500).json({ error: "Failed to create ZIP archive" });
+      }
     }
     return;
   }

--- a/functions/src/api-queue-status.ts
+++ b/functions/src/api-queue-status.ts
@@ -47,17 +47,45 @@ export const apiQueueStatus = onRequest({ cors: true }, async (req, res) => {
       return;
     }
 
-    const storagePath = queueDoc.data()?.storagePath;
+    const queueData = queueDoc.data()!;
+    const storagePath = queueData.storagePath;
+    const filename = queueData.filename;
+    const dataType = queueData.dataType;
+
     try {
       const bucket = storage.bucket();
       const file = bucket.file(storagePath);
-      const [url] = await file.getSignedUrl({
-        action: "read",
-        expires: Date.now() + 15 * 60 * 1000, // 15 minutes
-      });
-      res.status(200).json({ url });
+      const [contents] = await file.download();
+      const raw = contents.toString("utf-8");
+
+      if (dataType === "base64") {
+        const split = raw.split(",");
+        const base64Data = split.length > 1 ? split[1] : raw;
+        const buffer = Buffer.from(base64Data, "base64");
+
+        // Infer content type from filename extension
+        const ext = filename.split(".").pop()?.toLowerCase();
+        const mimeTypes: Record<string, string> = {
+          png: "image/png", jpg: "image/jpeg", jpeg: "image/jpeg",
+          gif: "image/gif", webp: "image/webp", wav: "audio/wav",
+          mp3: "audio/mpeg", mp4: "video/mp4", webm: "video/webm",
+          pdf: "application/pdf",
+        };
+        const contentType = mimeTypes[ext || ""] || "application/octet-stream";
+
+        res.setHeader("Content-Type", contentType);
+        res.setHeader("Content-Disposition", `attachment; filename="${filename}"`);
+        res.status(200).send(buffer);
+      } else {
+        const ext = filename.split(".").pop()?.toLowerCase();
+        const contentType = ext === "json" ? "application/json" : "text/csv";
+
+        res.setHeader("Content-Type", contentType);
+        res.setHeader("Content-Disposition", `attachment; filename="${filename}"`);
+        res.status(200).send(raw);
+      }
     } catch {
-      res.status(500).json({ error: "Failed to generate download URL" });
+      res.status(500).json({ error: "Failed to download file" });
     }
     return;
   }

--- a/functions/src/app.ts
+++ b/functions/src/app.ts
@@ -1,9 +1,11 @@
 import { initializeApp } from "firebase-admin/app";
 import { getFirestore } from "firebase-admin/firestore";
 import { getAuth } from "firebase-admin/auth";
+import { getStorage } from "firebase-admin/storage";
 
 const app = initializeApp();
 const db = getFirestore(app);
 const auth = getAuth(app);
+const storage = getStorage(app);
 
-export { db, auth };
+export { db, auth, storage };

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -7,6 +7,8 @@ import { oauth2Callback } from "./oauth2-callback.js";
 import { oauth2Regenerate } from "./oauth2-regenerate.js";
 import { checkEmailConflict } from "./check-email-conflict.js";
 import { scheduledTokenRefresh } from "./scheduled-token-refresh.js";
+import { scheduledUploadRetry } from "./scheduled-upload-retry.js";
+import { apiQueueStatus } from "./api-queue-status.js";
 import { generateOAuthState } from "./generate-oauth-state.js";
 import { saveOsfToken } from "./save-osf-token.js";
 import { getOsfToken } from "./get-osf-token.js";
@@ -24,6 +26,8 @@ export {
   oauth2Regenerate as oauth2regenerate,
   checkEmailConflict as checkemailconflict,
   scheduledTokenRefresh as scheduledtokenrefresh,
+  scheduledUploadRetry as scheduleduploadretry,
+  apiQueueStatus as apiqueuestatus,
   generateOAuthState as generateoauthstate,
   saveOsfToken as saveosftoken,
   getOsfToken as getosftoken,

--- a/functions/src/interfaces.ts
+++ b/functions/src/interfaces.ts
@@ -72,6 +72,27 @@ export interface ExperimentData {
     success: boolean;
     errorCode: number | null;
     errorText: string | null;
+    retryAfter?: number | null;
+  }
+
+  export interface QueuedUpload {
+    experimentID: string;
+    owner: string;
+    filename: string;
+    storagePath: string;
+    dataType: "data" | "base64";
+    osfFilesLink: string;
+    status: "pending" | "processing" | "completed" | "failed";
+    errorCode: number;
+    retryCount: number;
+    maxRetries: number;
+    createdAt: FirebaseFirestore.Timestamp;
+    lastAttemptAt: FirebaseFirestore.Timestamp | null;
+    nextRetryAt: FirebaseFirestore.Timestamp;
+    completedAt: FirebaseFirestore.Timestamp | null;
+    failureReason: string | null;
+    deduplicationKey: string;
+    sessionIncremented: boolean;
   }
 
   export interface OSFFile{

--- a/functions/src/put-file-osf.ts
+++ b/functions/src/put-file-osf.ts
@@ -46,7 +46,9 @@ export default async function putFileOSF(
   });
 
   if (osfResult.status !== 201) {
-    return { success: false, errorCode: osfResult.status, errorText: osfResult.statusText };
+    const retryAfterHeader = osfResult.headers.get('Retry-After');
+    const retryAfter = retryAfterHeader ? parseInt(retryAfterHeader, 10) : null;
+    return { success: false, errorCode: osfResult.status, errorText: osfResult.statusText, retryAfter };
   }
 
   return { success: true, errorCode: null, errorText: null };

--- a/functions/src/queue-upload.ts
+++ b/functions/src/queue-upload.ts
@@ -10,32 +10,33 @@ interface QueueUploadParams {
   osfFilesLink: string;
   errorCode: number;
   sessionIncremented: boolean;
+  failureReason?: string;
 }
 
 const MAX_RETRIES = 5;
 
 export default async function queueUpload(params: QueueUploadParams): Promise<string> {
   const deduplicationKey = `${params.experimentID}:${params.filename}`;
+  const docId = deduplicationKey.replace(/[/\\]/g, "_");
 
-  // Check for existing pending/processing entry with same key
-  const existing = await db
-    .collection("uploadQueue")
-    .where("deduplicationKey", "==", deduplicationKey)
-    .where("status", "in", ["pending", "processing"])
-    .limit(1)
-    .get();
-
-  if (!existing.empty) {
-    return existing.docs[0].id;
-  }
+  const docRef = db.collection("uploadQueue").doc(docId);
 
   const now = Timestamp.now();
   const nextRetryAt = Timestamp.fromMillis(now.toMillis() + 60 * 60 * 1000); // 1 hour
 
-  const docRef = db.collection("uploadQueue").doc();
+  // Use set with merge:false — if the doc already exists (pending/processing),
+  // the storage write is idempotent and the Firestore write overwrites with fresh data.
+  // If it was completed/failed, we re-queue it.
+  const existingDoc = await docRef.get();
+  if (existingDoc.exists) {
+    const status = existingDoc.data()?.status;
+    if (status === "pending" || status === "processing") {
+      return docId;
+    }
+  }
 
   // Write data to Cloud Storage
-  const storagePath = `upload-queue/${docRef.id}`;
+  const storagePath = `upload-queue/${docId}`;
   const bucket = storage.bucket();
   const file = bucket.file(storagePath);
   await file.save(params.data, { contentType: "text/plain" });
@@ -56,10 +57,10 @@ export default async function queueUpload(params: QueueUploadParams): Promise<st
     lastAttemptAt: null,
     nextRetryAt,
     completedAt: null,
-    failureReason: null,
+    failureReason: params.failureReason || null,
     deduplicationKey,
     sessionIncremented: params.sessionIncremented,
   });
 
-  return docRef.id;
+  return docId;
 }

--- a/functions/src/queue-upload.ts
+++ b/functions/src/queue-upload.ts
@@ -1,0 +1,65 @@
+import { Timestamp } from "firebase-admin/firestore";
+import { db, storage } from "./app.js";
+
+interface QueueUploadParams {
+  experimentID: string;
+  owner: string;
+  filename: string;
+  data: string;
+  dataType: "data" | "base64";
+  osfFilesLink: string;
+  errorCode: number;
+  sessionIncremented: boolean;
+}
+
+const MAX_RETRIES = 5;
+
+export default async function queueUpload(params: QueueUploadParams): Promise<string> {
+  const deduplicationKey = `${params.experimentID}:${params.filename}`;
+
+  // Check for existing pending/processing entry with same key
+  const existing = await db
+    .collection("uploadQueue")
+    .where("deduplicationKey", "==", deduplicationKey)
+    .where("status", "in", ["pending", "processing"])
+    .limit(1)
+    .get();
+
+  if (!existing.empty) {
+    return existing.docs[0].id;
+  }
+
+  const now = Timestamp.now();
+  const nextRetryAt = Timestamp.fromMillis(now.toMillis() + 60 * 60 * 1000); // 1 hour
+
+  const docRef = db.collection("uploadQueue").doc();
+
+  // Write data to Cloud Storage
+  const storagePath = `upload-queue/${docRef.id}`;
+  const bucket = storage.bucket();
+  const file = bucket.file(storagePath);
+  await file.save(params.data, { contentType: "text/plain" });
+
+  // Write metadata to Firestore
+  await docRef.set({
+    experimentID: params.experimentID,
+    owner: params.owner,
+    filename: params.filename,
+    storagePath,
+    dataType: params.dataType,
+    osfFilesLink: params.osfFilesLink,
+    status: "pending",
+    errorCode: params.errorCode,
+    retryCount: 0,
+    maxRetries: MAX_RETRIES,
+    createdAt: now,
+    lastAttemptAt: null,
+    nextRetryAt,
+    completedAt: null,
+    failureReason: null,
+    deduplicationKey,
+    sessionIncremented: params.sessionIncremented,
+  });
+
+  return docRef.id;
+}

--- a/functions/src/scheduled-upload-retry.ts
+++ b/functions/src/scheduled-upload-retry.ts
@@ -150,7 +150,7 @@ async function processQueueItem(queueDoc: FirebaseFirestore.QueryDocumentSnapsho
       return;
     }
 
-    await handleRetryFailure(docRef, data, `OSF error ${result.errorCode}: ${result.errorText}`);
+    await handleRetryFailure(docRef, data, `OSF error ${result.errorCode}: ${result.errorText}`, result.retryAfter);
   } catch (e) {
     const detail = e instanceof Error ? e.message : "Unknown error";
     await handleRetryFailure(docRef, data, `Upload exception: ${detail}`);
@@ -175,7 +175,8 @@ async function markCompleted(
 async function handleRetryFailure(
   docRef: FirebaseFirestore.DocumentReference,
   data: FirebaseFirestore.DocumentData,
-  reason: string
+  reason: string,
+  retryAfterSeconds?: number | null
 ) {
   const newRetryCount = (data.retryCount || 0) + 1;
 
@@ -189,8 +190,10 @@ async function handleRetryFailure(
     return;
   }
 
-  // Exponential backoff: 2^retryCount hours, capped at 24 hours
-  const backoffMs = Math.min(Math.pow(2, newRetryCount) * 60 * 60 * 1000, MAX_BACKOFF_MS);
+  // Honor Retry-After header if provided, otherwise use exponential backoff
+  const backoffMs = retryAfterSeconds
+    ? Math.min(retryAfterSeconds * 1000, MAX_BACKOFF_MS)
+    : Math.min(Math.pow(2, newRetryCount) * 60 * 60 * 1000, MAX_BACKOFF_MS);
   const nextRetryAt = Timestamp.fromMillis(Date.now() + backoffMs);
 
   console.log(`Upload ${docRef.id} retry ${newRetryCount} failed: ${reason}. Next retry at ${nextRetryAt.toDate().toISOString()}`);

--- a/functions/src/scheduled-upload-retry.ts
+++ b/functions/src/scheduled-upload-retry.ts
@@ -1,0 +1,231 @@
+import { onSchedule } from "firebase-functions/v2/scheduler";
+import { Timestamp } from "firebase-admin/firestore";
+import { db, storage } from "./app.js";
+import putFileOSF from "./put-file-osf.js";
+import resolveToken from "./resolve-token.js";
+import { ExperimentData, UserData } from "./interfaces.js";
+
+const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
+const MAX_BACKOFF_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+/**
+ * Scheduled function that runs every hour to retry failed OSF uploads.
+ * Processes up to 10 pending items per run, applies exponential backoff,
+ * and cleans up entries older than 7 days.
+ */
+export const scheduledUploadRetry = onSchedule("0 * * * *", async () => {
+  await retryPendingUploads();
+  await cleanupOldEntries();
+});
+
+async function retryPendingUploads() {
+  const now = Timestamp.now();
+
+  const pendingItems = await db
+    .collection("uploadQueue")
+    .where("status", "==", "pending")
+    .where("nextRetryAt", "<=", now)
+    .orderBy("nextRetryAt", "asc")
+    .limit(10)
+    .get();
+
+  if (pendingItems.empty) {
+    console.log("No pending uploads to retry.");
+    return;
+  }
+
+  console.log(`Found ${pendingItems.size} pending upload(s) to retry.`);
+
+  // Group by owner to avoid hammering same user's rate limit
+  const byOwner = new Map<string, FirebaseFirestore.QueryDocumentSnapshot[]>();
+  for (const doc of pendingItems.docs) {
+    const owner = doc.data().owner;
+    if (!byOwner.has(owner)) {
+      byOwner.set(owner, []);
+    }
+    byOwner.get(owner)!.push(doc);
+  }
+
+  // Interleave: take one from each owner at a time
+  const ordered: FirebaseFirestore.QueryDocumentSnapshot[] = [];
+  let hasMore = true;
+  let index = 0;
+  while (hasMore) {
+    hasMore = false;
+    for (const docs of byOwner.values()) {
+      if (index < docs.length) {
+        ordered.push(docs[index]);
+        hasMore = true;
+      }
+    }
+    index++;
+  }
+
+  for (const queueDoc of ordered) {
+    await processQueueItem(queueDoc);
+  }
+}
+
+async function processQueueItem(queueDoc: FirebaseFirestore.QueryDocumentSnapshot) {
+  const docRef = queueDoc.ref;
+  const data = queueDoc.data();
+
+  // Atomically claim the item
+  try {
+    await db.runTransaction(async (transaction) => {
+      const freshDoc = await transaction.get(docRef);
+      if (freshDoc.data()?.status !== "pending") {
+        throw new Error("Already claimed");
+      }
+      transaction.update(docRef, { status: "processing", lastAttemptAt: Timestamp.now() });
+    });
+  } catch {
+    console.log(`Skipping ${queueDoc.id} — already claimed by another instance.`);
+    return;
+  }
+
+  // Re-resolve the OSF token
+  const userDoc = await db.doc(`users/${data.owner}`).get();
+  if (!userDoc.exists) {
+    await docRef.update({ status: "failed", failureReason: "Owner user not found" });
+    return;
+  }
+
+  const expDoc = await db.doc(`experiments/${data.experimentID}`).get();
+  if (!expDoc.exists) {
+    await docRef.update({ status: "failed", failureReason: "Experiment not found" });
+    return;
+  }
+
+  const userData = userDoc.data() as UserData;
+  const expData = expDoc.data() as ExperimentData;
+
+  let token: string;
+  try {
+    const tokenResult = await resolveToken(userData, expData);
+    if (!tokenResult.success) {
+      await handleRetryFailure(docRef, data, `Token resolution failed: ${tokenResult.error}`);
+      return;
+    }
+    token = tokenResult.token;
+  } catch (e) {
+    const detail = e instanceof Error ? e.message : "Unknown error";
+    await handleRetryFailure(docRef, data, `Token resolution exception: ${detail}`);
+    return;
+  }
+
+  // Read cached data from Cloud Storage
+  let fileData: string | Buffer;
+  try {
+    const bucket = storage.bucket();
+    const file = bucket.file(data.storagePath);
+    const [contents] = await file.download();
+    if (data.dataType === "base64") {
+      const raw = contents.toString("utf-8");
+      const split = raw.split(",");
+      fileData = split.length > 1 ? Buffer.from(split[1], "base64") : Buffer.from(raw, "base64");
+    } else {
+      fileData = contents.toString("utf-8");
+    }
+  } catch (e) {
+    const detail = e instanceof Error ? e.message : "Unknown error";
+    await docRef.update({ status: "failed", failureReason: `Failed to read cached data: ${detail}` });
+    return;
+  }
+
+  // Attempt the upload
+  try {
+    const result = await putFileOSF(data.osfFilesLink, token, fileData, data.filename);
+
+    if (result.success) {
+      await markCompleted(docRef, data);
+      console.log(`Successfully retried upload ${queueDoc.id} (${data.filename})`);
+      return;
+    }
+
+    if (result.errorCode === 409) {
+      // File already exists — treat as success (original upload may have worked)
+      await markCompleted(docRef, data);
+      console.log(`Upload ${queueDoc.id} marked complete — file already exists in OSF.`);
+      return;
+    }
+
+    await handleRetryFailure(docRef, data, `OSF error ${result.errorCode}: ${result.errorText}`);
+  } catch (e) {
+    const detail = e instanceof Error ? e.message : "Unknown error";
+    await handleRetryFailure(docRef, data, `Upload exception: ${detail}`);
+  }
+}
+
+async function markCompleted(
+  docRef: FirebaseFirestore.DocumentReference,
+  data: FirebaseFirestore.DocumentData
+) {
+  await docRef.update({ status: "completed", completedAt: Timestamp.now() });
+
+  // Clean up Cloud Storage
+  try {
+    const bucket = storage.bucket();
+    await bucket.file(data.storagePath).delete();
+  } catch {
+    // Ignore — cleanup sweep will catch it
+  }
+}
+
+async function handleRetryFailure(
+  docRef: FirebaseFirestore.DocumentReference,
+  data: FirebaseFirestore.DocumentData,
+  reason: string
+) {
+  const newRetryCount = (data.retryCount || 0) + 1;
+
+  if (newRetryCount >= data.maxRetries) {
+    console.error(`Upload ${docRef.id} permanently failed after ${newRetryCount} retries: ${reason}`);
+    await docRef.update({
+      status: "failed",
+      retryCount: newRetryCount,
+      failureReason: reason,
+    });
+    return;
+  }
+
+  // Exponential backoff: 2^retryCount hours, capped at 24 hours
+  const backoffMs = Math.min(Math.pow(2, newRetryCount) * 60 * 60 * 1000, MAX_BACKOFF_MS);
+  const nextRetryAt = Timestamp.fromMillis(Date.now() + backoffMs);
+
+  console.log(`Upload ${docRef.id} retry ${newRetryCount} failed: ${reason}. Next retry at ${nextRetryAt.toDate().toISOString()}`);
+
+  await docRef.update({
+    status: "pending",
+    retryCount: newRetryCount,
+    nextRetryAt,
+  });
+}
+
+async function cleanupOldEntries() {
+  const cutoff = Timestamp.fromMillis(Date.now() - SEVEN_DAYS_MS);
+
+  const oldEntries = await db
+    .collection("uploadQueue")
+    .where("createdAt", "<=", cutoff)
+    .limit(50)
+    .get();
+
+  if (oldEntries.empty) {
+    return;
+  }
+
+  console.log(`Cleaning up ${oldEntries.size} old queue entries.`);
+
+  const bucket = storage.bucket();
+
+  for (const doc of oldEntries.docs) {
+    const data = doc.data();
+    try {
+      await bucket.file(data.storagePath).delete();
+    } catch {
+      // File may already be deleted
+    }
+    await doc.ref.delete();
+  }
+}

--- a/pages/admin/[experiment_id].js
+++ b/pages/admin/[experiment_id].js
@@ -73,7 +73,7 @@ function ExperimentPageDashboard({ experiment_id }) {
             )}
             {pendingUploads > 0 && (
               <Badge colorPalette="orange" variant="solid" px={2} py={1}>
-                {pendingUploads} pending upload{pendingUploads !== 1 ? "s" : ""}
+                {pendingUploads} upload{pendingUploads !== 1 ? "s" : ""} waiting
               </Badge>
             )}
             {pendingUploads === 0 && queueEntries.length > 0 && (

--- a/pages/admin/[experiment_id].js
+++ b/pages/admin/[experiment_id].js
@@ -66,7 +66,7 @@ function ExperimentPageDashboard({ experiment_id }) {
             <Text fontSize="sm" color="gray.400">
               {data.sessions || 0} session{data.sessions !== 1 ? "s" : ""}
             </Text>
-            {uploadError && (
+            {uploadError && queueEntries.length === 0 && (
               <Badge colorPalette="red" variant="solid" px={2} py={1}>
                 Data upload errors
               </Badge>
@@ -82,8 +82,8 @@ function ExperimentPageDashboard({ experiment_id }) {
               </Badge>
             )}
           </HStack>
-          {uploadError && <ErrorPanel errors={errorLog} />}
-          {queueEntries.length > 0 && <QueuePanel entries={queueEntries} experimentId={experiment_id} />}
+          {uploadError && queueEntries.length === 0 && <ErrorPanel errors={errorLog} />}
+          {queueEntries.length > 0 && <QueuePanel entries={queueEntries} experimentId={experiment_id} errorLog={uploadError ? errorLog : null} />}
           <Flex w="100%" gap={8} wrap="wrap" alignItems="flex-start">
             <VStack flex="1" minW="300px" gap={0} align="stretch">
               <ExperimentInfo data={data} />

--- a/pages/admin/[experiment_id].js
+++ b/pages/admin/[experiment_id].js
@@ -1,8 +1,8 @@
 import AuthCheck from "../../components/AuthCheck";
 import { useRouter } from "next/router";
-import { useDocumentData } from "react-firebase-hooks/firestore";
+import { useDocumentData, useCollectionData } from "react-firebase-hooks/firestore";
 import { db } from "../../lib/firebase";
-import { doc } from "firebase/firestore";
+import { doc, collection, query, where, orderBy } from "firebase/firestore";
 
 import { Spinner, Flex, VStack, HStack, Text, Badge, Separator } from "@chakra-ui/react";
 
@@ -13,6 +13,7 @@ import ExperimentValidation from "../../components/dashboard/ExperimentValidatio
 import MetadataControl from "../../components/dashboard/MetadataControl";
 import CodeHints from "../../components/dashboard/CodeHints";
 import ErrorPanel from "../../components/dashboard/ErrorPanel";
+import QueuePanel from "../../components/dashboard/QueuePanel";
 
 export async function getServerSideProps() {
   return { props: {} };
@@ -32,8 +33,18 @@ export default function ExperimentPage() {
 function ExperimentPageDashboard({ experiment_id }) {
   const experimentRef = experiment_id ? doc(db, `experiments/${experiment_id}`) : null;
   const logsRef = experiment_id ? doc(db, `logs/${experiment_id}`) : null;
+  const queueRef = experiment_id
+    ? query(
+        collection(db, "uploadQueue"),
+        where("experimentID", "==", experiment_id),
+        where("status", "in", ["pending", "processing", "failed"]),
+        orderBy("createdAt", "desc")
+      )
+    : null;
   const [data, loading, error, snapshot, reload] = useDocumentData(experimentRef);
   const logs = useDocumentData(logsRef)?.[0] || null;
+  const [queueData] = useCollectionData(queueRef, { idField: "id" });
+  const queueEntries = queueData || [];
 
   const uploadError = logs?.logError;
   const errorLog = logs?.errors;
@@ -57,8 +68,14 @@ function ExperimentPageDashboard({ experiment_id }) {
                 Data upload errors
               </Badge>
             )}
+            {queueEntries.length > 0 && (
+              <Badge colorPalette="orange" variant="solid" px={2} py={1}>
+                {queueEntries.filter(e => e.status === "pending" || e.status === "processing").length} pending upload{queueEntries.filter(e => e.status === "pending" || e.status === "processing").length !== 1 ? "s" : ""}
+              </Badge>
+            )}
           </HStack>
           {uploadError && <ErrorPanel errors={errorLog} />}
+          {queueEntries.length > 0 && <QueuePanel entries={queueEntries} experimentId={experiment_id} />}
           <Flex w="100%" gap={8} wrap="wrap" alignItems="flex-start">
             <VStack flex="1" minW="300px" gap={0} align="stretch">
               <ExperimentInfo data={data} />

--- a/pages/admin/[experiment_id].js
+++ b/pages/admin/[experiment_id].js
@@ -45,8 +45,8 @@ function ExperimentPageDashboard({ experiment_id }) {
     : null;
   const [data, loading, error, snapshot, reload] = useDocumentData(experimentRef);
   const logs = useDocumentData(logsRef)?.[0] || null;
-  const [queueData] = useCollectionData(queueRef, { idField: "id" });
-  const queueEntries = queueData || [];
+  const [, , , queueSnapshot] = useCollectionData(queueRef);
+  const queueEntries = queueSnapshot?.docs.map(d => ({ id: d.id, ...d.data() })) || [];
 
   const pendingUploads = queueEntries.filter(e => e.status === "pending" || e.status === "processing").length;
   const uploadError = logs?.logError;

--- a/pages/admin/[experiment_id].js
+++ b/pages/admin/[experiment_id].js
@@ -46,6 +46,7 @@ function ExperimentPageDashboard({ experiment_id }) {
   const [queueData] = useCollectionData(queueRef, { idField: "id" });
   const queueEntries = queueData || [];
 
+  const pendingUploads = queueEntries.filter(e => e.status === "pending" || e.status === "processing").length;
   const uploadError = logs?.logError;
   const errorLog = logs?.errors;
 
@@ -68,9 +69,14 @@ function ExperimentPageDashboard({ experiment_id }) {
                 Data upload errors
               </Badge>
             )}
-            {queueEntries.length > 0 && (
+            {pendingUploads > 0 && (
               <Badge colorPalette="orange" variant="solid" px={2} py={1}>
-                {queueEntries.filter(e => e.status === "pending" || e.status === "processing").length} pending upload{queueEntries.filter(e => e.status === "pending" || e.status === "processing").length !== 1 ? "s" : ""}
+                {pendingUploads} pending upload{pendingUploads !== 1 ? "s" : ""}
+              </Badge>
+            )}
+            {pendingUploads === 0 && queueEntries.length > 0 && (
+              <Badge colorPalette="red" variant="solid" px={2} py={1}>
+                {queueEntries.length} failed upload{queueEntries.length !== 1 ? "s" : ""}
               </Badge>
             )}
           </HStack>

--- a/pages/admin/[experiment_id].js
+++ b/pages/admin/[experiment_id].js
@@ -1,7 +1,7 @@
 import AuthCheck from "../../components/AuthCheck";
 import { useRouter } from "next/router";
 import { useDocumentData, useCollectionData } from "react-firebase-hooks/firestore";
-import { db } from "../../lib/firebase";
+import { db, auth } from "../../lib/firebase";
 import { doc, collection, query, where, orderBy } from "firebase/firestore";
 
 import { Spinner, Flex, VStack, HStack, Text, Badge, Separator } from "@chakra-ui/react";
@@ -33,10 +33,12 @@ export default function ExperimentPage() {
 function ExperimentPageDashboard({ experiment_id }) {
   const experimentRef = experiment_id ? doc(db, `experiments/${experiment_id}`) : null;
   const logsRef = experiment_id ? doc(db, `logs/${experiment_id}`) : null;
-  const queueRef = experiment_id
+  const uid = auth.currentUser?.uid;
+  const queueRef = experiment_id && uid
     ? query(
         collection(db, "uploadQueue"),
         where("experimentID", "==", experiment_id),
+        where("owner", "==", uid),
         where("status", "in", ["pending", "processing", "failed"]),
         orderBy("createdAt", "desc")
       )

--- a/pages/faq.js
+++ b/pages/faq.js
@@ -45,10 +45,38 @@ export default function FAQ() {
           </Text>
         </FAQItem>
         <FAQItem value="item-2" question="Will DataPipe store my data?">
+          <Text mb={2}>
+            Under normal operation, no. DataPipe routes your data to the Open
+            Science Framework but does not keep a copy. Data passes through
+            DataPipe for optional validation and is then sent directly to your
+            OSF project.
+          </Text>
           <Text>
-            No. DataPipe routes your data to the Open Science Framework but
-            does not keep a copy. Data passes through DataPipe for optional
-            validation and is then sent directly to your OSF project.
+            The one exception is when an upload to the OSF fails (for example,
+            due to a temporary OSF outage or rate limit). In that case,
+            DataPipe temporarily caches the data so it can retry the upload
+            automatically. Cached data is encrypted at rest, stored for up to
+            one week, and deleted as soon as the upload succeeds. See the
+            question below for details.
+          </Text>
+        </FAQItem>
+        <FAQItem value="item-2b" question="What happens if an upload to the OSF fails?">
+          <Text mb={2}>
+            If the OSF is temporarily unavailable or returns an error, DataPipe
+            will not lose your data. Failed uploads are automatically cached
+            and retried with increasing intervals (starting at one hour, up to
+            24 hours) for up to five attempts over approximately one week.
+          </Text>
+          <Text mb={2}>
+            Your experiment dashboard will show an orange badge for pending
+            retries or a red badge if all retries have been exhausted. You can
+            expand the queued files panel to see the status of each file,
+            including the reason for failure and the number of retry attempts.
+          </Text>
+          <Text>
+            You can also download any cached file directly from the dashboard
+            at any time, so you always have a way to recover your data even if
+            the automatic retries do not succeed.
           </Text>
         </FAQItem>
         <FAQItem value="item-3" question="How much does it cost?">

--- a/storage.rules
+++ b/storage.rules
@@ -1,0 +1,8 @@
+rules_version = '2';
+service firebase.storage {
+  match /b/{bucket}/o {
+    match /{allPaths=**} {
+      allow read, write: if false;
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- When OSF uploads fail (rate limits, server errors, network issues), data is cached in Cloud Storage and retried automatically with exponential backoff — up to 5 attempts over ~1 week
- Experiment dashboard shows queue status with pending/failed badges, file details table, expiration countdowns, and per-file or bulk ZIP download
- QueuePanel consolidates upload errors into a single panel, replacing the separate ErrorPanel when queue entries exist
- New `/api/queuestatus` endpoint for listing queue entries and downloading files (single or ZIP)
- Firestore security rules, composite indexes, and Cloud Storage rules for the new `uploadQueue` collection
- FAQ updated to explain temporary caching and data loss protections
- Shared `resolveToken` helper extracted for token resolution across API endpoints and retry function

## What's included

- **Backend**: `queue-upload.ts`, `scheduled-upload-retry.ts`, `api-queue-status.ts` (with ZIP support via archiver), updated `api-data.ts` and `api-base64.ts` to queue on failure
- **Frontend**: `QueuePanel.js` with status badges, expiration countdown, download buttons, "Download all as ZIP", "Why am I seeing this?" explainer
- **Security**: `storage.rules` (deny all client access), Firestore read rule for `uploadQueue` scoped to owner, deterministic doc IDs for dedup
- **Infra**: Firestore composite indexes, `firebase.json` updates for storage rules and new API route
- **Tests**: `upload-queue.test.js` covering dedup, backoff math, Retry-After, and Firestore transaction claiming

## Test plan

- [x] Verify TypeScript compiles cleanly
- [x] Test failed uploads appear in Firestore `uploadQueue` and Cloud Storage
- [x] Verify client receives 202 with `OSF_UPLOAD_QUEUED` message
- [x] Verify dashboard shows queue panel with correct badge states
- [x] Test single file download (CSV, JSON, base64 binary)
- [x] Test "Download all as ZIP"
- [x] Verify Firestore security rules enforce owner-only reads
- [x] Verify scheduled retry processes pending items
- [ ] Test on production after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)