### PR TITLE
fix: queue derived Psych-DS files when a submission is diverted

### DIFF
--- a/functions/src/api-data.ts
+++ b/functions/src/api-data.ts
@@ -260,6 +260,11 @@ export const apiData = onRequest({ cors: true, memory: "512MiB", concurrency: 1 
       });
       await exp_doc_ref.set({ sessions: FieldValue.increment(1) }, { merge: true });
       await cleanupPending(pendingPath); // queue-upload has its own copy
+      // Same reasoning as the compaction-gate branch below: without this the
+      // session's derived tables are never generated at all. Pre-dates the
+      // gate and is far rarer (a rehydration lease lasts 60 seconds), but it
+      // is the identical hole.
+      await queueDerivedFiles(derivedFiles, derivedTarget, "Collision cache rehydrating");
       res.status(202).json({...MESSAGES.OSF_UPLOAD_QUEUED, metadataMessage});
       await writeLog(experimentID, "logError", {...MESSAGES.OSF_UPLOAD_EXCEPTION, detail: "Collision cache rehydrating"});
       return;
@@ -292,6 +297,15 @@ export const apiData = onRequest({ cors: true, memory: "512MiB", concurrency: 1 
       });
       await exp_doc_ref.set({ sessions: FieldValue.increment(1) }, { merge: true });
       await cleanupPending(pendingPath); // queue-upload has its own copy
+      // The derived Psych-DS tables have to be queued too. The retry worker
+      // only writes back what is in the queue -- it never re-runs the metadata
+      // pipeline -- so queueing the raw file alone means this session's
+      // data/<base>_data.csv is never produced at all. The raw file is the
+      // source of truth and no submitted data is lost either way, but the
+      // dataset ends up missing derived tables for every session the gate
+      // diverted, which is a Psych-DS dataset with holes in it. Observed live:
+      // 44 loose raw sessions against 10 derived CSVs.
+      await queueDerivedFiles(derivedFiles, derivedTarget, COMPACTION_HOLD_REASON, "CONTENTION");
       res.status(202).json({...MESSAGES.OSF_UPLOAD_QUEUED, metadataMessage});
       return;
     } catch {

--- a/scripts/live-check.mjs
+++ b/scripts/live-check.mjs
@@ -247,6 +247,32 @@ async function main() {
     );
   }
 
+  // ---- 5c. does every session still have its derived Psych-DS table? ----
+  // A submission the write gate diverts is queued and written back later by
+  // the retry worker -- which only writes what is IN the queue and never
+  // re-runs the metadata pipeline. Queueing the raw file alone therefore
+  // leaves that session with no data/<base>_data.csv, permanently. No
+  // submitted data is lost (the raw file is the source of truth) but the
+  // dataset is a Psych-DS dataset with holes in it, and nothing errors.
+  //
+  // Observed live 2026-08-20 before the fix: 44 loose raw sessions against 10
+  // derived CSVs. Emulator coverage for this needs the deployed function to
+  // reach a provider mock through the metadata block, which is exactly the
+  // wiring this script exists to avoid -- so the assertion lives here.
+  if (ZTOKEN && DEPOSITION) {
+    const files = await listDeposition();
+    const raw = files.filter((n) => n.startsWith("data_raw_"));
+    const csv = files.filter((n) => n.startsWith("data_") && !n.startsWith("data_raw_"));
+    record(
+      "5c. derived tables kept pace with raw sessions",
+      raw.length === csv.length ? "PASS" : "FAIL",
+      `${raw.length} loose raw session(s), ${csv.length} loose derived CSV(s)` +
+        (raw.length === csv.length
+          ? ""
+          : "  <-- sessions without a derived table; a diverted submission did not queue its Psych-DS files")
+    );
+  }
+
   // ---- 6. finalize ------------------------------------------------------
   if (ID_TOKEN) {
     const res = await fetch(`${BASE}/api/finalize`, {


### PR DESCRIPTION
Found on a live run: the deposition showed **44 loose raw sessions against 10 derived CSVs** — 44 sessions with no `data/<base>_data.csv` at all.

The compaction write gate queued the raw file and nothing else, and the retry worker only writes back what's *in* the queue — it never re-runs the metadata pipeline. So every session the gate diverted lost its derived Psych-DS tables permanently.

No submitted data was lost (the raw file is the source of truth), but the dataset ends up with holes in exactly the format this feature exists to produce, and **nothing errors while it happens**.

## Also fixed: the same hole next door

The two provider-failure branches beside it already call `queueDerivedFiles`. The gate branch was written from the collision-cache-rehydrating branch, which doesn't — so that one has the identical bug. It pre-dates the gate and is far rarer (a rehydration lease lasts 60s), but it's the same failure, so it's fixed here too.

## Why the assertion is in `live-check.mjs`, not the emulator suite

I tried the emulator route first. Covering it there needs the *deployed* function to reach a provider mock through the metadata block — which means proxying the shared 3581 port and then satisfying the SSRF origin check on a Firestore-supplied bucket URL. Three layers of fixture between the test and the one line it proves, and I was still debugging fixture problems rather than the behaviour.

The live script already talks to a real deployment, which is where the bug appeared and where the ratio is directly observable. The new `5c` step fails if loose raw sessions and loose derived CSVs don't match.

691 tests, 0 failures.