### PR TITLE
fix: outline buttons rendered near-black on the dark background

### DIFF
--- a/components/SignInWithOSF.js
+++ b/components/SignInWithOSF.js
@@ -6,6 +6,7 @@ import {
   VStack
 } from "@chakra-ui/react";
 import { OsfIcon } from "./OsfIcon";
+import { outlineOnDark } from "../lib/theme";
 
 export default function SignInWithOSF() {
   const [isLoading, setIsLoading] = useState(false);
@@ -46,7 +47,7 @@ export default function SignInWithOSF() {
       )}
 
       <Button
-        variant="outline"
+        {...outlineOnDark}
         loading={isLoading}
         loadingText="Redirecting to OSF..."
         onClick={handleOSFSignin}

--- a/components/account/LinkedAccounts.js
+++ b/components/account/LinkedAccounts.js
@@ -11,6 +11,7 @@ import {
   linkedProviderIds,
 } from "../../lib/auth-providers";
 import { AUTH_PROVIDER_ICONS } from "../AuthProviderIcons";
+import { outlineOnDark } from "../../lib/theme";
 import {
   isCancelledAuthError,
   messageForAuthError,
@@ -121,7 +122,7 @@ export default function LinkedAccounts() {
 
             {linked ? (
               <Button
-                variant="outline"
+                {...outlineOnDark}
                 size="sm"
                 disabled={last}
                 loading={pendingId === entry.id}

--- a/components/account/OsfRelinkButton.js
+++ b/components/account/OsfRelinkButton.js
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { Button } from "@chakra-ui/react";
 import { OsfIcon } from "../OsfIcon";
+import { outlineOnDark } from "../../lib/theme";
 
 // Re-runs the OSF authorization to restore WRITE access for an experiment
 // that is still collecting. This is the storage grant, not sign-in: it takes
@@ -45,7 +46,13 @@ export default function OsfRelinkButton({ children, ...buttonProps }) {
   };
 
   return (
-    <Button variant="outline" size="md" loading={isLoading} onClick={handleClick} {...buttonProps}>
+    <Button
+      {...outlineOnDark}
+      size="md"
+      loading={isLoading}
+      onClick={handleClick}
+      {...buttonProps}
+    >
       <OsfIcon /> {children}
     </Button>
   );

--- a/components/auth/AuthProviderButtons.js
+++ b/components/auth/AuthProviderButtons.js
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Button, Alert, Text, VStack } from "@chakra-ui/react";
 import { linkWithPopup, signInWithPopup } from "firebase/auth";
 import { auth } from "../../lib/firebase";
+import { outlineOnDark } from "../../lib/theme";
 import { AUTH_PROVIDER_LIST } from "../../lib/auth-providers";
 import { AUTH_PROVIDER_ICONS } from "../AuthProviderIcons";
 import {
@@ -74,7 +75,7 @@ export default function AuthProviderButtons({
         return (
           <Button
             key={entry.id}
-            variant="outline"
+            {...outlineOnDark}
             width="full"
             size="lg"
             loading={pendingId === entry.id}

--- a/lib/theme.js
+++ b/lib/theme.js
@@ -141,3 +141,31 @@ const config = defineConfig({
 });
 
 export const system = createSystem(defaultConfig, config);
+
+// Props for an outline Button on this app's permanently-dark background.
+//
+// Chakra v3's `outline` recipe sets `color: var(--chakra-colors-color-palette-fg)`.
+// With no colorPalette that resolves to the default gray palette's fg =
+// gray.800 -- near-black on greyBackground (#1C1F22), i.e. an invisible button.
+// Note this theme already re-points the SEMANTIC `fg` token light (above); what
+// it does not re-point is the gray PALETTE's fg, which is what unpaletted
+// recipes actually read.
+//
+// The `&&` is load-bearing. A plain `color="white"` prop, and an equivalent
+// `css={{ color: "white" }}`, both compile into the SAME emotion class as the
+// recipe, and the recipe's declaration is emitted AFTER theirs -- so at equal
+// specificity the recipe wins and the override silently does nothing. (Verified
+// against the emitted stylesheet: the prop rule sat at a lower byte offset than
+// the recipe rule for the identical class name.) Doubling the selector raises
+// specificity to 0-2-0 against the recipe's 0-1-0, which wins whatever the
+// emission order.
+export const outlineOnDark = {
+  variant: "outline",
+  css: {
+    "&&": {
+      color: "white",
+      borderColor: "whiteAlpha.400",
+      _hover: { bg: "whiteAlpha.200", borderColor: "white" },
+    },
+  },
+};


### PR DESCRIPTION
Follow-up to #159. The new "Sign in with …" buttons were dark-on-dark and effectively invisible.

## Cause

Chakra v3's `outline` recipe sets `color: var(--chakra-colors-color-palette-fg)`. With no `colorPalette` that resolves to the **default gray palette's** fg = `gray.800` — near-black on `greyBackground` (`#1C1F22`).

`lib/theme.js` already re-points the semantic `fg` token light, but not the gray *palette's* fg, which is what unpaletted recipes actually read.

## Why the obvious fix didn't work

A plain `color="white"` prop — the pattern used elsewhere in this codebase — compiles into the **same emotion class** as the recipe, and the recipe's declaration is emitted **after** it. At equal specificity the recipe wins and the override silently does nothing. `css={{ color: "white" }}` behaves identically.

Measured against the emitted stylesheet, for the identical class name:

```
offset 69676  spec 0-1-0  color: var(--chakra-colors-white)              ← prop, loses
offset 69819  spec 0-1-0  color: var(--chakra-colors-color-palette-fg)   ← recipe, wins
```

Fixed by doubling the selector (`&&`) → 0-2-0 vs the recipe's 0-1-0, which wins regardless of emission order:

```
offset 69736  spec 0-1-0  color: var(--chakra-colors-color-palette-fg)
offset 72004  spec 0-2-0  color: var(--chakra-colors-white)              ← wins
```

Shared as `outlineOnDark` from `lib/theme.js` so the four call sites can't drift.

## Verified

Against the rendered HTML of a production build, all four buttons on `/signin` and `/signup` resolve to `var(--chakra-colors-white)`. 47 suites / 487 tests pass under `firebase emulators:exec --project datapipe-test`; lint and build clean.

## Worth knowing

This same trap likely affects the **pre-existing** outline buttons in `components/CopyButton.js` and `pages/admin/index.js` — both use the `color="white"` prop that this change demonstrates does not win. Left alone here: they're behind auth and weren't part of the reported problem, but they're worth a look.

A broader alternative would be re-pointing the gray palette's `fg` semantic token in the theme, which would fix every unpaletted component at once. Not done here because the blast radius is app-wide and this was a targeted bug report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)