### PR TITLE
fix: put dataset_description.json inside the finalized archive

### DIFF
--- a/docs/finalization-spec.md
+++ b/docs/finalization-spec.md
@@ -20,8 +20,18 @@ files into ONE archive carrying the full Psych-DS tree, leaving
    be triggered by our own memory ceiling — see Phase 2.
 3. **`.psychds-ignore` goes INSIDE the final archive** and its loose copy is
    deleted. Nothing regenerates it once submissions stop.
-   `dataset_description.json` stays loose so the record still shows a
-   descriptor.
+   **`dataset_description.json` goes inside the archive AND stays loose.**
+   Corrected 2026-08-20 after inspecting a real finalized deposition: the
+   original "stays loose only" rule left the archive with no descriptor at all,
+   so the zip was not a valid Psych-DS dataset (the spec requires it at the
+   dataset root) and neither was the record around it, whose data is sealed in
+   a zip — half the spec met by unzipping and half by not. It is inside because
+   the archive IS the dataset, the only place the `data/raw/...` tree exists;
+   it is also loose so the record shows a human-readable descriptor and
+   metadata-block.ts's `metadataFileRef` still resolves. Duplicating it is safe
+   only because finalization is terminal — nothing can update one copy and
+   leave the other stale, which is why compaction still keeps it strictly out
+   of its batches during collection.
 4. **Publishing / minting a DOI is out of scope.** Irreversible, and the
    researcher's call.
 

--- a/docs/finalization-spec.md
+++ b/docs/finalization-spec.md
@@ -18,20 +18,28 @@ files into ONE archive carrying the full Psych-DS tree, leaving
    but they break Psych-DS compatibility, so they are a last resort reachable
    only above a provider's hard per-file limit (Zenodo: 50 GB). They must never
    be triggered by our own memory ceiling — see Phase 2.
-3. **`.psychds-ignore` goes INSIDE the final archive** and its loose copy is
-   deleted. Nothing regenerates it once submissions stop.
-   **`dataset_description.json` goes inside the archive AND stays loose.**
-   Corrected 2026-08-20 after inspecting a real finalized deposition: the
-   original "stays loose only" rule left the archive with no descriptor at all,
-   so the zip was not a valid Psych-DS dataset (the spec requires it at the
-   dataset root) and neither was the record around it, whose data is sealed in
-   a zip — half the spec met by unzipping and half by not. It is inside because
-   the archive IS the dataset, the only place the `data/raw/...` tree exists;
-   it is also loose so the record shows a human-readable descriptor and
-   metadata-block.ts's `metadataFileRef` still resolves. Duplicating it is safe
-   only because finalization is terminal — nothing can update one copy and
-   leave the other stale, which is why compaction still keeps it strictly out
-   of its batches during collection.
+3. **The record ends as exactly ONE file: the merged archive.** Both Psych-DS
+   control files go inside it — `.psychds-ignore` and
+   `dataset_description.json` — and nothing is left loose.
+
+   Corrected twice, which is worth recording. The original rule kept the
+   descriptor loose "so the record still shows a descriptor", which left the
+   archive with none at all: the zip was not a valid Psych-DS dataset (the spec
+   requires the descriptor at the dataset root) and the record was not one
+   either (its data is sealed in a zip). Half the spec met by unzipping and
+   half by not. The first fix wrote it in BOTH places, which was valid but
+   duplicated a file to serve a need that does not survive checking — Zenodo
+   has a built-in zip previewer that lists archive contents on the record page
+   without downloading, so putting the descriptor inside hides nothing, and a
+   second copy is a second thing that can be wrong. Nothing reads the loose
+   copy either: `metadata-block.ts` owns the `metadataFileRef` pointing at it,
+   and that only runs during a submission, which a finalized experiment
+   rejects.
+
+   Compaction still keeps both files strictly out of its batches during
+   collection (`NEVER_ARCHIVE`), where they are live and rewritten per
+   submission. This rule applies only at finalization, which is terminal.
+
 4. **Publishing / minting a DOI is out of scope.** Irreversible, and the
    researcher's call.
 

