### PR TITLE
fix: give account-linking failures their own wording

### DIFF
--- a/__tests__/auth-errors.test.js
+++ b/__tests__/auth-errors.test.js
@@ -1,0 +1,115 @@
+import {
+  isCancelledAuthError,
+  messageForAuthError,
+} from "../lib/auth-errors";
+
+describe("isCancelledAuthError", () => {
+  it("treats the three popup-dismissal codes as cancellations", () => {
+    expect(isCancelledAuthError("auth/popup-closed-by-user")).toBe(true);
+    expect(isCancelledAuthError("auth/cancelled-popup-request")).toBe(true);
+    expect(isCancelledAuthError("auth/user-cancelled")).toBe(true);
+  });
+
+  it("does not swallow real failures", () => {
+    expect(isCancelledAuthError("auth/email-already-in-use")).toBe(false);
+    expect(isCancelledAuthError("auth/popup-blocked")).toBe(false);
+    expect(isCancelledAuthError(undefined)).toBe(false);
+  });
+});
+
+describe("messageForAuthError email collisions", () => {
+  // The bug this pins: an ORCID account has no email address, so the first
+  // federated provider a researcher links is the first thing that can collide
+  // with an account they already had. Linking then fails with
+  // auth/email-already-in-use, and the sign-in wording told them to "sign in
+  // using the method you set up originally, then add GitHub from your account
+  // settings" -- which is precisely what they had just done.
+  it("does not send a linking researcher back to the account page they are on", () => {
+    const message = messageForAuthError(
+      "auth/email-already-in-use",
+      "GitHub",
+      "link"
+    );
+    expect(message).not.toMatch(/account settings/i);
+    expect(message).toMatch(/different DataPipe account/i);
+    expect(message).toMatch(/GitHub/);
+  });
+
+  it("keeps the front-door advice on the sign-in path", () => {
+    const message = messageForAuthError(
+      "auth/email-already-in-use",
+      "Google",
+      "signIn"
+    );
+    expect(message).toMatch(/account settings/i);
+  });
+
+  it("defaults to the sign-in wording when no mode is given", () => {
+    expect(messageForAuthError("auth/email-already-in-use", "Google")).toBe(
+      messageForAuthError("auth/email-already-in-use", "Google", "signIn")
+    );
+  });
+
+  it("gives the same linking advice for the sign-in-only sibling code", () => {
+    expect(
+      messageForAuthError(
+        "auth/account-exists-with-different-credential",
+        "GitHub",
+        "link"
+      )
+    ).toBe(messageForAuthError("auth/email-already-in-use", "GitHub", "link"));
+  });
+
+  it("says there is no self-service merge rather than implying a retry helps", () => {
+    const message = messageForAuthError(
+      "auth/email-already-in-use",
+      "GitHub",
+      "link"
+    );
+    expect(message).toMatch(/Contact page/);
+    expect(message).not.toMatch(/try again/i);
+  });
+});
+
+describe("messageForAuthError fallbacks", () => {
+  it("names the operation that actually failed", () => {
+    expect(messageForAuthError("auth/internal-error", "GitHub", "signIn")).toMatch(
+      /sign-in/
+    );
+    expect(messageForAuthError("auth/internal-error", "GitHub", "link")).toMatch(
+      /link your GitHub account/
+    );
+    expect(
+      messageForAuthError("auth/internal-error", "GitHub", "unlink")
+    ).toMatch(/unlink your GitHub account/);
+  });
+
+  it("falls back to sign-in wording for an unrecognised mode", () => {
+    expect(messageForAuthError("auth/internal-error", "GitHub", "wat")).toMatch(
+      /sign-in/
+    );
+  });
+
+  it("has a usable message when the provider name is unknown", () => {
+    expect(messageForAuthError("auth/internal-error")).toMatch(
+      /that provider/
+    );
+  });
+});
+
+describe("messageForAuthError mode-independent codes", () => {
+  it.each([
+    ["auth/credential-already-in-use", /already linked to a DataPipe account/],
+    ["auth/provider-already-linked", /already linked to a DataPipe account/],
+    ["auth/popup-blocked", /blocked the sign-in window/],
+    ["auth/operation-not-allowed", /not enabled for DataPipe/],
+    ["auth/no-such-provider", /not linked to this account/],
+    ["auth/unauthorized-domain", /not authorized for sign-in/],
+    ["auth/network-request-failed", /Check your connection/],
+    ["auth/requires-recent-login", /sign out and sign back in/],
+  ])("%s reads the same in every mode", (code, pattern) => {
+    for (const mode of ["signIn", "link", "unlink"]) {
+      expect(messageForAuthError(code, "GitHub", mode)).toMatch(pattern);
+    }
+  });
+});

