### PR TITLE
perf: skip metadata block when inactive

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -5,7 +5,7 @@ name: Test
 
 on:
   pull_request:
-    branches: ["main"]
+    branches: ["main", "test"]
   push:
     branches: ["test"]
 

--- a/functions/src/__tests__/skip-metadata-emulator.test.js
+++ b/functions/src/__tests__/skip-metadata-emulator.test.js
@@ -1,0 +1,112 @@
+/**
+ * @jest-environment node
+ */
+
+import { initializeApp } from "firebase-admin/app";
+import { getFirestore } from "firebase-admin/firestore";
+import MESSAGES from "../api-messages";
+
+process.env.FIRESTORE_EMULATOR_HOST = "localhost:8080";
+
+jest.setTimeout(30000);
+
+const config = {
+  projectId: "datapipe-test",
+};
+
+async function saveData(body) {
+  const response = await fetch(
+    "http://localhost:5001/datapipe-test/us-central1/apidata",
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "*/*",
+      },
+      body: JSON.stringify(body),
+    }
+  );
+  const message = await response.json();
+  return message;
+}
+
+const sampleData = `[{
+  "trial_type": "html-keyboard-response",
+  "trial_index": 1,
+  "time_elapsed": 776
+}]`;
+
+beforeAll(async () => {
+  initializeApp(config);
+  const db = getFirestore();
+
+  await db.collection("users").doc("skip-metadata-user").set({
+    osfTokenValid: true,
+    osfToken: "valid",
+    usingPersonalToken: true,
+  });
+
+  // Experiment with metadata disabled
+  await db.collection("experiments").doc("skip-metadata-exp").set({
+    active: true,
+    metadataActive: false,
+    owner: "skip-metadata-user",
+    osfFilesLink: "http://localhost:3000/endpoint",
+  });
+
+  // Experiment with metadata enabled (for comparison)
+  await db.collection("experiments").doc("skip-metadata-exp-active").set({
+    active: true,
+    metadataActive: true,
+    owner: "skip-metadata-user",
+    osfFilesLink: "http://localhost:3000/endpoint",
+  });
+});
+
+describe("skip metadata when inactive", () => {
+  it("should not produce metadata when metadataActive is false", async () => {
+    const response = await saveData({
+      experimentID: "skip-metadata-exp",
+      data: sampleData,
+      filename: "test-skip-metadata.json",
+    });
+
+    // When metadata is skipped, metadataMessage should be empty
+    // and the response should not contain metadata error info
+    expect(response.metadataMessage).toBeFalsy();
+  });
+
+  it("should not create a metadata document in Firestore when metadataActive is false", async () => {
+    const db = getFirestore();
+
+    // Clear any existing metadata doc
+    await db.collection("metadata").doc("skip-metadata-exp").delete();
+
+    await saveData({
+      experimentID: "skip-metadata-exp",
+      data: sampleData,
+      filename: "test-skip-metadata-2.json",
+    });
+
+    const metadataDoc = await db
+      .collection("metadata")
+      .doc("skip-metadata-exp")
+      .get();
+
+    // No metadata document should have been created
+    expect(metadataDoc.exists).toBe(false);
+  });
+
+  it("should still attempt metadata processing when metadataActive is true", async () => {
+    const response = await saveData({
+      experimentID: "skip-metadata-exp-active",
+      data: sampleData,
+      filename: "test-with-metadata.json",
+    });
+
+    // When metadata is active, the function will attempt to process metadata.
+    // Without a valid mock OSF server, it may fail, but the metadataMessage
+    // should not be empty — it should reflect an attempt was made.
+    expect(response.metadataMessage).not.toEqual("");
+  });
+});

--- a/functions/src/api-data.ts
+++ b/functions/src/api-data.ts
@@ -111,18 +111,23 @@ export const apiData = onRequest({ cors: true, memory: "512MiB" }, async (req, r
 
   //METADATA BLOCK START
 
-  //Creates or references a document containing the metadata for the experiment in the metdata collection on Firestore.
-  const metadata_doc_ref: DocumentReference<DocumentData> = db.collection("metadata").doc(experimentID);
+  let metadataMessage: string = '';
 
-  const metadataResponse: MetadataResponse = await blockMetadata(exp_data, user_data, metadata_doc_ref, data, metadataOptions);
+  if (exp_data.metadataActive) {
+    //Creates or references a document containing the metadata for the experiment in the metdata collection on Firestore.
+    const metadata_doc_ref: DocumentReference<DocumentData> = db.collection("metadata").doc(experimentID);
 
-  if (metadataResponse.success === false) {
-    res.status(400).json(metadataResponse);
-    await writeLog(experimentID, "logError", {...MESSAGES.METADATA_ERROR, detail: metadataResponse.message});
-    return;
+    const metadataResponse: MetadataResponse = await blockMetadata(exp_data, user_data, metadata_doc_ref, data, metadataOptions);
+
+    if (metadataResponse.success === false) {
+      res.status(400).json(metadataResponse);
+      await writeLog(experimentID, "logError", {...MESSAGES.METADATA_ERROR, detail: metadataResponse.message});
+      return;
+    }
+
+    metadataMessage = metadataResponse.metadataMessage;
   }
 
-  const metadataMessage: string = metadataResponse.metadataMessage;
   //METADATA BLOCK END
 
   let result: OSFResult;


### PR DESCRIPTION
## Summary
- Skips calling `blockMetadata()` entirely when `exp_data.metadataActive` is false
- Previously, even with metadata disabled, the function still performed token decryption, potential OAuth token refresh, and Firestore document reference creation before hitting the `metadataActive` check inside `blockMetadata`
- For experiments without metadata enabled, this eliminates unnecessary work on every data submission

## Test plan
- [ ] Submit data to an experiment with `metadataActive: false` — should succeed with no metadata processing
- [ ] Submit data to an experiment with `metadataActive: true` — metadata should still be generated and uploaded as before
- [ ] Verify `metadataMessage` is empty string (not undefined) in the response when metadata is inactive

🤖 Generated with [Claude Code](https://claude.com/claude-code)