### PR TITLE
fix: deployed gdrive OAuth uses real Google creds, not emulator mocks

### DIFF
--- a/.github/workflows/firebase-deploy-test.yml
+++ b/.github/workflows/firebase-deploy-test.yml
@@ -56,6 +56,9 @@ jobs:
           echo "REDIRECT_URI=https://datapipe-test.web.app/oauth2/callback" >> .env
           echo "TOKEN_ENCRYPTION_KEY=${{ secrets.FIRESTORE_KEY_TEST }}" >> .env
           echo "NEXT_PUBLIC_OSF_ENV=" >> .env
+          # Google Drive client secret for the deployed test site. Client id and
+          # redirect uri are non-secret and live in functions/.env.datapipe-test.
+          echo "GDRIVE_CLIENT_SECRET=${{ secrets.TEST_GDRIVE_CLIENT_SECRET }}" >> .env
       - name: Install dependencies and build functions
         working-directory: functions
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -135,6 +135,8 @@ yarn-error.log*
 
 # local env files
 .env*.local
+# ...except the committed emulator/CI overrides (never deployed by Firebase)
+!functions/.env.local
 
 # vercel
 .vercel

--- a/functions/.env.datapipe-test
+++ b/functions/.env.datapipe-test
@@ -1,7 +1,22 @@
-GDRIVE_API_BASE=http://127.0.0.1:3579
-GDRIVE_TOKEN_URL=http://127.0.0.1:3580/token
-GDRIVE_AUTHORIZE_URL=http://127.0.0.1:3580/authorize
-GDRIVE_CLIENT_ID=test-client-id
-GDRIVE_CLIENT_SECRET=test-client-secret
-GDRIVE_REDIRECT_URI=http://localhost:3000/oauth2/connect
+# Real config for the DEPLOYED datapipe-test site.
+#
+# Firebase loads this file both on `firebase deploy` and in the emulator.
+# Emulator runs additionally load .env.local, which overrides everything here
+# with local mock values -- so the mock Drive/token servers and test dummies
+# live in .env.local, NOT here. Anything in this file reaches the live site.
+#
+# The Google client secret is NOT here (this file is committed). It is
+# injected at deploy time from the TEST_GDRIVE_CLIENT_SECRET GitHub secret
+# (see .github/workflows/firebase-deploy-test.yml), and for a local
+# `firebase deploy` it comes from the git-ignored functions/.env.
+#
+# GDRIVE_AUTHORIZE_URL / GDRIVE_TOKEN_URL / GDRIVE_API_BASE are intentionally
+# unset so the code falls back to the real Google defaults.
+GDRIVE_CLIENT_ID=699904257039-6ruej6q9bopica806khlmsqj6jg4eg6c.apps.googleusercontent.com
+GDRIVE_REDIRECT_URI=https://datapipe-test.web.app/oauth2/connect
+
+# NOTE (pre-existing, unrelated to the gdrive fix): this dummy key overrides
+# the real FIRESTORE_KEY_TEST secret on the deployed test site because
+# .env.<project> beats .env. Left as-is to avoid orphaning already-encrypted
+# test tokens; worth revisiting as a separate change.
 TOKEN_ENCRYPTION_KEY=abababababababababababababababababababababababababababababababab

--- a/functions/.env.local
+++ b/functions/.env.local
@@ -1,0 +1,20 @@
+# Emulator-only overrides for local dev and the CI test suite.
+#
+# Firebase loads this file ONLY when running the emulators; it is never
+# included in `firebase deploy`. That is exactly why the Google Drive mock
+# values live here instead of in .env.datapipe-test -- keeping them out of
+# the deployed test site (see .env.datapipe-test for the real values).
+#
+# It is intentionally committed (see the `!functions/.env.local` exception
+# in the root .gitignore) so `npm test` / `firebase emulators:exec` work from
+# a fresh checkout, in CI and locally, with no extra setup. Every value here
+# is a non-secret test dummy. The oauth-connect / gdrive emulator tests
+# assert against these exact values and mock servers bind the fixed ports
+# below, so keep them in sync with those tests.
+GDRIVE_API_BASE=http://127.0.0.1:3579
+GDRIVE_TOKEN_URL=http://127.0.0.1:3580/token
+GDRIVE_AUTHORIZE_URL=http://127.0.0.1:3580/authorize
+GDRIVE_CLIENT_ID=test-client-id
+GDRIVE_CLIENT_SECRET=test-client-secret
+GDRIVE_REDIRECT_URI=http://localhost:3000/oauth2/connect
+TOKEN_ENCRYPTION_KEY=abababababababababababababababababababababababababababababababab


### PR DESCRIPTION
## Problem

Connecting Google Drive on **datapipe-test.web.app** sent users to a `localhost`/`127.0.0.1` authorize URL instead of Google's consent screen.

**Root cause:** Firebase loads `functions/.env.datapipe-test` on *both* `firebase deploy` and the emulator. That file held the emulator mock values (127.0.0.1 token/authorize servers, `test-client-id`, `localhost:3000` redirect), so the deployed functions handed those to the browser.

## Fix

Split emulator vs. deployed config along Firebase's emulator-only `.env.local` seam (`.env.local` is loaded only by the emulator, never deployed, and takes precedence):

- **`functions/.env.local`** (new, committed, never deployed) — mock values for local dev + CI. Un-ignored in `.gitignore` so a fresh checkout works with no setup; all values are non-secret test dummies.
- **`functions/.env.datapipe-test`** — now the real deployed config: Google client id + `https://datapipe-test.web.app/oauth2/connect`. Authorize/token/api-base URLs left unset so real Google defaults apply.
- **`firebase-deploy-test.yml`** — injects `GDRIVE_CLIENT_SECRET` from the new `TEST_GDRIVE_CLIENT_SECRET` GitHub secret.

## Prereqs already done
- Drive API enabled on `datapipe-test`
- OAuth consent screen + Web client created (redirect `https://datapipe-test.web.app/oauth2/connect`, scope `drive.file`)
- `TEST_GDRIVE_CLIENT_SECRET` GitHub secret set

## Verification
`oauth-connect-emulator`, `gdrive-emulator`, `resolve-token-gdrive` suites pass (24/24) — `.env.local` overrides shadow the real values under the emulator, so CI stays green.

Merging this to `test` triggers `firebase-deploy-test.yml`, which deploys the functions with real Drive creds.

> Note: `.env.datapipe-test` still carries a dummy `TOKEN_ENCRYPTION_KEY` that overrides the real `FIRESTORE_KEY_TEST` secret on deploy (same pre-existing leak pattern). Left as-is here to avoid orphaning already-encrypted test tokens — worth a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)