--- a/components/account/LinkedAccounts.js
+++ b/components/account/LinkedAccounts.js
@@ -52,7 +52,7 @@ export default function LinkedAccounts() {
       });
     } catch (err) {
       if (!isCancelledAuthError(err?.code)) {
-        setError(messageForAuthError(err?.code, entry.name));
+        setError(messageForAuthError(err?.code, entry.name, "link"));
       }
     } finally {
       setPendingId(null);
@@ -66,7 +66,7 @@ export default function LinkedAccounts() {
       const updated = await unlink(auth.currentUser, entry.providerId);
       setAfterAction({ uid: updated.uid, ids: linkedProviderIds(updated) });
     } catch (err) {
-      setError(messageForAuthError(err?.code, entry.name));
+      setError(messageForAuthError(err?.code, entry.name, "unlink"));
     } finally {
       setPendingId(null);
     }

--- a/components/auth/AuthProviderButtons.js
+++ b/components/auth/AuthProviderButtons.js
@@ -53,7 +53,7 @@ export default function AuthProviderButtons({
       }
     } catch (err) {
       if (!isCancelledAuthError(err?.code)) {
-        setError(messageForAuthError(err?.code, entry.name));
+        setError(messageForAuthError(err?.code, entry.name, mode));
       }
     } finally {
       setPendingId(null);

--- a/lib/auth-errors.js
+++ b/lib/auth-errors.js
@@ -18,14 +18,40 @@ export function isCancelledAuthError(code) {
   return CANCELLED.has(code);
 }
 
-export function messageForAuthError(code, providerName = "that provider") {
+// The same code means different things depending on which operation raised it,
+// and the advice has to differ with it. `auth/email-already-in-use` from the
+// sign-in page means "you already have an account, go in the front door"; the
+// identical code from the account page means "you are already inside, and this
+// credential belongs to someone else's front door". Telling a researcher who
+// is sitting in their account settings to go to their account settings is how
+// this went wrong the first time.
+const FALLBACK = {
+  signIn: (name) => `Could not complete ${name} sign-in. Please try again.`,
+  link: (name) => `Could not link your ${name} account. Please try again.`,
+  unlink: (name) => `Could not unlink your ${name} account. Please try again.`,
+};
+
+export function messageForAuthError(
+  code,
+  providerName = "that provider",
+  mode = "signIn"
+) {
   switch (code) {
     case "auth/account-exists-with-different-credential":
     case "auth/email-already-in-use":
       // Deliberately does not name the other method. Firebase's email
       // enumeration protection makes fetchSignInMethodsForEmail return
       // nothing, so any specific claim here would be a guess.
-      return `An account already exists with this email address. Sign in using the method you set up originally, then add ${providerName} from your account settings.`;
+      //
+      // Firebase allows one account per email address, so linking a
+      // credential whose email is already spoken for is refused outright.
+      // There is no self-service merge -- experiments are keyed by
+      // `owner: uid` and moving them between accounts is a maintainer
+      // operation -- so the copy has to say that rather than imply a retry
+      // will help.
+      return mode === "link"
+        ? `Your ${providerName} account's email address already belongs to a different DataPipe account, so it can't be linked to this one. Sign out and sign in to that account instead, or link a ${providerName} account that uses a different email address. If you need two accounts combined, get in touch through the Contact page.`
+        : `An account already exists with this email address. Sign in using the method you set up originally, then add ${providerName} from your account settings.`;
 
     case "auth/credential-already-in-use":
     case "auth/provider-already-linked":
@@ -37,6 +63,9 @@ export function messageForAuthError(code, providerName = "that provider") {
     case "auth/operation-not-allowed":
       return `${providerName} sign-in is not enabled for DataPipe yet. Please try another method.`;
 
+    case "auth/no-such-provider":
+      return `${providerName} is not linked to this account.`;
+
     case "auth/unauthorized-domain":
       return "This site is not authorized for sign-in. Please report this to the DataPipe maintainers.";
 
@@ -47,6 +76,6 @@ export function messageForAuthError(code, providerName = "that provider") {
       return "For security, please sign out and sign back in before changing your sign-in methods.";
 
     default:
-      return `Could not complete ${providerName} sign-in. Please try again.`;
+      return (FALLBACK[mode] || FALLBACK.signIn)(providerName);
   }
 }


### PR DESCRIPTION
## The report

> When I am logged into an account that I created with ORCID and try to Link GitHub in my /admin/account page, I get the error: *An account already exists with this email address. Sign in using the method you set up originally, then add GitHub from your account settings.*

That advice is for a visitor standing at the sign-in page. It was shown to a researcher who was already signed in, already on the account page, doing exactly what it told them to do.

## What was actually happening

The refusal itself is correct, and is not a bug. Firebase allows **one account per email address**, so `linkWithPopup` throws `auth/email-already-in-use` when the incoming credential's email already belongs to a *different* Firebase user. On `datapipe-test` the ORCID account (`qrRQqIdiRCSdZJ2rBPP0f5MbFn52`, displayName "Joshua R. de Leeuw") carries **no email at all**, while two older accounts hold `josh.deleeuw@gmail.com` and `jdeleeuw@vassar.edu`. The GitHub credential's email matches one of those, so it cannot be attached.

The code is `auth/email-already-in-use` by elimination: `auth/account-exists-with-different-credential` is only raised on the sign-in path, and `auth/credential-already-in-use` maps to different copy.

**ORCID is what makes this reachable.** It returns no `email` claim (`providesEmail: false` in `lib/auth-providers.js`), so an ORCID-created account starts with no email, and the first federated provider linked to it is the first opportunity for a collision with an account the researcher already had. A Google-created account would have collided at sign-up instead, where the old copy was right.

## The fix

`messageForAuthError(code, providerName, mode)` now takes the operation. Only the collision case and the fallback vary; the other eight codes read identically in all three modes, which the tests assert.

| mode | on `auth/email-already-in-use` |
|---|---|
| `signIn` | unchanged — "…then add GitHub from your account settings." |
| `link` | "Your GitHub account's email address already belongs to a different DataPipe account, so it can't be linked to this one. Sign out and sign in to that account instead, or link a GitHub account that uses a different email address. If you need two accounts combined, get in touch through the Contact page." |

The linking copy states plainly that there is no self-service merge rather than implying a retry will help — experiments are keyed by `owner: uid`, so combining two accounts means re-parenting documents, a maintainer operation.

Three call sites pass the mode: `AuthProviderButtons` forwards its existing `mode` prop; `LinkedAccounts` passes `"link"` and `"unlink"`. The unlink path was previously reporting failures as sign-in failures.

Also adds `auth/no-such-provider`, which `unlink` can raise and which was falling through to the sign-in fallback.

## Known gap, not fixed here

A researcher who ends up with two accounts has no way to combine them. That is pre-existing and structural, not introduced by this change. Worth deciding on before the OSF sunset, since the migration banner will push OSF-era users through this same linking flow.

## Verification

- `__tests__/auth-errors.test.js` is new — the module had no test file. 18 tests, including one that pins the specific regression (linking copy must not mention "account settings").
- Full suite under the emulators: **48 suites / 505 tests** pass.
- `npm run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)