### PR TITLE
fix: delete accounts server-side, and purge everything they own

### DIFF
--- a/__tests__/auth-errors.test.js
+++ b/__tests__/auth-errors.test.js
@@ -1,0 +1,115 @@
+import {
+  isCancelledAuthError,
+  messageForAuthError,
+} from "../lib/auth-errors";
+
+describe("isCancelledAuthError", () => {
+  it("treats the three popup-dismissal codes as cancellations", () => {
+    expect(isCancelledAuthError("auth/popup-closed-by-user")).toBe(true);
+    expect(isCancelledAuthError("auth/cancelled-popup-request")).toBe(true);
+    expect(isCancelledAuthError("auth/user-cancelled")).toBe(true);
+  });
+
+  it("does not swallow real failures", () => {
+    expect(isCancelledAuthError("auth/email-already-in-use")).toBe(false);
+    expect(isCancelledAuthError("auth/popup-blocked")).toBe(false);
+    expect(isCancelledAuthError(undefined)).toBe(false);
+  });
+});
+
+describe("messageForAuthError email collisions", () => {
+  // The bug this pins: an ORCID account has no email address, so the first
+  // federated provider a researcher links is the first thing that can collide
+  // with an account they already had. Linking then fails with
+  // auth/email-already-in-use, and the sign-in wording told them to "sign in
+  // using the method you set up originally, then add GitHub from your account
+  // settings" -- which is precisely what they had just done.
+  it("does not send a linking researcher back to the account page they are on", () => {
+    const message = messageForAuthError(
+      "auth/email-already-in-use",
+      "GitHub",
+      "link"
+    );
+    expect(message).not.toMatch(/account settings/i);
+    expect(message).toMatch(/different DataPipe account/i);
+    expect(message).toMatch(/GitHub/);
+  });
+
+  it("keeps the front-door advice on the sign-in path", () => {
+    const message = messageForAuthError(
+      "auth/email-already-in-use",
+      "Google",
+      "signIn"
+    );
+    expect(message).toMatch(/account settings/i);
+  });
+
+  it("defaults to the sign-in wording when no mode is given", () => {
+    expect(messageForAuthError("auth/email-already-in-use", "Google")).toBe(
+      messageForAuthError("auth/email-already-in-use", "Google", "signIn")
+    );
+  });
+
+  it("gives the same linking advice for the sign-in-only sibling code", () => {
+    expect(
+      messageForAuthError(
+        "auth/account-exists-with-different-credential",
+        "GitHub",
+        "link"
+      )
+    ).toBe(messageForAuthError("auth/email-already-in-use", "GitHub", "link"));
+  });
+
+  it("says there is no self-service merge rather than implying a retry helps", () => {
+    const message = messageForAuthError(
+      "auth/email-already-in-use",
+      "GitHub",
+      "link"
+    );
+    expect(message).toMatch(/Contact page/);
+    expect(message).not.toMatch(/try again/i);
+  });
+});
+
+describe("messageForAuthError fallbacks", () => {
+  it("names the operation that actually failed", () => {
+    expect(messageForAuthError("auth/internal-error", "GitHub", "signIn")).toMatch(
+      /sign-in/
+    );
+    expect(messageForAuthError("auth/internal-error", "GitHub", "link")).toMatch(
+      /link your GitHub account/
+    );
+    expect(
+      messageForAuthError("auth/internal-error", "GitHub", "unlink")
+    ).toMatch(/unlink your GitHub account/);
+  });
+
+  it("falls back to sign-in wording for an unrecognised mode", () => {
+    expect(messageForAuthError("auth/internal-error", "GitHub", "wat")).toMatch(
+      /sign-in/
+    );
+  });
+
+  it("has a usable message when the provider name is unknown", () => {
+    expect(messageForAuthError("auth/internal-error")).toMatch(
+      /that provider/
+    );
+  });
+});
+
+describe("messageForAuthError mode-independent codes", () => {
+  it.each([
+    ["auth/credential-already-in-use", /already linked to a DataPipe account/],
+    ["auth/provider-already-linked", /already linked to a DataPipe account/],
+    ["auth/popup-blocked", /blocked the sign-in window/],
+    ["auth/operation-not-allowed", /not enabled for DataPipe/],
+    ["auth/no-such-provider", /not linked to this account/],
+    ["auth/unauthorized-domain", /not authorized for sign-in/],
+    ["auth/network-request-failed", /Check your connection/],
+    ["auth/requires-recent-login", /sign out and sign back in/],
+  ])("%s reads the same in every mode", (code, pattern) => {
+    for (const mode of ["signIn", "link", "unlink"]) {
+      expect(messageForAuthError(code, "GitHub", mode)).toMatch(pattern);
+    }
+  });
+});

--- a/components/account/DeleteAccount.js
+++ b/components/account/DeleteAccount.js
@@ -1,29 +1,54 @@
-import { useState, useContext } from "react";
-import { UserContext } from "../../lib/context";
+import { useState } from "react";
 
 import {
   HStack,
+  VStack,
   Button,
   Text,
+  Alert,
   Dialog,
-  Tooltip,
 } from "@chakra-ui/react";
 
 import { auth } from "../../lib/firebase";
-import { deleteUser } from "firebase/auth";
 
 import { useRouter } from "next/router";
 