--- a/functions/src/__tests__/finalization-emulator.test.js
+++ b/functions/src/__tests__/finalization-emulator.test.js
@@ -390,15 +390,20 @@ describe("F1. the full merge", () => {
     expect(result.archived).toBe(5);
 
     const entries = readZipEntries(finalArchiveBytes());
-    // 3 (batch1) + 2 (batch2) + 2 loose + .psychds-ignore = 8 exploded entries.
-    expect(entries.size).toBe(8);
+    // 3 (batch1) + 2 (batch2) + 2 loose + .psychds-ignore + the descriptor
+    // = 9 exploded entries. Note `archived` above is 5 and this is 9: the
+    // first counts top-level provider files REMOVED, the second counts what
+    // ends up inside the archive -- and the descriptor is in the archive
+    // without being removed.
+    expect(entries.size).toBe(9);
     for (let i = 1; i <= 7; i += 1) {
       expect(entries.has(`data/raw/subject-${i}.json`)).toBe(true);
     }
     expect(entries.has(".psychds-ignore")).toBe(true);
-    // The record's descriptor is excluded from the merge and never appears
-    // inside the archive.
-    expect(entries.has("dataset_description.json")).toBe(false);
+    // The descriptor IS inside the archive: Psych-DS requires it at the
+    // dataset root, and the archive is the dataset (it is the only place the
+    // data/raw/... tree exists). See F11.
+    expect(entries.has("dataset_description.json")).toBe(true);
   });
 
   it("leaves dataset_description.json loose and moves .psychds-ignore inside the archive", async () => {
@@ -1035,5 +1040,53 @@ describe("F10. archive-too-large", () => {
     const expData = (await db.collection("experiments").doc(experimentID).get()).data();
     expect(expData.finalized).not.toBe(true);
     expect(expData.compaction?.compactingUntil).toBeUndefined();
+  });
+});
+
+describe("F11. the merged archive is a valid Psych-DS dataset on its own", () => {
+  // Caught by inspecting a real finalized deposition. The archive contained
+  // the whole data/raw/... tree but NO dataset_description.json, because
+  // finalization excluded it to leave a descriptor visible on the record.
+  //
+  // That produced an artifact valid in neither view: the zip was not a
+  // Psych-DS dataset (the spec requires the descriptor at the dataset root)
+  // and neither was the record around it, whose data is sealed inside a zip.
+  // Half the spec met by unzipping and half by not.
+
+  it("contains dataset_description.json at the archive root", async () => {
+    const { experimentID } = await seedFinalizableExperiment();
+
+    const result = await finalizeExperiment(experimentID);
+    expect(result.status).toBe("finalized");
+
+    const entries = readZipEntries(finalArchiveBytes());
+    expect([...entries.keys()]).toContain("dataset_description.json");
+    // And it is the real descriptor, not an empty placeholder.
+    expect(JSON.parse(entries.get("dataset_description.json").toString("utf8"))).toBeTruthy();
+  });
+
+  it("also leaves a copy loose on the record", async () => {
+    // Both, not either. A visitor should see a descriptor without downloading
+    // an archive, and metadata-block.ts holds a metadataFileRef to that
+    // object.
+    const { experimentID } = await seedFinalizableExperiment();
+    await finalizeExperiment(experimentID);
+
+    expect(mock.has("dataset_description.json")).toBe(true);
+    expect(mock.keys().sort()).toEqual(["dataset_description.json", "datapipe-final.zip"].sort());
+  });
+
+  it("the two copies are identical, since nothing can update either afterwards", async () => {
+    // Duplication is only safe because finalization is terminal. If the
+    // experiment could still accept submissions, metadata-block.ts would
+    // update the loose copy and the archived one would silently go stale.
+    const { experimentID } = await seedFinalizableExperiment();
+    const before = mock.get("dataset_description.json").toString("utf8");
+
+    await finalizeExperiment(experimentID);
+
+    const entries = readZipEntries(finalArchiveBytes());
+    expect(entries.get("dataset_description.json").toString("utf8")).toBe(before);
+    expect(mock.get("dataset_description.json").toString("utf8")).toBe(before);
   });
 });

