### PR TITLE
feat: point the test deployment at the Zenodo sandbox

### DIFF
--- a/.github/workflows/firebase-deploy-test.yml
+++ b/.github/workflows/firebase-deploy-test.yml
@@ -20,6 +20,9 @@ env:
   NEXT_PUBLIC_GENERATE_STATE: "https://datapipe-test.web.app/api/generateoauthstate"
   NEXT_PUBLIC_BASE_URL: "https://datapipe-test.web.app"
   NEXT_PUBLIC_OSF_ENV: ""
+  # sandbox.zenodo.org. Without this the TEST site creates real
+  # depositions on the live Zenodo using the researcher's real account.
+  NEXT_PUBLIC_ZENODO_ENV: "sandbox."
   # Google Picker (folder selection for gdrive experiments). The API key is
   # restricted to the Picker API + our domains, so it is safe in the browser
   # bundle -- not a secret. The project number is public.

--- a/.github/workflows/firebase-deploy.yml
+++ b/.github/workflows/firebase-deploy.yml
@@ -20,6 +20,9 @@ env:
   NEXT_PUBLIC_GENERATE_STATE: "https://pipe.jspsych.org/api/generateoauthstate"
   NEXT_PUBLIC_BASE_URL: "https://pipe.jspsych.org"
   NEXT_PUBLIC_OSF_ENV: ""
+  # Empty = the real zenodo.org. Set explicitly rather than relying on the
+  # default, so production never inherits a sandbox value by accident.
+  NEXT_PUBLIC_ZENODO_ENV: ""
 
 jobs:
   build:

--- a/__tests__/provider-config.test.js
+++ b/__tests__/provider-config.test.js
@@ -86,3 +86,67 @@ describe("STORAGE_PROVIDERS.dataverse", () => {
     expect(STORAGE_PROVIDERS.dataverse.id).toBe("dataverse");
   });
 });
+
+describe("zenodo: which Zenodo a deployment points at", () => {
+  // NEXT_PUBLIC_ZENODO_ENV is read at module scope, so each case has to
+  // re-import with the value already set. jest.resetModules + a dynamic
+  // require is the only way to exercise more than one deployment shape.
+  function loadWith(zenodoEnv) {
+    let mod;
+    jest.isolateModules(() => {
+      const prior = process.env.NEXT_PUBLIC_ZENODO_ENV;
+      if (zenodoEnv === undefined) {
+        delete process.env.NEXT_PUBLIC_ZENODO_ENV;
+      } else {
+        process.env.NEXT_PUBLIC_ZENODO_ENV = zenodoEnv;
+      }
+      mod = require("../lib/provider-config").STORAGE_PROVIDERS;
+      if (prior === undefined) {
+        delete process.env.NEXT_PUBLIC_ZENODO_ENV;
+      } else {
+        process.env.NEXT_PUBLIC_ZENODO_ENV = prior;
+      }
+    });
+    return mod;
+  }
+
+  it("points production at the real zenodo.org", () => {
+    expect(loadWith("").zenodo.defaultServerUrl).toBe("https://zenodo.org");
+  });
+
+  it("points the test deployment at the sandbox", () => {
+    // The whole reason this setting exists: without it the test site creates
+    // real depositions on the live service using the researcher's real
+    // account.
+    expect(loadWith("sandbox.").zenodo.defaultServerUrl).toBe(
+      "https://sandbox.zenodo.org"
+    );
+  });
+
+  it("falls back to production when the variable is absent entirely", () => {
+    // An unset variable must never resolve to something like
+    // "https://undefinedzenodo.org", and defaulting to sandbox would be worse
+    // -- a misconfigured production deploy would silently write nowhere real.
+    expect(loadWith(undefined).zenodo.defaultServerUrl).toBe("https://zenodo.org");
+  });
+
+  it("containerLink follows the container's host, not the current deployment", () => {
+    // Same rule as dataverse above. An experiment created before a deployment
+    // was switched still lives where it was created, so its link has to follow
+    // the data rather than today's configuration.
+    const url = loadWith("sandbox.").zenodo.containerLink({
+      providerContainer: {
+        serverUrl: "https://zenodo.org",
+        depositionId: 5551212,
+      },
+    });
+    expect(url).toBe("https://zenodo.org/deposit/5551212");
+  });
+
+  it("containerLink falls back to the deployment host for a container with no serverUrl", () => {
+    const url = loadWith("sandbox.").zenodo.containerLink({
+      providerContainer: { depositionId: 42 },
+    });
+    expect(url).toBe("https://sandbox.zenodo.org/deposit/42");
+  });
+});

--- a/lib/provider-config.js
+++ b/lib/provider-config.js
@@ -19,6 +19,18 @@
 // and it must be kept in sync by hand with functions/src/providers/*.ts
 // whenever containerInput changes there. The duplication is deliberate:
 // lib/ is bundled into the Next.js app and cannot import from functions/src/.
