### PR TITLE
fix: increase memory limit for data upload functions

### DIFF
--- a/functions/src/api-base64.ts
+++ b/functions/src/api-base64.ts
@@ -9,7 +9,7 @@ import resolveToken from "./resolve-token.js";
 import queueUpload from "./queue-upload.js";
 import { ExperimentData, UserData, OSFResult } from './interfaces';
 
-export const apiBase64 = onRequest({ cors: true }, async (req, res) => {
+export const apiBase64 = onRequest({ cors: true, memory: "512MiB" }, async (req, res) => {
   const { experimentID, data, filename } = req.body;
 
   if (!experimentID || !data || !filename) {

--- a/functions/src/api-data.ts
+++ b/functions/src/api-data.ts
@@ -11,7 +11,7 @@ import resolveToken from "./resolve-token.js";
 import queueUpload from "./queue-upload.js";
 import { ExperimentData, UserData, MetadataResponse, OSFResult, RequestBody } from './interfaces';
 
-export const apiData = onRequest({ cors: true }, async (req, res) => {
+export const apiData = onRequest({ cors: true, memory: "512MiB" }, async (req, res) => {
   const { experimentID, data, filename, metadataOptions }: RequestBody = req.body;
 
   if (!experimentID || !data || !filename) {


### PR DESCRIPTION
## Summary
- Increases memory limit from 256MiB to 512MiB for `apiData` and `apiBase64` Cloud Functions
- Resolves OOM crashes that were returning 503 responses without CORS headers, causing users to report CORS policy errors (#102)

## Root cause
Firebase Functions logs show repeated `Memory limit of 256 MiB exceeded` errors. The Node.js runtime + Firebase SDK baseline uses ~150MiB, and the data payload is held in 2-3 copies during processing (validation, metadata, upload), leaving insufficient headroom at 256MiB for larger submissions.

When the function is OOM-killed, Firebase infrastructure returns a 503 with no CORS headers (since the `{ cors: true }` handler never completes), which browsers report as a CORS error.

## Test plan
- [ ] Deploy to test environment and verify functions start successfully
- [ ] Submit a data file through the API and confirm 201 response
- [ ] Monitor Cloud Functions logs for OOM errors after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)