### PR TITLE
fix: re-point the gray palette for this app's dark surface

### DIFF
--- a/components/SignInWithOSF.js
+++ b/components/SignInWithOSF.js
@@ -6,7 +6,6 @@ import {
   VStack
 } from "@chakra-ui/react";
 import { OsfIcon } from "./OsfIcon";
-import { outlineOnDark } from "../lib/theme";
 
 export default function SignInWithOSF() {
   const [isLoading, setIsLoading] = useState(false);
@@ -47,7 +46,7 @@ export default function SignInWithOSF() {
       )}
 
       <Button
-        {...outlineOnDark}
+        variant="outline"
         loading={isLoading}
         loadingText="Redirecting to OSF..."
         onClick={handleOSFSignin}

--- a/components/account/LinkedAccounts.js
+++ b/components/account/LinkedAccounts.js
@@ -11,7 +11,6 @@ import {
   linkedProviderIds,
 } from "../../lib/auth-providers";
 import { AUTH_PROVIDER_ICONS } from "../AuthProviderIcons";
-import { outlineOnDark } from "../../lib/theme";
 import {
   isCancelledAuthError,
   messageForAuthError,
@@ -122,7 +121,7 @@ export default function LinkedAccounts() {
 
             {linked ? (
               <Button
-                {...outlineOnDark}
+                variant="outline"
                 size="sm"
                 disabled={last}
                 loading={pendingId === entry.id}

--- a/components/account/OsfRelinkButton.js
+++ b/components/account/OsfRelinkButton.js
@@ -1,7 +1,6 @@
 import { useState } from "react";
 import { Button } from "@chakra-ui/react";
 import { OsfIcon } from "../OsfIcon";
-import { outlineOnDark } from "../../lib/theme";
 
 // Re-runs the OSF authorization to restore WRITE access for an experiment
 // that is still collecting. This is the storage grant, not sign-in: it takes
@@ -47,7 +46,7 @@ export default function OsfRelinkButton({ children, ...buttonProps }) {
 
   return (
     <Button
-      {...outlineOnDark}
+      variant="outline"
       size="md"
       loading={isLoading}
       onClick={handleClick}

--- a/components/auth/AuthProviderButtons.js
+++ b/components/auth/AuthProviderButtons.js
@@ -2,7 +2,6 @@ import { useState } from "react";
 import { Button, Alert, Text, VStack } from "@chakra-ui/react";
 import { linkWithPopup, signInWithPopup } from "firebase/auth";
 import { auth } from "../../lib/firebase";
-import { outlineOnDark } from "../../lib/theme";
 import { AUTH_PROVIDER_LIST } from "../../lib/auth-providers";
 import { AUTH_PROVIDER_ICONS } from "../AuthProviderIcons";
 import {
@@ -75,7 +74,7 @@ export default function AuthProviderButtons({
         return (
           <Button
             key={entry.id}
-            {...outlineOnDark}
+            variant="outline"
             width="full"
             size="lg"
             loading={pendingId === entry.id}

--- a/lib/theme.js
+++ b/lib/theme.js
@@ -83,6 +83,44 @@ const config = defineConfig({
         border: {
           DEFAULT: { value: { _light: "{colors.gray.400}", _dark: "{colors.gray.400}" } },
         },
+        // DataPipe renders on a permanently dark surface (see globalCss below:
+        // body is greyBackground #1C1F22), but Chakra's mode is light, so every
+        // palette resolves its _light values. For the GRAY palette those are
+        // built for a white page and are wrong here -- most damagingly
+        // gray.fg = gray.800 = #27272a, a 1.09:1 contrast ratio against the
+        // body. Any component that does not name a colorPalette falls back to
+        // gray, so `variant="outline"` and `variant="ghost"` buttons across the
+        // app rendered near-black on near-black and were effectively invisible.
+        //
+        // Components that DO set an explicit color (components/Footer.js,
+        // CopyButton.js, dashboard/Title.js) were never affected and are
+        // unchanged by this -- a style prop still overrides the recipe. What
+        // this fixes is the default, so a button no longer has to remember to
+        // opt out of an invisible one.
+        //
+        // Measured against the body: gray.800 gave 1.11:1, gray.200 gives
+        // 13.05:1.
+        //
+        // These re-point the whole gray palette to a dark-surface reading. The
+        // whole palette, not just fg: variants read different tokens, and
+        // lightening fg alone would leave `subtle` painting light text on the
+        // near-white gray.subtle background.
+        gray: {
+          fg: { value: { _light: "{colors.gray.200}", _dark: "{colors.gray.200}" } },
+          subtle: { value: { _light: "{colors.gray.800}", _dark: "{colors.gray.800}" } },
+          muted: { value: { _light: "{colors.gray.700}", _dark: "{colors.gray.700}" } },
+          emphasized: { value: { _light: "{colors.gray.600}", _dark: "{colors.gray.600}" } },
+          // Inverted against the page: a light chip with dark text, so a solid
+          // gray button reads as a button instead of a hole.
+          solid: { value: { _light: "{colors.gray.200}", _dark: "{colors.gray.200}" } },
+          contrast: { value: { _light: "{colors.gray.900}", _dark: "{colors.gray.900}" } },
+          // gray.500 (#71717a) rather than the darker gray.600: measured
+          // against the #1C1F22 body, 600 gives 2.14:1 and 500 gives 3.43:1,
+          // and WCAG 1.4.11 wants 3.0 for non-text UI boundaries like a
+          // button outline.
+          border: { value: { _light: "{colors.gray.500}", _dark: "{colors.gray.500}" } },
+          focusRing: { value: { _light: "{colors.gray.400}", _dark: "{colors.gray.400}" } },
+        },
         brandOrange: {
           contrast: { value: { _light: "white", _dark: "white" } },
           fg: { value: { _light: "{colors.brandOrange.500}", _dark: "{colors.brandOrange.300}" } },
@@ -142,30 +180,8 @@ const config = defineConfig({
 
 export const system = createSystem(defaultConfig, config);
 
-// Props for an outline Button on this app's permanently-dark background.
-//
-// Chakra v3's `outline` recipe sets `color: var(--chakra-colors-color-palette-fg)`.
-// With no colorPalette that resolves to the default gray palette's fg =
-// gray.800 -- near-black on greyBackground (#1C1F22), i.e. an invisible button.
-// Note this theme already re-points the SEMANTIC `fg` token light (above); what
-// it does not re-point is the gray PALETTE's fg, which is what unpaletted
-// recipes actually read.
-//
-// The `&&` is load-bearing. A plain `color="white"` prop, and an equivalent
-// `css={{ color: "white" }}`, both compile into the SAME emotion class as the
-// recipe, and the recipe's declaration is emitted AFTER theirs -- so at equal
-// specificity the recipe wins and the override silently does nothing. (Verified
-// against the emitted stylesheet: the prop rule sat at a lower byte offset than
-// the recipe rule for the identical class name.) Doubling the selector raises
-// specificity to 0-2-0 against the recipe's 0-1-0, which wins whatever the
-// emission order.
-export const outlineOnDark = {
-  variant: "outline",
-  css: {
-    "&&": {
-      color: "white",
-      borderColor: "whiteAlpha.400",
-      _hover: { bg: "whiteAlpha.200", borderColor: "white" },
-    },
-  },
-};
+// NOTE: an `outlineOnDark` helper used to live here, spreading a
+// double-specificity `&&` override onto each outline button to beat the recipe.
+// It is gone because the gray palette re-pointing above fixes the cause rather
+// than each symptom -- a plain `variant="outline"` is now legible by default,
+// app-wide, including on buttons nobody has touched.


### PR DESCRIPTION
Follow-up to #160, which fixed the symptom on four buttons. This fixes the cause and **reverts that workaround**.

## The defect

DataPipe renders on a permanently dark surface (`globalCss` sets body to `greyBackground` `#1C1F22`) while Chakra's colour mode is **light**, so every palette resolves its `_light` values. For the gray palette those are built for a white page:

```
gray.fg → gray.800 → #27272a   on #1C1F22  =  1.11:1
```

Any component that doesn't name a `colorPalette` falls back to gray, so an unstyled `variant="outline"` or `variant="ghost"` button was effectively invisible. After: `gray.fg → gray.200` = **13.05:1**.

The **whole palette** moves, not just `fg`. Variants read different tokens — lightening `fg` alone would leave `subtle` painting light text on the near-white `gray.subtle` background.

`gray.border` is `gray.500` rather than `gray.600`: WCAG 1.4.11 asks 3.0 for non-text UI boundaries, and measured against the body, 600 gives 2.14:1 while 500 gives 3.43:1.

## Correction to #160

That PR claimed a style prop cannot beat the recipe, and that the outline buttons in `Footer.js`, `CopyButton.js` and `dashboard/Title.js` were therefore also broken. **That was wrong.** Josh pointed out the footer's "Donate on Open Collective" button renders white — it carries `color="white"` and that works.

The real defect was narrower: the new auth buttons set **no colour at all** and inherited the bad default. Components that set an explicit colour were never affected and are unchanged here. Apologies for the noise in #160's description.

## Blast radius

Only components that specify no colour — i.e. exactly the broken ones. Checked the two token consumers that could have gone the other way:

- Both `variant="subtle"` uses are `Alert.Root` with a `status`, which sets its own palette (orange/green), not gray.
- `colorPalette="gray"` appears twice: `QueuePanel`'s "Download all" (`variant="solid"`, now a light chip with dark text instead of near-black on near-black) and the "Enabled" badge in `LinkedAccounts`.

The `&&` double-specificity override and the `outlineOnDark` helper are removed; the four call sites are plain `variant="outline"` again and legible from the theme alone — as is any future one.

## Verified

Token chain resolves `color-palette-fg → gray-fg → gray.200 → #e4e4e7` in the built output; footer button still `var(--chakra-colors-white)`. 47 suites / 487 tests pass under `firebase emulators:exec --project datapipe-test`; lint and build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)