+// Which Zenodo this DEPLOYMENT points at: "" on production -> zenodo.org,
+// "sandbox." on the test site -> sandbox.zenodo.org. Same host-prefix shape as
+// NEXT_PUBLIC_OSF_ENV.
+//
+// Resolved once, here, rather than inline at each use. The two uses below are
+// evaluated at different times -- defaultServerUrl when this module loads,
+// containerLink when it is called -- so reading process.env separately in each
+// would let them disagree. Next inlines NEXT_PUBLIC_* at build time so that
+// cannot bite in the browser, but it does in tests, which is where it showed
+// up.
+const ZENODO_HOST = `https://${process.env.NEXT_PUBLIC_ZENODO_ENV ?? ""}zenodo.org`;
+
 export const STORAGE_PROVIDERS = {
   gdrive: {
     id: "gdrive",
@@ -73,14 +85,20 @@ export const STORAGE_PROVIDERS = {
     id: "zenodo",
     name: "Zenodo",
     authMethod: "static-token",
-    // NOT federated, unlike Dataverse: there is one production Zenodo. The
-    // connect endpoint still requires a serverUrl, so this fixed value is sent
-    // on the researcher's behalf and no field is rendered
-    // (see ProviderConnections.js's handleTokenConnect). The sandbox
-    // (sandbox.zenodo.org) is reachable by the spike script, which calls the
-    // adapter directly, so it needs no researcher-facing option here.
+    // NOT federated, unlike Dataverse: a researcher never picks an
+    // installation, so no field is rendered and this value is sent on their
+    // behalf (see ProviderConnections.js's handleTokenConnect).
+    //
+    // It is still per-DEPLOYMENT, which is what NEXT_PUBLIC_ZENODO_ENV
+    // controls: "" on production -> zenodo.org, "sandbox." on the test site ->
+    // sandbox.zenodo.org. Same host-prefix shape as NEXT_PUBLIC_OSF_ENV, and
+    // for the same reason -- without it the test deployment writes real
+    // depositions to the live service using the researcher's real account.
+    // The two Zenodos have entirely separate accounts and tokens, so a
+    // sandbox token pasted into a production-pointed deployment is rejected
+    // at connect time rather than silently misfiling data.
     needsServerUrl: false,
-    defaultServerUrl: "https://zenodo.org",
+    defaultServerUrl: ZENODO_HOST,
     tokenLabel: "Personal access token",
     tokenHelp:
       "Create one under Applications → Personal access tokens in your Zenodo account settings. It needs the deposit:write and deposit:actions scopes. Zenodo tokens do not expire.",
@@ -88,8 +106,13 @@ export const STORAGE_PROVIDERS = {
     // Zenodo depositions stay unpublished while data is being collected, so
     // the researcher-facing link is the deposit editor rather than a public
     // record page (which does not exist until they publish).
+    // Host comes from the CONTAINER, not from the env above, matching
+    // dataverse's containerLink. The env only decides where NEW connections
+    // point; an experiment created before the deployment was switched still
+    // lives wherever it was created, and its link has to follow the data
+    // rather than the current configuration.
     containerLink: (exp) =>
-      `https://zenodo.org/deposit/${exp.providerContainer?.depositionId}`,
+      `${exp.providerContainer?.serverUrl ?? ZENODO_HOST}/deposit/${exp.providerContainer?.depositionId}`,
     containerLabel: "Zenodo Deposition",
     containerLinkText: "Open deposition",
     // Mirrors functions/src/providers/zenodo.ts's containerInput exactly.


### PR DESCRIPTION
`lib/provider-config.js` hardcoded `https://zenodo.org` and renders no server-URL field, so connecting Zenodo on **datapipe-test creates real depositions on the live service** using the researcher's real account.

There was no workaround from the UI: pasting a sandbox token is rejected at connect time, because the connect endpoint validates it against zenodo.org. The only way to test against sandbox was to hand-write the connection document into Firestore.

## Change

`NEXT_PUBLIC_ZENODO_ENV` selects the host exactly the way `NEXT_PUBLIC_OSF_ENV` already does — a prefix, `""` on production → `zenodo.org`, `"sandbox."` on test → `sandbox.zenodo.org`. Both workflows set it explicitly rather than relying on the default, so production can't inherit a sandbox value by accident.

**No backend change.** `zenodo.ts` already allowlists both hosts and resolves the server from the stored connection, so this only decides where *new* connections point. Existing connections keep the host they were made against, which is correct.

`containerLink` now takes its host from the **container** rather than a constant, matching `dataverse`'s already-tested behavior — an experiment created before a deployment was switched still lives where it was created, so its link must follow the data, not today's config.

## Note

The host resolves once at module scope. `defaultServerUrl` is evaluated at module load and `containerLink` when called, so reading `process.env` separately in each allowed them to disagree — a test caught this, and the fix was to the code rather than the test.

685 tests passing, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)