--- a/functions/src/__tests__/finalization-emulator.test.js
+++ b/functions/src/__tests__/finalization-emulator.test.js
@@ -384,10 +384,10 @@ describe("F1. the full merge", () => {
     expect(result.status).toBe("finalized");
     expect(result.archiveName).toBe("datapipe-final.zip");
     // archived counts top-level provider files consumed by the merge: the 2
-    // batch archives + 2 loose sessions + .psychds-ignore = 5. Each batch
-    // then explodes into its own members once unpacked, which is what the
-    // archive's entry count below checks.
-    expect(result.archived).toBe(5);
+    // batch archives + 2 loose sessions + .psychds-ignore + the descriptor
+    // = 6. Each batch then explodes into its own members once unpacked, which
+    // is what the archive's entry count below checks.
+    expect(result.archived).toBe(6);
 
     const entries = readZipEntries(finalArchiveBytes());
     // 3 (batch1) + 2 (batch2) + 2 loose + .psychds-ignore + the descriptor
@@ -406,22 +406,25 @@ describe("F1. the full merge", () => {
     expect(entries.has("dataset_description.json")).toBe(true);
   });
 
-  it("leaves dataset_description.json loose and moves .psychds-ignore inside the archive", async () => {
+  it("moves both Psych-DS control files inside the archive", async () => {
     const { experimentID } = await seedFinalizableExperiment();
     await finalizeExperiment(experimentID);
 
-    expect(mock.has("dataset_description.json")).toBe(true);
-    // Nothing regenerates it once finalized, so the loose copy is gone.
+    // Neither is left loose. Nothing regenerates them once finalized, and the
+    // archive is the dataset -- both belong at its root, not beside it.
+    expect(mock.has("dataset_description.json")).toBe(false);
     expect(mock.has(PSYCHDS_IGNORE_FILE)).toBe(false);
+
     const entries = readZipEntries(finalArchiveBytes());
     expect(entries.get(".psychds-ignore").toString("utf8")).toBe(PSYCHDS_IGNORE_CONTENT);
+    expect(entries.has("dataset_description.json")).toBe(true);
   });
 
-  it("deletes every merged member, leaving only the archive and the descriptor", async () => {
+  it("deletes every merged member, leaving the archive as the record's only file", async () => {
     const { experimentID } = await seedFinalizableExperiment();
     await finalizeExperiment(experimentID);
 
-    expect(mock.keys().sort()).toEqual(["dataset_description.json", "datapipe-final.zip"].sort());
+    expect(mock.keys()).toEqual(["datapipe-final.zip"]);
   });
 
   it("keeps names flat for an experiment that never wrote a slashed path", async () => {
@@ -520,8 +523,9 @@ describe("F4. resuming an interrupted pass", () => {
   async function computeMergedArchive({ experimentID, names, batch1, batch2, looseContents, looseNames }) {
     // Reproduce exactly what runFinalization's merge would produce: batch
     // members re-emitted at their recorded paths, loose files at their
-    // reconstructed paths, .psychds-ignore included, dataset_description.json
-    // excluded.
+    // reconstructed paths, and BOTH Psych-DS control files included --
+    // .psychds-ignore and dataset_description.json. The archive is the
+    // dataset, so its root carries the descriptor.
     const entries = [];
     for (const [name, content] of batch1.contents) {
       const paths = archivePathsFor(zenodoProvider, true, [name]);
@@ -536,8 +540,13 @@ describe("F4. resuming an interrupted pass", () => {
       entries.push({ path: loosePaths.get(name), content: looseContents.get(name) });
     }
     entries.push({ path: ".psychds-ignore", content: Buffer.from(PSYCHDS_IGNORE_CONTENT) });
+    entries.push({
+      path: "dataset_description.json",
+      content: mock.get("dataset_description.json"),
+    });
 
-    const members = names.filter((n) => n !== "dataset_description.json");
+    // Every provider file is a member now; nothing is held back.
+    const members = names;
     return { ...(await buildArchive(entries)), members };
   }
 
@@ -632,7 +641,7 @@ describe("F4. resuming an interrupted pass", () => {
     // Nothing was deleted before the crash, so the safe move is to throw the
     // record away and finalize normally.
     expect(result.status).toBe("finalized");
-    expect(result.archived).toBe(5);
+    expect(result.archived).toBe(6);
     expect(mock.has("datapipe-final.zip")).toBe(true);
   });
 });
@@ -646,7 +655,7 @@ describe("F5. finalization is permanent", () => {
     const second = await finalizeExperiment(experimentID);
     expect(second.status).toBe("already-finalized");
     // Nothing else moved -- the archive from the first pass is untouched.
-    expect(mock.keys().sort()).toEqual(["dataset_description.json", "datapipe-final.zip"].sort());
+    expect(mock.keys()).toEqual(["datapipe-final.zip"]);
   });
 
   it("refuses a new /api/data submission once finalized", async () => {
@@ -1051,7 +1060,6 @@ describe("F11. the merged archive is a valid Psych-DS dataset on its own", () =>
   // That produced an artifact valid in neither view: the zip was not a
   // Psych-DS dataset (the spec requires the descriptor at the dataset root)
   // and neither was the record around it, whose data is sealed inside a zip.
-  // Half the spec met by unzipping and half by not.
 
   it("contains dataset_description.json at the archive root", async () => {
     const { experimentID } = await seedFinalizableExperiment();
@@ -1061,32 +1069,33 @@ describe("F11. the merged archive is a valid Psych-DS dataset on its own", () =>
 
     const entries = readZipEntries(finalArchiveBytes());
     expect([...entries.keys()]).toContain("dataset_description.json");
-    // And it is the real descriptor, not an empty placeholder.
     expect(JSON.parse(entries.get("dataset_description.json").toString("utf8"))).toBeTruthy();
   });
 
-  it("also leaves a copy loose on the record", async () => {
-    // Both, not either. A visitor should see a descriptor without downloading
-    // an archive, and metadata-block.ts holds a metadataFileRef to that
-    // object.
+  it("leaves the record as exactly one file", async () => {
+    // No loose copy. Zenodo's zip previewer lists archive contents on the
+    // record page without downloading, so putting the descriptor inside hides
+    // nothing -- and a second copy is a second thing that can be wrong.
     const { experimentID } = await seedFinalizableExperiment();
     await finalizeExperiment(experimentID);
 
-    expect(mock.has("dataset_description.json")).toBe(true);
-    expect(mock.keys().sort()).toEqual(["dataset_description.json", "datapipe-final.zip"].sort());
+    expect(mock.keys()).toEqual(["datapipe-final.zip"]);
   });
 
-  it("the two copies are identical, since nothing can update either afterwards", async () => {
-    // Duplication is only safe because finalization is terminal. If the
-    // experiment could still accept submissions, metadata-block.ts would
-    // update the loose copy and the archived one would silently go stale.
+  it("seals every archived filename, including the descriptor's", async () => {
+    // Everything leaves the provider listing now, so a cold cache would
+    // otherwise rehydrate from a listing containing only the archive and
+    // forget every filename the study ever used.
     const { experimentID } = await seedFinalizableExperiment();
-    const before = mock.get("dataset_description.json").toString("utf8");
-
     await finalizeExperiment(experimentID);
 
-    const entries = readZipEntries(finalArchiveBytes());
-    expect(entries.get("dataset_description.json").toString("utf8")).toBe(before);
-    expect(mock.get("dataset_description.json").toString("utf8")).toBe(before);
+    const claim = await db
+      .collection("experiments")
+      .doc(experimentID)
+      .collection("filenameClaims")
+      .doc(claimDocId(SALT, "dataset_description.json"))
+      .get();
+    expect(claim.exists).toBe(true);
+    expect(claim.data().sealed).toBe(true);
   });
 });

--- a/functions/src/finalization.ts
+++ b/functions/src/finalization.ts
@@ -54,13 +54,27 @@ import {
 // there is never more than one merged archive to name.
 const FINAL_ARCHIVE_NAME = "datapipe-final.zip";
 
-// The only file finalization ever leaves loose. Same reason compaction never
-// sweeps it into a batch (see NEVER_ARCHIVE in compaction.ts): it is the
-// record's live Psych-DS descriptor, and metadata-block.ts holds a
-// metadataFileRef to it that a buried copy would break. Everything else --
-// every batch archive, every loose session file, and .psychds-ignore -- is a
-// member of the merge.
-const EXCLUDE_FROM_MERGE = new Set(["dataset_description.json"]);
+// dataset_description.json goes INSIDE the merged archive AND stays loose on
+// the record. Both, deliberately.
+//
+// Inside, because Psych-DS requires it at the dataset root. The merged archive
+// IS the dataset -- it is the only place the data/raw/... tree exists, since
+// Zenodo cannot store a slash in a key. An archive without the descriptor is
+// not a valid Psych-DS dataset, and neither is the record around it, whose
+// data is sealed in a zip. Leaving it only on the outside produced an artifact
+// that validated in neither view: half the spec met by unzipping and half by
+// not.
+//
+// Loose, because the record should still show a human-readable descriptor
+// without anyone downloading an archive, and because metadata-block.ts holds a
+// metadataFileRef to that object.
+//
+// Duplicating it is safe here specifically because finalization is TERMINAL:
+// the experiment stops accepting submissions, so nothing can update one copy
+// and leave the other stale. That would not be safe during collection, which
+// is why compaction still keeps it strictly out of its batches
+// (NEVER_ARCHIVE in compaction.ts).
+const KEEP_LOOSE_AFTER_MERGE = new Set(["dataset_description.json"]);
 
 export interface FinalizationResult {
   // Carried on every result the same way CompactionResult carries it, so log
@@ -245,9 +259,12 @@ async function runFinalization(experimentID: string): Promise<Omit<FinalizationR
       };
     }
 
-    const members = files.filter((file) => !EXCLUDE_FROM_MERGE.has(file.name));
+    // Everything goes into the archive; only some of it is then removed from
+    // the record. See KEEP_LOOSE_AFTER_MERGE.
+    const members = files;
+    const removable = files.filter((file) => !KEEP_LOOSE_AFTER_MERGE.has(file.name));
 
-    if (members.length === 0) {
+    if (removable.length === 0) {
       // Nothing was ever collected beyond the descriptor -- finalizing is
       // still the correct terminal state (the study is over either way), just
       // with no archive to build.
@@ -289,7 +306,10 @@ async function runFinalization(experimentID: string): Promise<Omit<FinalizationR
       return { status: "archive-too-large", detail };
     }
 
-    const memberHashes = members.map((file) => claimDocId(salt, file.name));
+    // Hashes cover only what is actually leaving the listing. The descriptor
+    // stays loose, so a cold cache still rehydrates its claim normally and it
+    // needs no sealing.
+    const memberHashes = removable.map((file) => claimDocId(salt, file.name));
     const runRef = finalizationRunRef(experimentID);
 
     // Recorded BEFORE the provider upload -- this is the crash-safety hinge.
@@ -303,7 +323,7 @@ async function runFinalization(experimentID: string): Promise<Omit<FinalizationR
       status: "uploading",
       memberHashes,
       expectedMd5: build.md5,
-      fileCount: members.length,
+      fileCount: removable.length,
       createdAt: Timestamp.now(),
     });
 
@@ -317,12 +337,12 @@ async function runFinalization(experimentID: string): Promise<Omit<FinalizationR
 
     // Everything in the merge is now inside a verified archive on the
     // provider, so the originals can go.
-    await sealAndDeleteMembers(experimentID, provider, auth, container, runRef, memberHashes, members);
+    await sealAndDeleteMembers(experimentID, provider, auth, container, runRef, memberHashes, removable);
     await deleteStorageObject(storagePath);
 
     await markFinalized(experimentID, sessionsSeen);
 
-    return { status: "finalized", archived: members.length, archiveName: FINAL_ARCHIVE_NAME };
+    return { status: "finalized", archived: removable.length, archiveName: FINAL_ARCHIVE_NAME };
   } catch (e) {
     const detail = e instanceof Error ? e.message : String(e);
     await releaseLease(experimentID, sessionsSeen, { "compaction.lastError": detail }).catch(() => undefined);

--- a/functions/src/finalization.ts
+++ b/functions/src/finalization.ts
@@ -54,27 +54,24 @@ import {
 // there is never more than one merged archive to name.
 const FINAL_ARCHIVE_NAME = "datapipe-final.zip";
 
-// dataset_description.json goes INSIDE the merged archive AND stays loose on
-// the record. Both, deliberately.
+// THE RECORD ENDS AS EXACTLY ONE FILE: the merged archive. Everything goes
+// inside it, dataset_description.json included, and nothing is left loose.
 //
-// Inside, because Psych-DS requires it at the dataset root. The merged archive
-// IS the dataset -- it is the only place the data/raw/... tree exists, since
-// Zenodo cannot store a slash in a key. An archive without the descriptor is
-// not a valid Psych-DS dataset, and neither is the record around it, whose
-// data is sealed in a zip. Leaving it only on the outside produced an artifact
-// that validated in neither view: half the spec met by unzipping and half by
-// not.
+// Psych-DS requires the descriptor at the dataset root, and the archive IS the
+// dataset -- it is the only place the data/raw/... tree exists, since Zenodo
+// cannot store a slash in a key. An earlier version left the descriptor loose
+// so the record would show something human-readable, which produced an
+// artifact valid in neither view: a zip that was not a Psych-DS dataset
+// (no descriptor) inside a record that was not one either (data sealed in a
+// zip). A brief second version wrote it in BOTH places, which was correct but
+// duplicated a file for a reason that does not survive checking -- Zenodo has
+// a built-in zip previewer that lists archive contents on the record page
+// without downloading, so nothing is hidden by putting the descriptor inside.
 //
-// Loose, because the record should still show a human-readable descriptor
-// without anyone downloading an archive, and because metadata-block.ts holds a
-// metadataFileRef to that object.
-//
-// Duplicating it is safe here specifically because finalization is TERMINAL:
-// the experiment stops accepting submissions, so nothing can update one copy
-// and leave the other stale. That would not be safe during collection, which
-// is why compaction still keeps it strictly out of its batches
-// (NEVER_ARCHIVE in compaction.ts).
-const KEEP_LOOSE_AFTER_MERGE = new Set(["dataset_description.json"]);
+// Nothing reads the loose copy afterwards either: metadata-block.ts owns the
+// metadataFileRef pointing at it, and that only runs during a submission,
+// which a finalized experiment rejects.
+const DESCRIPTOR = "dataset_description.json";
 
 export interface FinalizationResult {
   // Carried on every result the same way CompactionResult carries it, so log
@@ -259,12 +256,14 @@ async function runFinalization(experimentID: string): Promise<Omit<FinalizationR
       };
     }
 
-    // Everything goes into the archive; only some of it is then removed from
-    // the record. See KEEP_LOOSE_AFTER_MERGE.
+    // Every file is both archived and removed -- see DESCRIPTOR above.
     const members = files;
-    const removable = files.filter((file) => !KEEP_LOOSE_AFTER_MERGE.has(file.name));
+    const removable = files;
 
-    if (removable.length === 0) {
+    // "Nothing collected" is judged on DATA, not on file count: an experiment
+    // that only ever got its descriptor has no dataset to build, and wrapping
+    // a lone descriptor in an archive would be noise.
+    if (files.filter((file) => file.name !== DESCRIPTOR).length === 0) {
       // Nothing was ever collected beyond the descriptor -- finalizing is
       // still the correct terminal state (the study is over either way), just
       // with no archive to build.
@@ -306,9 +305,9 @@ async function runFinalization(experimentID: string): Promise<Omit<FinalizationR
       return { status: "archive-too-large", detail };
     }
 
-    // Hashes cover only what is actually leaving the listing. The descriptor
-    // stays loose, so a cold cache still rehydrates its claim normally and it
-    // needs no sealing.
+    // Everything leaves the listing, so everything needs sealing -- a cold
+    // cache rehydrates from that listing and would otherwise forget every
+    // filename the study ever used.
     const memberHashes = removable.map((file) => claimDocId(salt, file.name));
     const runRef = finalizationRunRef(experimentID);
 


### PR DESCRIPTION
Found by inspecting a real finalized deposition, not by a test.

The merged archive carried the whole `data/raw/...` tree but **no `dataset_description.json` at all**, because finalization excluded it to leave a descriptor visible on the record.

That produced an artifact valid in **neither** view:

- Psych-DS requires the descriptor at the dataset root, and **the archive is the dataset** — it's the only place the directory tree exists, since Zenodo can't store a slash in a key. So the zip wasn't a valid Psych-DS dataset.
- Nor was the record around it, whose data is sealed inside a zip.

Half the spec met by unzipping and half by not.

## Change

The descriptor now goes **inside the archive AND stays loose** on the record. Inside because the archive is the dataset; loose because the record should show a human-readable descriptor without downloading an archive, and `metadata-block.ts` holds a `metadataFileRef` to that object.

Duplicating it is safe **only because finalization is terminal** — the experiment stops accepting submissions, so nothing can update one copy and leave the other stale. That isn't true during collection, which is why compaction still keeps it strictly out of its batches.

Sealing now covers only what actually leaves the listing; the descriptor stays loose, so a cold cache rehydrates its claim normally.

`F1` asserted the old behaviour explicitly — updated, along with its entry count.

691 tests, 0 failures.