+// Deletion runs server-side (functions/src/delete-account.ts) rather than
+// through deleteUser() here. The client SDK can only delete the auth record,
+// and it is the auth record that has to go LAST: the researcher's experiments,
+// queued uploads, pending submissions and stored provider credentials all key
+// off the uid, and destroying the account first means a failed cleanup strands
+// them with no owner and no way to sign back in and retry.
 export default function DeleteAccount({ setDeleting }) {
-  const { user } = useContext(UserContext);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [open, setOpen] = useState(false);
   const [deleteError, setDeleteError] = useState(null);
   const router = useRouter();
 
   const deleteAccount = async function () {
+    setIsSubmitting(true);
     try {
-      await deleteUser(auth.currentUser);
+      // Not forced: a refreshed token carries the same auth_time, so it would
+      // not get past the endpoint's recent-login check anyway.
+      const idToken = await auth.currentUser.getIdToken();
+      const response = await fetch("/api/deleteaccount", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${idToken}` },
+      });
+
+      if (!response.ok) {
+        const body = await response.json().catch(() => ({}));
+        throw new Error(
+          body.code === "requires-recent-login"
+            ? "For security, sign out and sign back in, then delete your account."
+            : body.error ||
+              "Could not delete your account. Nothing was lost -- please try again."
+        );
+      }
+
+      // The auth record is gone; drop the local session so the app does not
+      // keep acting on a user that no longer exists.
+      await auth.signOut().catch(() => {});
       router.push("/admin/deleted-account");
     } catch (error) {
       setDeleting(false);
@@ -33,62 +58,65 @@ export default function DeleteAccount({ setDeleting }) {
   };
 
   return (
-    <HStack justifyContent="space-between" w="100%" flexWrap="wrap" gap={3}>
-      <Text fontSize={"lg"}>Delete DataPipe Account</Text>
-      <HStack>
-        {deleteError && (
-          <Tooltip.Root>
-            <Tooltip.Trigger asChild>
-              <Text fontSize="sm" color="red.400" cursor="default">Failed</Text>
-            </Tooltip.Trigger>
-            <Tooltip.Positioner>
-              <Tooltip.Content>{deleteError}</Tooltip.Content>
-            </Tooltip.Positioner>
-          </Tooltip.Root>
-        )}
-        <Button loading={isSubmitting} onClick={() => setOpen(true)} colorPalette="red">
+    <VStack w="100%" align="stretch" gap={3}>
+      {deleteError && (
+        <Alert.Root status="error" borderRadius="md">
+          <Alert.Indicator />
+          <Text fontSize="sm">{deleteError}</Text>
+        </Alert.Root>
+      )}
+
+      <HStack justifyContent="space-between" w="100%" flexWrap="wrap" gap={3}>
+        <Text fontSize={"lg"}>Delete DataPipe Account</Text>
+        <Button
+          loading={isSubmitting}
+          onClick={() => setOpen(true)}
+          colorPalette="red"
+        >
           Delete Account
         </Button>
+
+        <Dialog.Root open={open} onOpenChange={(e) => setOpen(e.open)}>
+          <Dialog.Backdrop />
+          <Dialog.Positioner>
+            <Dialog.Content bg="greyBackground" color="white">
+              <Dialog.Header fontSize="lg" fontWeight="bold">
+                Delete Account
+              </Dialog.Header>
+
+              <Dialog.Body>
+                <Text mb={4}>
+                  Are you sure? This action is final. We cannot recover any
+                  experiments that are associated with this account after
+                  deletion.
+                </Text>
+                <Text>
+                  Deleting your DataPipe account will not affect any data
+                  already written to your storage provider.
+                </Text>
+              </Dialog.Body>
+
+              <Dialog.Footer>
+                <Button onClick={() => setOpen(false)} colorPalette="brandTeal">
+                  Cancel
+                </Button>
+                <Button
+                  colorPalette="red"
+                  onClick={() => {
+                    setDeleting(true);
+                    setOpen(false);
+                    setDeleteError(null);
+                    deleteAccount();
+                  }}
+                  ml={3}
+                >
+                  Delete
+                </Button>
+              </Dialog.Footer>
+            </Dialog.Content>
+          </Dialog.Positioner>
+        </Dialog.Root>
       </HStack>
-      <Dialog.Root open={open} onOpenChange={(e) => setOpen(e.open)}>
-        <Dialog.Backdrop />
-        <Dialog.Positioner>
-          <Dialog.Content bg="greyBackground" color="white">
-            <Dialog.Header fontSize="lg" fontWeight="bold">
-              Delete Account
-            </Dialog.Header>
-
-            <Dialog.Body>
-              <Text mb={4}>
-                Are you sure? This action is final. We cannot recover any
-                experiments that are associated with this account after
-                deletion.
-              </Text>
-              <Text>
-                Deleting your DataPipe account will not affect any data already
-                written to your storage provider.
-              </Text>
-            </Dialog.Body>
-
-            <Dialog.Footer>
-              <Button onClick={() => setOpen(false)} colorPalette="brandTeal">
-                Cancel
-              </Button>
-              <Button
-                colorPalette="red"
-                onClick={() => {
-                  setDeleting(true);
-                  setOpen(false);
-                  deleteAccount();
-                }}
-                ml={3}
-              >
-                Delete
-              </Button>
-            </Dialog.Footer>
-          </Dialog.Content>
-        </Dialog.Positioner>
-      </Dialog.Root>
-    </HStack>
+    </VStack>
   );
 }

--- a/components/account/LinkedAccounts.js
+++ b/components/account/LinkedAccounts.js
@@ -52,7 +52,7 @@ export default function LinkedAccounts() {
       });
     } catch (err) {
       if (!isCancelledAuthError(err?.code)) {
-        setError(messageForAuthError(err?.code, entry.name));
+        setError(messageForAuthError(err?.code, entry.name, "link"));
       }
     } finally {
       setPendingId(null);
@@ -66,7 +66,7 @@ export default function LinkedAccounts() {
       const updated = await unlink(auth.currentUser, entry.providerId);
       setAfterAction({ uid: updated.uid, ids: linkedProviderIds(updated) });
     } catch (err) {
-      setError(messageForAuthError(err?.code, entry.name));
+      setError(messageForAuthError(err?.code, entry.name, "unlink"));
     } finally {
       setPendingId(null);
     }

--- a/components/auth/AuthProviderButtons.js
+++ b/components/auth/AuthProviderButtons.js
@@ -53,7 +53,7 @@ export default function AuthProviderButtons({
       }
     } catch (err) {
       if (!isCancelledAuthError(err?.code)) {
-        setError(messageForAuthError(err?.code, entry.name));
+        setError(messageForAuthError(err?.code, entry.name, mode));
       }
     } finally {
       setPendingId(null);

--- a/firebase.json
+++ b/firebase.json
@@ -77,6 +77,10 @@
       {
         "source": "/api/providersetupwarnings",
         "function": "providersetupwarnings"
+      },
+      {
+        "source": "/api/deleteaccount",
+        "function": "deleteaccount"
       }
     ]
   },

--- a/functions/scripts/backfill-osf-auth-emails.mjs
+++ b/functions/scripts/backfill-osf-auth-emails.mjs
@@ -21,8 +21,8 @@
 // signup from colliding with one of these accounts in the meantime).
 //
 // Usage:
-//   node scripts/backfill-osf-auth-emails.mjs              # dry run, changes nothing
-//   node scripts/backfill-osf-auth-emails.mjs --apply      # actually writes
+//   node functions/scripts/backfill-osf-auth-emails.mjs              # dry run, changes nothing
+//   node functions/scripts/backfill-osf-auth-emails.mjs --apply      # actually writes
 //
 // Env:
 //   GOOGLE_APPLICATION_CREDENTIALS  service-account key with Firebase Admin access

--- a/functions/scripts/purge-orphaned-users.mjs
+++ b/functions/scripts/purge-orphaned-users.mjs
@@ -1,0 +1,191 @@
+// Find and remove data belonging to accounts that no longer exist in Firebase
+// Auth.
+//
+// WHY THIS EXISTS
+//
+// Account deletion used to run client-side: deleteUser(auth.currentUser)
+// destroyed the Auth record first, and cleanup hung off the onUserDeleted
+// trigger afterwards. When that cleanup did not run, or ran against a stale
+// users/{uid}.experiments array, the data outlived the account with no owner
+// left to notice. datapipe-test carries the proof -- two users/ documents and
+// two experiments (one of them still `active`) belonging to uids that have no
+// Auth record.
+//
+// An orphaned experiment is not inert. It still resolves in /api/data, and
+// api-data.ts persists the submission to Cloud Storage BEFORE it checks that
+// the owner exists, so every submission to an orphan leaves a file behind and
+// then answers 400. That accrues storage indefinitely for a study nobody owns.
+//
+// functions/src/delete-account.ts fixes the ordering going forward (purge
+// first, delete the Auth record last). This script cleans up what the old
+// order already left behind. It should need to be run once per project.
+//
+// Usage:
+//   node functions/scripts/purge-orphaned-users.mjs             # dry run, changes nothing
+//   node functions/scripts/purge-orphaned-users.mjs --apply     # actually deletes
+//
+// Env:
+//   GOOGLE_APPLICATION_CREDENTIALS  service-account key with Firebase Admin access
+//   FIREBASE_PROJECT_ID             (optional) overrides the credential's project
+//
+// SAFETY: an account is treated as orphaned only when getUser(uid) raises
+// auth/user-not-found. Any other error -- rate limit, transport failure,
+// permission problem -- is reported as `undetermined` and skipped, because
+// mistaking a live account for a dead one here would delete a researcher's
+// study.
+
+import { initializeApp, applicationDefault } from "firebase-admin/app";
+import { getAuth } from "firebase-admin/auth";
+import { getFirestore } from "firebase-admin/firestore";
+import { getStorage } from "firebase-admin/storage";
+
+const apply = process.argv.includes("--apply");
+
+const projectId = process.env.FIREBASE_PROJECT_ID;
+initializeApp({
+  credential: applicationDefault(),
+  ...(projectId ? { projectId } : {}),
+  storageBucket: `${projectId || ""}.appspot.com`,
+});
+
+const auth = getAuth();
+const db = getFirestore();
+const bucket = getStorage().bucket();
+
+async function authRecordState(uid) {
+  try {
+    await auth.getUser(uid);
+    return "live";
+  } catch (e) {
+    if (e?.errorInfo?.code === "auth/user-not-found") return "missing";
+    console.warn(`  ! could not resolve ${uid}: ${e?.message || e}`);
+    return "undetermined";
+  }
+}
+
+// Every uid that owns something, whether or not it still has a users/ doc.
+// Collected from both directions because the two can disagree -- that
+// disagreement is the bug.
+async function collectCandidateUids() {
+  const uids = new Set();
+  const userDocs = await db.collection("users").get();
+  for (const doc of userDocs.docs) uids.add(doc.id);
+  const experiments = await db.collection("experiments").get();
+  for (const doc of experiments.docs) {
+    const owner = doc.data().owner;
+    if (owner) uids.add(owner);
+  }
+  return [...uids];
+}
+
+async function describe(uid) {
+  const owned = await db
+    .collection("experiments")
+    .where("owner", "==", uid)
+    .get();
+  const queued = await db
+    .collection("uploadQueue")
+    .where("owner", "==", uid)
+    .get();
+  const userDoc = await db.collection("users").doc(uid).get();
+
+  let pendingFiles = 0;
+  for (const doc of owned.docs) {
+    const [files] = await bucket.getFiles({
+      prefix: `pending-data/${doc.id}/`,
+    });
+    pendingFiles += files.length;
+  }
+
+  return {
+    experiments: owned.docs.map((d) => ({
+      id: d.id,
+      title: d.data().title,
+      active: d.data().active === true,
+    })),
+    queueEntries: queued.size,
+    pendingFiles,
+    email: userDoc.exists ? userDoc.data().email : "(no users/ document)",
+  };
+}
+
+async function purge(uid, summary) {
+  const batch = db.batch();
+  for (const exp of summary.experiments) {
+    const claims = await db
+      .collection("experiments")
+      .doc(exp.id)
+      .collection("filenameClaims")
+      .get();
+    for (const claim of claims.docs) batch.delete(claim.ref);
+
+    const [files] = await bucket.getFiles({ prefix: `pending-data/${exp.id}/` });
+    for (const file of files) await file.delete({ ignoreNotFound: true });
+
+    batch.delete(db.collection("experiments").doc(exp.id));
+    batch.delete(db.collection("metadata").doc(exp.id));
+    batch.delete(db.collection("logs").doc(exp.id));
+  }
+  const queued = await db
+    .collection("uploadQueue")
+    .where("owner", "==", uid)
+    .get();
+  for (const doc of queued.docs) batch.delete(doc.ref);
+  batch.delete(db.collection("users").doc(uid));
+  await batch.commit();
+}
+
+const report = { orphaned: [], live: 0, undetermined: [] };
+
+const candidates = await collectCandidateUids();
+console.log(
+  `${apply ? "APPLY" : "DRY RUN"}: checking ${candidates.length} uid(s)\n`
+);
+
+for (const uid of candidates) {
+  const state = await authRecordState(uid);
+  if (state === "live") {
+    report.live += 1;
+    continue;
+  }
+  if (state === "undetermined") {
+    report.undetermined.push(uid);
+    continue;
+  }
+
+  const summary = await describe(uid);
+  report.orphaned.push({ uid, ...summary });
+
+  console.log(`ORPHAN ${uid}  (${summary.email})`);
+  for (const exp of summary.experiments) {
+    console.log(
+      `    experiment ${exp.id} "${exp.title}"${exp.active ? "  [ACTIVE - still accepting data]" : ""}`
+    );
+  }
+  if (summary.queueEntries) console.log(`    ${summary.queueEntries} queue entries`);
+  if (summary.pendingFiles) console.log(`    ${summary.pendingFiles} pending files`);
+
+  if (apply) {
+    await purge(uid, summary);
+    console.log("    purged");
+  }
+  console.log("");
+}
+
+console.log("---");
+console.log(`live accounts:      ${report.live}`);
+console.log(`orphaned accounts:  ${report.orphaned.length}`);
+console.log(
+  `  experiments:      ${report.orphaned.reduce((n, o) => n + o.experiments.length, 0)}` +
+    ` (${report.orphaned.reduce((n, o) => n + o.experiments.filter((e) => e.active).length, 0)} active)`
+);
+console.log(
+  `  pending files:    ${report.orphaned.reduce((n, o) => n + o.pendingFiles, 0)}`
+);
+console.log(`undetermined:       ${report.undetermined.length}`);
+if (report.undetermined.length) {
+  console.log(`  ${report.undetermined.join("\n  ")}`);
+}
+if (!apply && report.orphaned.length) {
+  console.log("\nNothing was changed. Re-run with --apply to delete.");
+}

--- a/functions/src/__tests__/purge-user-data-emulator.test.js
+++ b/functions/src/__tests__/purge-user-data-emulator.test.js
@@ -1,0 +1,217 @@
+/**
+ * @jest-environment node
+ */
+
+process.env.FIRESTORE_EMULATOR_HOST = "localhost:8080";
+process.env.FIREBASE_STORAGE_EMULATOR_HOST = "localhost:9199";
+process.env.GCLOUD_PROJECT = "datapipe-test";
+// app.js (imported transitively below) calls initializeApp() with no args and
+// reads the default bucket from FIREBASE_CONFIG -- set before those imports.
+process.env.FIREBASE_CONFIG = JSON.stringify({
+  projectId: "datapipe-test",
+  storageBucket: "datapipe-test.appspot.com",
+});
+
+const { randomUUID } = require("crypto");
+const { getFirestore } = require("firebase-admin/firestore");
+const { getStorage } = require("firebase-admin/storage");
+const { purgeUserData } = require("../../lib/purge-user-data.js");
+
+jest.setTimeout(30000);
+
+const db = getFirestore();
+const bucket = getStorage().bucket();
+
+// Every document this suite creates is namespaced by a per-run uid so it can
+// never collide with, or delete, anything belonging to a suite running in
+// parallel. See the note in scheduled-pending-recovery-emulator.test.js.
+function makeUid() {
+  return `purge-test-${randomUUID()}`;
+}
+
+async function seedExperiment(uid, experimentID, { active = true } = {}) {
+  await db.collection("experiments").doc(experimentID).set({
+    active,
+    owner: uid,
+    title: "Purge fixture",
+    storageProvider: "gdrive",
+  });
+  await db
+    .collection("experiments")
+    .doc(experimentID)
+    .collection("filenameClaims")
+    .doc("claim-one")
+    .set({ filename: "subject-1.json", claimedAt: Date.now() });
+  await db.collection("metadata").doc(experimentID).set({ owner: uid });
+  await db.collection("logs").doc(experimentID).set({ owner: uid });
+  await bucket
+    .file(`pending-data/${experimentID}/subject-1.json_123`)
+    .save(JSON.stringify({ experimentID, filename: "s.json", data: "[]" }), {
+      contentType: "application/json",
+    });
+}
+
+async function exists(ref) {
+  return (await ref.get()).exists;
+}
+
+describe("purgeUserData", () => {
+  const strays = [];
+
+  afterEach(async () => {
+    // Only what this suite created and the purge did not remove.
+    while (strays.length) {
+      await strays.pop().delete().catch(() => {});
+    }
+  });
+
+  it("removes every trace of the account", async () => {
+    const uid = makeUid();
+    const experimentID = `exp-${randomUUID()}`;
+    await seedExperiment(uid, experimentID);
+    await db
+      .collection("users")
+      .doc(uid)
+      .set({ uid, email: "purge@example.com", experiments: [experimentID] });
+    const queueDocId = `queue-${randomUUID()}`;
+    await db
+      .collection("uploadQueue")
+      .doc(queueDocId)
+      .set({ owner: uid, experimentID, status: "pending" });
+
+    const counts = await purgeUserData(uid);
+
+    expect(counts).toMatchObject({
+      experiments: 1,
+      filenameClaims: 1,
+      metadata: 1,
+      logs: 1,
+      queueEntries: 1,
+      pendingFiles: 1,
+      userDocument: 1,
+    });
+
+    expect(await exists(db.collection("users").doc(uid))).toBe(false);
+    expect(await exists(db.collection("experiments").doc(experimentID))).toBe(
+      false
+    );
+    expect(await exists(db.collection("metadata").doc(experimentID))).toBe(
+      false
+    );
+    expect(await exists(db.collection("logs").doc(experimentID))).toBe(false);
+    expect(await exists(db.collection("uploadQueue").doc(queueDocId))).toBe(
+      false
+    );
+
+    const [pending] = await bucket.getFiles({
+      prefix: `pending-data/${experimentID}/`,
+    });
+    expect(pending).toHaveLength(0);
+  });
+
+  // The regression that left a live experiment behind in datapipe-test: the
+  // old implementation read users/{uid}.experiments, so anything missing from
+  // that array survived its owner -- and a surviving `active` experiment still
+  // accepts submissions and writes them to Cloud Storage.
+  it("deletes experiments missing from the users/{uid}.experiments array", async () => {
+    const uid = makeUid();
+    const listed = `exp-${randomUUID()}`;
+    const drifted = `exp-${randomUUID()}`;
+    await seedExperiment(uid, listed);
+    await seedExperiment(uid, drifted);
+    // The array knows about only one of the two.
+    await db
+      .collection("users")
+      .doc(uid)
+      .set({ uid, email: "drift@example.com", experiments: [listed] });
+
+    const counts = await purgeUserData(uid);
+
+    expect(counts.experiments).toBe(2);
+    expect(await exists(db.collection("experiments").doc(drifted))).toBe(false);
+  });
+
+  // Deleting a Firestore document does not delete its subcollections.
+  it("clears the filenameClaims subcollection under each experiment", async () => {
+    const uid = makeUid();
+    const experimentID = `exp-${randomUUID()}`;
+    await seedExperiment(uid, experimentID);
+
+    await purgeUserData(uid);
+
+    const claims = await db
+      .collection("experiments")
+      .doc(experimentID)
+      .collection("filenameClaims")
+      .get();
+    expect(claims.empty).toBe(true);
+  });
+
+  it("works when the user document is already gone", async () => {
+    const uid = makeUid();
+    const experimentID = `exp-${randomUUID()}`;
+    await seedExperiment(uid, experimentID);
+    // No users/{uid} doc at all -- the orphan state already in datapipe-test.
+
+    const counts = await purgeUserData(uid);
+
+    expect(counts.experiments).toBe(1);
+    expect(counts.userDocument).toBe(0);
+  });
+
+  // deleteAccount purges and then deletes the auth record, which fires
+  // onUserDeleted, which purges again.
+  it("is idempotent", async () => {
+    const uid = makeUid();
+    const experimentID = `exp-${randomUUID()}`;
+    await seedExperiment(uid, experimentID);
+    await db
+      .collection("users")
+      .doc(uid)
+      .set({ uid, email: "twice@example.com", experiments: [experimentID] });
+
+    await purgeUserData(uid);
+    const second = await purgeUserData(uid);
+
+    expect(second).toMatchObject({
+      experiments: 0,
+      filenameClaims: 0,
+      metadata: 0,
+      logs: 0,
+      queueEntries: 0,
+      pendingFiles: 0,
+      userDocument: 0,
+    });
+  });
+
+  it("leaves another researcher's data untouched", async () => {
+    const victim = makeUid();
+    const bystander = makeUid();
+    const victimExp = `exp-${randomUUID()}`;
+    const bystanderExp = `exp-${randomUUID()}`;
+    await seedExperiment(victim, victimExp);
+    await seedExperiment(bystander, bystanderExp);
+    const bystanderUserRef = db.collection("users").doc(bystander);
+    await bystanderUserRef.set({
+      uid: bystander,
+      email: "bystander@example.com",
+      experiments: [bystanderExp],
+    });
+    strays.push(bystanderUserRef);
+    strays.push(db.collection("experiments").doc(bystanderExp));
+    strays.push(db.collection("metadata").doc(bystanderExp));
+    strays.push(db.collection("logs").doc(bystanderExp));
+
+    await purgeUserData(victim);
+
+    expect(await exists(db.collection("experiments").doc(bystanderExp))).toBe(
+      true
+    );
+    expect(await exists(bystanderUserRef)).toBe(true);
+    const [pending] = await bucket.getFiles({
+      prefix: `pending-data/${bystanderExp}/`,
+    });
+    expect(pending).toHaveLength(1);
+    await Promise.all(pending.map((f) => f.delete()));
+  });
+});

--- a/functions/src/delete-account.ts
+++ b/functions/src/delete-account.ts
@@ -1,0 +1,80 @@
+import { onRequest } from "firebase-functions/v2/https";
+import { auth } from "./app.js";
+import { purgeUserData } from "./purge-user-data.js";
+
+// Account deletion, moved server-side.
+//
+// It used to be a bare client-side deleteUser(auth.currentUser), with the
+// cleanup hanging off the onUserDeleted auth trigger. That arrangement has an
+// ordering problem that no amount of care in the trigger can fix: the auth
+// record is destroyed first, so if the cleanup does not run -- or runs
+// partially -- the researcher's data is stranded with no owner and no way for
+// them to sign in and try again. datapipe-test still carries the residue:
+// user documents and a still-`active` experiment belonging to accounts that no
+// longer exist.
+//
+// Here the order is inverted. Purge first, delete the auth record only once
+// the purge has returned. A failure now leaves the account intact and the
+// operation retryable, which is the safe direction to fail in.
+//
+// onUserDeleted is kept as a backstop for deletions that do not come through
+// this endpoint (the Firebase console, the Admin SDK, a support action).
+
+// Firebase's own threshold for auth/requires-recent-login. Client-side
+// deleteUser enforced this for us; server-side nothing does, so the check has
+// to be explicit or moving the call server-side would quietly weaken it -- a
+// stolen session token would be enough to destroy an account.
+const MAX_AUTH_AGE_SECONDS = 5 * 60;
+
+export const deleteAccount = onRequest({ cors: true }, async (req, res) => {
+  if (req.method !== "POST") {
+    res.status(405).json({ error: "Method not allowed" });
+    return;
+  }
+
+  const authHeader = req.headers.authorization;
+  if (!authHeader || !authHeader.startsWith("Bearer ")) {
+    res.status(401).json({ error: "Authentication required" });
+    return;
+  }
+
+  let uid: string;
+  let authTime: number;
+  try {
+    const idToken = authHeader.split("Bearer ")[1];
+    // checkRevoked: a researcher who signed out everywhere should not be able
+    // to delete the account with a token minted before that.
+    const decodedToken = await auth.verifyIdToken(idToken, true);
+    uid = decodedToken.uid;
+    authTime = decodedToken.auth_time;
+  } catch {
+    res.status(401).json({ error: "Invalid authentication token" });
+    return;
+  }
+
+  const tokenAgeSeconds = Date.now() / 1000 - authTime;
+  if (tokenAgeSeconds > MAX_AUTH_AGE_SECONDS) {
+    // A distinct code so the client can say "sign in again" rather than
+    // showing a generic failure.
+    res.status(403).json({
+      error: "Please sign in again before deleting your account.",
+      code: "requires-recent-login",
+    });
+    return;
+  }
+
+  try {
+    const counts = await purgeUserData(uid);
+    await auth.deleteUser(uid);
+    res.status(200).json({ success: true, deleted: counts });
+  } catch (e) {
+    const detail = e instanceof Error ? e.message : "Unknown error";
+    console.error(`Account deletion failed for ${uid}: ${detail}`);
+    // The account still exists and still owns whatever survived, so the
+    // researcher can retry. Say so rather than leaving them guessing.
+    res.status(500).json({
+      error:
+        "Could not finish deleting your account. Nothing was lost -- please try again.",
+    });
+  }
+});

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -15,6 +15,7 @@ import { connectProvider, connectStaticTokenProvider, disconnectProvider } from 
 import { saveOsfToken } from "./save-osf-token.js";
 import { getOsfToken } from "./get-osf-token.js";
 import { onUserDeleted } from "./on-user-deleted.js";
+import { deleteAccount } from "./delete-account.js";
 import { createExperiment } from "./create-experiment.js";
 import { getProviderAccessToken } from "./get-provider-access-token.js";
 import { providerSetupWarnings } from "./provider-setup-warnings.js";
@@ -41,6 +42,7 @@ export {
   saveOsfToken as saveosftoken,
   getOsfToken as getosftoken,
   onUserDeleted as onuserdeleted,
+  deleteAccount as deleteaccount,
   createExperiment as createexperiment,
   getProviderAccessToken as getprovideraccesstoken,
   providerSetupWarnings as providersetupwarnings

--- a/functions/src/on-user-deleted.ts
+++ b/functions/src/on-user-deleted.ts
@@ -1,33 +1,22 @@
 import * as auth from "firebase-functions/v1/auth";
-import { db } from "./app.js";
-import { UserData } from "./interfaces.js";
+import { purgeUserData } from "./purge-user-data.js";
 
+// Backstop for auth records deleted outside the app: the Firebase console, the
+// Admin SDK, a support action. The normal path is the deleteAccount HTTPS
+// function, which purges first and deletes the auth record afterwards; this
+// trigger covers the deletions that never touch it.
+//
+// It is a backstop rather than the primary mechanism on purpose. It fires
+// after the account is already gone, so a failure here strands data with no
+// owner and no way for the researcher to sign back in and retry -- and there
+// is evidence in datapipe-test that this has already happened at least twice.
+// Whether the miss was a trigger that did not fire or an experiment missing
+// from the users/{uid}.experiments array it used to read, relying on
+// after-the-fact cleanup as the only line of defence is the wrong shape.
+//
+// purgeUserData is idempotent, so running after deleteAccount has already
+// purged is harmless.
 export const onUserDeleted = auth.user().onDelete(async (user) => {
-  const uid = user.uid;
-
-  // Get the user document to find their experiments
-  const userDocRef = db.collection("users").doc(uid);
-  const userDoc = await userDocRef.get();
-
-  if (userDoc.exists) {
-    const userData = userDoc.data() as UserData;
-    const experimentIds = userData.experiments || [];
-
-    // Delete in batches of 500 (Firestore batch limit is 500 operations)
-    const batchSize = 500;
-    for (let i = 0; i < experimentIds.length; i += batchSize) {
-      const batch = db.batch();
-      const chunk = experimentIds.slice(i, i + batchSize);
-
-      for (const experimentId of chunk) {
-        batch.delete(db.collection("experiments").doc(experimentId));
-        batch.delete(db.collection("logs").doc(experimentId));
-      }
-
-      await batch.commit();
-    }
-
-    // Delete the user document itself
-    await userDocRef.delete();
-  }
+  const counts = await purgeUserData(user.uid);
+  console.log(`Purged data for deleted user ${user.uid}:`, counts);
 });

--- a/functions/src/purge-user-data.ts
+++ b/functions/src/purge-user-data.ts
@@ -1,0 +1,133 @@
+import { db, storage } from "./app.js";
+
+// Everything that belongs to one researcher, removed in one pass.
+//
+// This exists because account deletion used to leave residue. The old
+// implementation lived in on-user-deleted.ts and had two defects that this
+// module fixes:
+//
+//   1. It found experiments through `users/{uid}.experiments`, an array the
+//      client maintains. When that array drifts, the experiment survives its
+//      owner -- and a surviving experiment is the dangerous kind of orphan,
+//      not a harmless one. api-data.ts writes the submission to Cloud Storage
+//      (persistPending) BEFORE it checks that the owner still exists, so a
+//      still-`active` orphan accepts and stores a file on every submission
+//      and then answers 400. Querying `where owner == uid` cannot drift.
+//
+//   2. It deleted the experiment document but not the `filenameClaims`
+//      subcollection underneath it. Deleting a Firestore document does not
+//      delete its subcollections; the claims would have outlived both the
+//      experiment and the account.
+//
+// Idempotent by construction: Firestore deletes of absent documents succeed,
+// and the storage sweep tolerates a missing prefix. That matters because both
+// callers can run for the same uid -- deleteAccount purges and then deletes
+// the auth record, which fires the onUserDeleted trigger, which purges again.
+const BATCH_LIMIT = 500;
+
+export interface PurgeCounts {
+  experiments: number;
+  filenameClaims: number;
+  metadata: number;
+  logs: number;
+  queueEntries: number;
+  pendingFiles: number;
+  userDocument: number;
+}
+
+async function deleteInBatches(
+  refs: FirebaseFirestore.DocumentReference[]
+): Promise<number> {
+  for (let i = 0; i < refs.length; i += BATCH_LIMIT) {
+    const batch = db.batch();
+    for (const ref of refs.slice(i, i + BATCH_LIMIT)) {
+      batch.delete(ref);
+    }
+    await batch.commit();
+  }
+  return refs.length;
+}
+
+/**
+ * Remove every Firestore document and Cloud Storage object belonging to `uid`.
+ *
+ * Deliberately does NOT touch the Firebase Auth record. Callers order that
+ * themselves, and the order is load-bearing: purge first, delete the auth
+ * record last. Deleting the account first and then failing mid-purge would
+ * leave data with no owner and no way for the researcher to sign back in and
+ * retry -- the exact state this module is meant to prevent.
+ */
+export async function purgeUserData(uid: string): Promise<PurgeCounts> {
+  const counts: PurgeCounts = {
+    experiments: 0,
+    filenameClaims: 0,
+    metadata: 0,
+    logs: 0,
+    queueEntries: 0,
+    pendingFiles: 0,
+    userDocument: 0,
+  };
+
+  const ownedExperiments = await db
+    .collection("experiments")
+    .where("owner", "==", uid)
+    .get();
+
+  const experimentIds = ownedExperiments.docs.map((doc) => doc.id);
+
+  for (const experimentId of experimentIds) {
+    // Subcollection first: once the parent document is gone the claims are
+    // unreachable through the console but still billable and still returned
+    // by collection-group queries.
+    const claims = await db
+      .collection("experiments")
+      .doc(experimentId)
+      .collection("filenameClaims")
+      .get();
+    counts.filenameClaims += await deleteInBatches(
+      claims.docs.map((doc) => doc.ref)
+    );
+
+    // Submissions that were persisted but never uploaded. Left behind, these
+    // are replayed by scheduledPendingRecovery forever.
+    const [pendingFiles] = await storage
+      .bucket()
+      .getFiles({ prefix: `pending-data/${experimentId}/` });
+    for (const file of pendingFiles) {
+      await file.delete({ ignoreNotFound: true });
+    }
+    counts.pendingFiles += pendingFiles.length;
+  }
+
+  counts.experiments = await deleteInBatches(
+    ownedExperiments.docs.map((doc) => doc.ref)
+  );
+
+  // metadata/ and logs/ are keyed by experiment id, not by uid.
+  counts.metadata = await deleteInBatches(
+    experimentIds.map((id) => db.collection("metadata").doc(id))
+  );
+  counts.logs = await deleteInBatches(
+    experimentIds.map((id) => db.collection("logs").doc(id))
+  );
+
+  // uploadQueue is keyed by its own id and carries the owner as a field, so it
+  // has to be queried separately -- an entry can outlive the experiment it
+  // came from.
+  const queued = await db
+    .collection("uploadQueue")
+    .where("owner", "==", uid)
+    .get();
+  counts.queueEntries = await deleteInBatches(queued.docs.map((doc) => doc.ref));
+
+  // Last: the user document holds connectedAccounts, i.e. the storage
+  // provider credentials. If an earlier step throws, the researcher still
+  // owns a coherent account.
+  const userDocRef = db.collection("users").doc(uid);
+  if ((await userDocRef.get()).exists) {
+    await userDocRef.delete();
+    counts.userDocument = 1;
+  }
+
+  return counts;
+}

--- a/lib/auth-errors.js
+++ b/lib/auth-errors.js
@@ -18,14 +18,40 @@ export function isCancelledAuthError(code) {
   return CANCELLED.has(code);
 }
 
-export function messageForAuthError(code, providerName = "that provider") {
+// The same code means different things depending on which operation raised it,
+// and the advice has to differ with it. `auth/email-already-in-use` from the
+// sign-in page means "you already have an account, go in the front door"; the
+// identical code from the account page means "you are already inside, and this
+// credential belongs to someone else's front door". Telling a researcher who
+// is sitting in their account settings to go to their account settings is how
+// this went wrong the first time.
+const FALLBACK = {
+  signIn: (name) => `Could not complete ${name} sign-in. Please try again.`,
+  link: (name) => `Could not link your ${name} account. Please try again.`,
+  unlink: (name) => `Could not unlink your ${name} account. Please try again.`,
+};
+
+export function messageForAuthError(
+  code,
+  providerName = "that provider",
+  mode = "signIn"
+) {
   switch (code) {
     case "auth/account-exists-with-different-credential":
     case "auth/email-already-in-use":
       // Deliberately does not name the other method. Firebase's email
       // enumeration protection makes fetchSignInMethodsForEmail return
       // nothing, so any specific claim here would be a guess.
-      return `An account already exists with this email address. Sign in using the method you set up originally, then add ${providerName} from your account settings.`;
+      //
+      // Firebase allows one account per email address, so linking a
+      // credential whose email is already spoken for is refused outright.
+      // There is no self-service merge -- experiments are keyed by
+      // `owner: uid` and moving them between accounts is a maintainer
+      // operation -- so the copy has to say that rather than imply a retry
+      // will help.
+      return mode === "link"
+        ? `Your ${providerName} account's email address already belongs to a different DataPipe account, so it can't be linked to this one. Sign out and sign in to that account instead, or link a ${providerName} account that uses a different email address. If you need two accounts combined, get in touch through the Contact page.`
+        : `An account already exists with this email address. Sign in using the method you set up originally, then add ${providerName} from your account settings.`;
 
     case "auth/credential-already-in-use":
     case "auth/provider-already-linked":
@@ -37,6 +63,9 @@ export function messageForAuthError(code, providerName = "that provider") {
     case "auth/operation-not-allowed":
       return `${providerName} sign-in is not enabled for DataPipe yet. Please try another method.`;
 
+    case "auth/no-such-provider":
+      return `${providerName} is not linked to this account.`;
+
     case "auth/unauthorized-domain":
       return "This site is not authorized for sign-in. Please report this to the DataPipe maintainers.";
 
@@ -47,6 +76,6 @@ export function messageForAuthError(code, providerName = "that provider") {
       return "For security, please sign out and sign back in before changing your sign-in methods.";
 
     default:
-      return `Could not complete ${providerName} sign-in. Please try again.`;
+      return (FALLBACK[mode] || FALLBACK.signIn)(providerName);
   }
 }


### PR DESCRIPTION
## The bug

Account deletion ran client-side — `deleteUser(auth.currentUser)` destroyed the Firebase Auth record first, with cleanup hanging off the `onUserDeleted` trigger afterwards. That ordering cannot be made safe: once the auth record is gone, a cleanup that doesn't run leaves the researcher's data with no owner and no way for them to sign back in and retry.

**`datapipe-test` carries the residue.** Two `users/` documents belong to uids with no auth record (`VmG8c4JMytWhZZaMn4dsjyDLQoS2`, `si2gl3Mk0oh2BYEar3qcFjlrcJx2`), and so do two experiments — `HHxzE2CVJiTb` ("milo") is still **`active: true`**.

An orphaned active experiment is not inert. `api-data.ts` persists each submission to Cloud Storage (`persistPending`, line 88) **before** it checks that the owner exists (line 96), and the `INVALID_OWNER` path returns without calling `cleanupPending`. So every submission to an orphan leaves a file behind and then answers 400 — unbounded storage for a study nobody owns.

## The fix

**Ordering inverted.** `functions/src/delete-account.ts` purges first and deletes the auth record only once the purge returns. Failing now leaves the account intact and the operation retryable — the safe direction.

**The purge moves to `purge-user-data.ts`** and closes two gaps in what the trigger did:

| | before | after |
|---|---|---|
| finding experiments | `users/{uid}.experiments`, a client-maintained array | `where owner == uid` — cannot drift |
| `filenameClaims` subcollection | left behind (Firestore doesn't cascade) | deleted |
| `uploadQueue` entries | untouched | deleted |
| `pending-data/` objects | untouched | deleted |

**`onUserDeleted` stays as a backstop** for deletions that never reach the endpoint — the console, the Admin SDK, a support action. `purgeUserData` is idempotent, so the trigger firing after `deleteAccount` has already purged is harmless.

**Recent-login preserved.** Client-side `deleteUser` enforced `auth/requires-recent-login` for us; moving server-side would have silently dropped it, leaving a stolen session token sufficient to destroy an account. The endpoint checks `auth_time` against Firebase's own five-minute threshold and verifies with `checkRevoked: true`. The client maps that to "sign out and sign back in" rather than the old bare tooltip, which showed a raw Firebase error in red 12px text.

## Cleaning up what's already there

`functions/scripts/purge-orphaned-users.mjs` — dry-run by default. It treats an account as orphaned **only** on an explicit `auth/user-not-found`; any other error (rate limit, transport, permissions) is reported as `undetermined` and skipped, because mistaking a live account for a dead one here deletes a real study.

I could not run it: ADC reaches Firestore but returns `Missing or insufficient permissions`, so it needs the service-account credentials described in its header. **Run the dry run before the apply** — I have not seen its output.

Both admin-SDK scripts also move under `functions/`, where `firebase-admin` actually resolves. They imported it from `scripts/`, which has no `node_modules` — neither could ever have run, including the OSF email backfill.

## Verification

- New `purge-user-data-emulator.test.js`: 6 tests, including the array-drift regression and a bystander-isolation check.
- Full suite: **49 suites / 511 tests** pass.
- `npm run lint` clean, `tsc` clean.

Not verified end-to-end against a real auth record — the endpoint's `auth_time` path and `auth.deleteUser` need a live sign-in, which is the manual check below.

## Manual check after deploy

Delete the throwaway ORCID account (`qrRQqIdiRC…`, owns nothing) and confirm `users/qrRQqIdiRC…` disappears with it. That both exercises this change and clears the way for the ORCID link test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)