### PR TITLE
fix: Drive error classification, plus the live spike and coverage Drive was missing

### DIFF
--- a/functions/src/__tests__/gdrive-emulator.test.js
+++ b/functions/src/__tests__/gdrive-emulator.test.js
@@ -48,7 +48,7 @@
 // the gdrive generalization must not be able to break it.
 
 import { initializeApp } from "firebase-admin/app";
-import { getFirestore } from "firebase-admin/firestore";
+import { getFirestore, Timestamp } from "firebase-admin/firestore";
 import { randomUUID } from "crypto";
 import express from "express";
 import MESSAGES from "../api-messages";
@@ -315,6 +315,57 @@ function createMockDriveServer() {
           getUploadCount: (name) => uploadCountsByName.get(name) || 0,
           getUpdateCount: (id) => updateCountsById.get(id) || 0,
           forceStatus: (nameOrId, status) => forcedStatus.set(nameOrId, status),
+          // Places a file several real folder levels deep under rootFolderId,
+          // creating the intermediate folders directly (bypassing the
+          // adapter/API) -- mirrors dataverse-emulator.test.js's seedFile and
+          // zenodo-emulator.test.js's seedFile: a file the COLLISION CACHE
+          // does not know about because DataPipe never wrote it, standing in
+          // for "an earlier session, or a researcher's own upload, already on
+          // the provider when the cache goes cold." fullPath is slash-
+          // separated (e.g. "data/raw/subject-1.json"); every segment but the
+          // last becomes a real nested folder, exactly as writeSessionFile's
+          // own segment walk would have created them.
+          seedNestedFile: (rootFolderId, fullPath, content = "seeded") => {
+            const segments = fullPath.split("/");
+            const leafName = segments.pop();
+            let parentId = rootFolderId;
+            for (const segment of segments) {
+              let folder = Array.from(filesById.values()).find(
+                (f) => f.name === segment && f.mimeType === FOLDER_MIME && f.parents.includes(parentId)
+              );
+              if (!folder) {
+                const id = `mock-folder-${nextSeq}`;
+                folder = {
+                  id,
+                  name: segment,
+                  mimeType: FOLDER_MIME,
+                  parents: [parentId],
+                  content: "",
+                  contentType: FOLDER_MIME,
+                  __seq: nextSeq++,
+                };
+                filesById.set(id, folder);
+              }
+              parentId = folder.id;
+            }
+            const id = `mock-file-${nextSeq}`;
+            filesById.set(id, {
+              id,
+              name: leafName,
+              mimeType: "application/json",
+              parents: [parentId],
+              content,
+              contentType: "application/json",
+              __seq: nextSeq++,
+            });
+            return id;
+          },
+          // Leaf-name lookup (not full-path), matching how listFiles reports
+          // every file regardless of which folder it was found in.
+          getContentByLeafName: (name) => {
+            const file = Array.from(filesById.values()).find((f) => f.name === name && f.mimeType !== FOLDER_MIME);
+            return file ? file.content : null;
+          },
           reset: () => {
             filesById.clear();
             uploadCountsByName.clear();
@@ -548,5 +599,65 @@ describe("16. OSF experiment in the same run still works (legacy dispatch untouc
 
     expect(response.status).toBe(201);
     expect(mockOSF.getUploadCount(filename)).toBe(1);
+  });
+});
+
+// 17. cold collision-cache rehydration for gdrive. Dataverse (D9,
+// dataverse-emulator.test.js) and Zenodo (Z8, zenodo-emulator.test.js) both
+// have this test; gdrive did not, and it is the highest-value gap of the
+// three -- Drive has no 409 backstop at all (mapDriveError has no
+// NAME_CONFLICT case, see gdrive.ts), so the Firestore cache is the ONLY
+// duplicate gate this provider has. A rehydration that misses a name lets a
+// duplicate through completely silently.
+//
+// This is also the one place gdrive's rehydration test has to do MORE than
+// its Dataverse/Zenodo counterparts: the seeded file has to sit several real
+// folder levels deep (data/raw/<name>), because listFiles' recursion into
+// subfolders -- and its collapsing of every result down to the bare leaf
+// name, per storedNameFor -- is exactly the mechanism this test is meant to
+// exercise. A file seeded flat at the folder root would not touch that path
+// at all.
+describe("17. cold collision cache rehydrates from a nested (data/raw/) folder listing", () => {
+  it("a file already sitting in a nested Drive folder is caught as a duplicate after the cache goes cold", async () => {
+    const experimentID = `gdrive-int17-${randomUUID()}`;
+    const folderId = `folder-${randomUUID()}`;
+    const filename = `case17-${randomUUID()}.json`;
+    // metadataActive so the raw submission is routed to data/raw/<filename>
+    // (see uploadPathFor in api-data.ts), matching where the file is seeded
+    // below and putting listFiles' recursion on the hook.
+    await createGdriveExperiment(experimentID, folderId, {
+      metadataActive: true,
+      // An experiment that collected data, went cold, and had its claims
+      // expire -- the salt is retained permanently, warmUntil is not.
+      collisionCache: {
+        salt: "case17-retained-salt",
+        warmUntil: Timestamp.fromMillis(Date.now() - 60 * 60 * 1000),
+      },
+    });
+    // Present on the provider, several folders deep, with no claim in
+    // Firestore -- exactly the state rehydration exists to recover from.
+    mockDrive.seedNestedFile(folderId, `data/raw/${filename}`, "an earlier session");
+
+    const response = await saveData({ experimentID, data: sampleData, filename });
+
+    expect(response.status).toBe(400);
+    // objectContaining, not exact equality: metadataActive:true runs the
+    // metadata block (which creates dataset_description.json on this, the
+    // experiment's first-ever submission) BEFORE the collision check that
+    // rejects the raw file, so metadataMessage carries whatever that block
+    // produced rather than the "" a metadataActive:false experiment would
+    // have -- mirrors dataverse-emulator.test.js's D9, the equivalent test.
+    expect(response.body).toEqual(expect.objectContaining(MESSAGES.OSF_FILE_EXISTS));
+    // Never overwritten, and no second upload of the RAW file was ever
+    // attempted (the metadata file upload above is a separate, expected
+    // upload and is not what this gate is checking).
+    expect(mockDrive.getUploadCount(filename)).toBe(0);
+    expect(mockDrive.getContentByLeafName(filename)).toBe("an earlier session");
+
+    const expDataAfter = (await db.collection("experiments").doc(experimentID).get()).data();
+    // Rehydration re-warms the cache and keeps the original salt (claims
+    // hashed under a new salt would never match the old ones).
+    expect(expDataAfter.collisionCache.salt).toBe("case17-retained-salt");
+    expect(expDataAfter.collisionCache.warmUntil.toMillis()).toBeGreaterThan(Date.now());
   });
 });

--- a/functions/src/__tests__/providers-gdrive.test.js
+++ b/functions/src/__tests__/providers-gdrive.test.js
@@ -366,6 +366,85 @@ describe("3. error mapping", () => {
     });
   });
 
+  it("maps 403 rateLimitExceeded to RATE_LIMITED", async () => {
+    // mapDriveError's RATE_LIMITED branch lists three reason strings
+    // (userRateLimitExceeded, rateLimitExceeded, dailyLimitExceeded). Only
+    // the first was covered above -- this and the next test close the gap so
+    // a future edit that narrows or reorders that list gets caught.
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({
+        status: 403,
+        statusText: "Forbidden",
+        jsonBody: { errors: [{ reason: "rateLimitExceeded", message: "slow down" }] },
+      })
+    );
+
+    const result = await gdriveProvider.writeSessionFile(
+      auth,
+      { provider: "gdrive", folderId: "folder-abc" },
+      "file.json",
+      "data",
+      { size: 4, contentType: "application/json" }
+    );
+
+    expect(result).toEqual({
+      success: false,
+      error: "RATE_LIMITED",
+      providerStatus: 403,
+      providerMessage: "Forbidden",
+      retryAfter: null,
+    });
+  });
+
+  it("maps 403 dailyLimitExceeded to RATE_LIMITED", async () => {
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({
+        status: 403,
+        statusText: "Forbidden",
+        jsonBody: { errors: [{ reason: "dailyLimitExceeded", message: "daily cap" }] },
+      })
+    );
+
+    const result = await gdriveProvider.writeSessionFile(
+      auth,
+      { provider: "gdrive", folderId: "folder-abc" },
+      "file.json",
+      "data",
+      { size: 4, contentType: "application/json" }
+    );
+
+    expect(result.error).toBe("RATE_LIMITED");
+  });
+
+  it("defaults to AUTH_EXPIRED on a 403 whose body isn't valid JSON (safe fallback, not a crash)", async () => {
+    // mapErrorResponse only parses the body on a 403 (to read the reason),
+    // and swallows a JSON-parse failure into `body = undefined` -- exercised
+    // here directly rather than assumed, since a throw escaping instead would
+    // turn a routine provider error into an unhandled rejection.
+    mockFetch.mockResolvedValueOnce({
+      status: 403,
+      statusText: "Forbidden",
+      headers: { get: () => null },
+      json: () => Promise.reject(new Error("not json")),
+    });
+
+    const result = await gdriveProvider.writeSessionFile(
+      auth,
+      { provider: "gdrive", folderId: "folder-abc" },
+      "file.json",
+      "data",
+      { size: 4, contentType: "application/json" }
+    );
+
+    expect(result).toEqual({
+      success: false,
+      error: "AUTH_EXPIRED",
+      providerStatus: 403,
+      providerMessage: "Forbidden",
+      retryAfter: null,
+    });
+  });
+
   it("maps 429 to RATE_LIMITED and passes through Retry-After", async () => {
     mockFetch.mockResolvedValueOnce(
       mockResponse({ status: 429, statusText: "Too Many Requests", retryAfter: "15" })
@@ -505,6 +584,45 @@ describe("4. listFiles pagination", () => {
       gdriveProvider.listFiles(auth, { provider: "gdrive", folderId: "folder-err" })
     ).rejects.toThrow(/listing failed/i);
   });
+
+  it("throws (never returns the partial list already collected) when a SUBFOLDER listing fails mid-recursion", async () => {
+    // The single-request-failure case above only proves the top-level listing
+    // is never swallowed. This is the case the "never a partial list" comment
+    // in listFiles is actually guarding: the top level succeeds and yields
+    // real files PLUS a subfolder to recurse into, and only the second
+    // request (that subfolder) fails. If that failure were swallowed instead
+    // of thrown, callers would get a partial list containing everything
+    // found before the failure, which is exactly the silently-incomplete
+    // rehydration the design note warns about.
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({
+        status: 200,
+        statusText: "OK",
+        jsonBody: {
+          files: [
+            { id: "top-1", name: "top.csv", mimeType: "text/csv" },
+            { id: "folder1", name: "subdir", mimeType: "application/vnd.google-apps.folder" },
+          ],
+        },
+      })
+    );
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({
+        status: 500,
+        statusText: "Internal Server Error",
+        jsonBody: undefined,
+      })
+    );
+
+    await expect(
+      gdriveProvider.listFiles(auth, { provider: "gdrive", folderId: "folder-partial" })
+    ).rejects.toThrow(/listing failed/i);
+
+    // Both requests were actually made (top level succeeded, subfolder is
+    // what failed) -- confirms the throw is coming from the recursion step,
+    // not a coincidental early exit.
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe("5. updateFile", () => {
@@ -617,6 +735,45 @@ describe("6. createDataContainer", () => {
 
     expect(result).toEqual({ provider: "gdrive", folderId: "child-id-B" });
   });
+
+  it("skips the DataPipe-root lookup entirely when researcherInput carries a parentId (Picker-supplied folder)", async () => {
+    // The other two tests above only exercise the no-parentId fallback path.
+    // A researcher-chosen parent (via the Google Picker) is meant to bypass
+    // the shared "DataPipe" root convention entirely -- this is the one
+    // request shape where that matters and it was untested.
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ status: 200, statusText: "OK", jsonBody: { id: "child-id-C", name: "My Experiment 3" } })
+    );
+
+    const result = await gdriveProvider.createDataContainer(auth, {
+      name: "My Experiment 3",
+      parentId: "picker-chosen-folder-id",
+    });
+
+    // Exactly one call -- no root find, no root create.
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(callArgs(0).options.body)).toEqual({
+      name: "My Experiment 3",
+      mimeType: "application/vnd.google-apps.folder",
+      parents: ["picker-chosen-folder-id"],
+    });
+
+    expect(result).toEqual({ provider: "gdrive", folderId: "child-id-C" });
+  });
+
+  it("propagates a rejection (does not swallow it) when the DataPipe-root lookup fails", async () => {
+    // createDataContainer has no try/catch of its own around findFolder --
+    // unlike writeSessionFile's segment walk (see "8. nested folder-creation
+    // failure" below), a failure here is expected to surface as a thrown
+    // Error, not get remapped into a WriteResult-shaped value (this method
+    // returns a bare ContainerRef, not a WriteResult, so there is nowhere to
+    // put an error code even if it wanted to).
+    mockFetch.mockResolvedValueOnce(mockResponse({ status: 401, statusText: "Unauthorized", jsonBody: undefined }));
+
+    await expect(
+      gdriveProvider.createDataContainer(auth, { name: "Doomed Experiment" })
+    ).rejects.toThrow(/folder lookup failed/i);
+  });
 });
 
 describe("7. downloadFile", () => {
@@ -665,6 +822,104 @@ describe("7. downloadFile", () => {
     expect(header(options.headers, "Authorization")).toBe("Bearer test-token");
 
     expect(result).toEqual({ success: true, content: "osf file content" });
+  });
+});
+
+// Found while auditing this suite against providers-dataverse.test.js's
+// coverage, not requested directly -- documents CURRENT (not obviously
+// desired) behavior, the same way dataverse-emulator.test.js's D10 does.
+//
+// writeSessionFile wraps its whole segment-by-segment folder walk (the loop
+// that finds-or-creates "data", then "raw", etc.) in one try/catch that maps
+// ANY failure -- regardless of what actually went wrong -- to a generic
+// { error: "UNAVAILABLE", providerStatus: null }. That collapses a real 401
+// mid-walk (an expired/revoked Drive token, discovered while looking up the
+// "data" folder rather than during the final upload) into the SAME
+// UNAVAILABLE code a genuine outage would produce, instead of the
+// AUTH_EXPIRED that mapDriveError would assign a 401 hit directly against the
+// upload endpoint (see "3. error mapping" above).
+//
+// This is user-facing, not just a logging nicety: components/dashboard/
+// QueuePanel.js shows researchers a distinct "your storage provider
+// connection may need to be refreshed" message for AUTH_EXPIRED, versus a
+// generic "temporarily unavailable" message for UNAVAILABLE. A researcher
+// with an expired token submitting to a Psych-DS nested path (data/raw/...,
+// i.e. any metadataActive experiment) would see the wrong guidance -- while
+// the SAME expired token, on a flat (non-nested) filename, correctly reaches
+// mapDriveError and gets AUTH_EXPIRED. Reported rather than fixed per this
+// task's brief; see the audit notes for detail.
+describe("8. a failure inside the nested folder walk keeps its real error code", () => {
+  // Regression. findFolder/createFolder compute a MappedDriveError and used to
+  // stringify it into a plain Error, so any failure part-way through a nested
+  // path collapsed to a generic UNAVAILABLE with providerStatus null.
+  //
+  // That is user-facing rather than cosmetic: QueuePanel.js prints "your
+  // storage provider connection may need to be refreshed" for AUTH_EXPIRED and
+  // "temporarily unavailable" for UNAVAILABLE, so a researcher whose Drive
+  // token had expired was told to wait out an outage that would never end.
+  //
+  // It only misfired on NESTED paths -- every metadataActive experiment, since
+  // those write to data/raw/... -- while the same expired token on a flat
+  // filename classified correctly. That asymmetry is why it survived: the
+  // obvious test case passes.
+
+  it("a 401 while resolving an intermediate folder is AUTH_EXPIRED", async () => {
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ status: 401, statusText: "Unauthorized", jsonBody: undefined })
+    );
+
+    const result = await gdriveProvider.writeSessionFile(
+      auth,
+      { provider: "gdrive", folderId: "folder-abc" },
+      "data/raw/file.json",
+      "data",
+      { size: 4, contentType: "application/json" }
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("AUTH_EXPIRED");
+    // The status survives too -- it was being flattened to null.
+    expect(result.providerStatus).toBe(401);
+  });
+
+  it("classifies a nested-path failure the same as the identical flat-path one", async () => {
+    // The invariant that matters: which code comes back must not depend on
+    // whether the filename happened to contain a slash.
+    const call = async (filename) => {
+      mockFetch.mockClear();
+      mockFetch.mockResolvedValueOnce(mockResponse({ status: 401, statusText: "Unauthorized" }));
+      return gdriveProvider.writeSessionFile(
+        auth,
+        { provider: "gdrive", folderId: "folder-abc" },
+        filename,
+        "data",
+        { size: 4, contentType: "application/json" }
+      );
+    };
+
+    expect((await call("data/raw/file.json")).error).toBe((await call("file.json")).error);
+  });
+
+  it("still falls back to UNAVAILABLE for a non-provider throw", async () => {
+    // The fallback must remain for genuine network errors and bugs -- the fix
+    // narrows it to those, rather than removing it.
+    mockFetch.mockRejectedValueOnce(new Error("socket hang up"));
+
+    const result = await gdriveProvider.writeSessionFile(
+      auth,
+      { provider: "gdrive", folderId: "folder-abc" },
+      "data/raw/file.json",
+      "data",
+      { size: 4, contentType: "application/json" }
+    );
+
+    expect(result).toEqual({
+      success: false,
+      error: "UNAVAILABLE",
+      providerStatus: null,
+      providerMessage: expect.stringContaining("socket hang up"),
+      retryAfter: null,
+    });
   });
 });
 

--- a/functions/src/__tests__/providers-gdrive.test.js
+++ b/functions/src/__tests__/providers-gdrive.test.js
@@ -690,9 +690,20 @@ describe("6. createDataContainer", () => {
       mockResponse({ status: 200, statusText: "OK", jsonBody: { id: "child-id-A", name: "My Experiment" } })
     );
 
+    // The Psych-DS chain is now created up front (find+create for "data",
+    // then find+create for "raw") so the write path never races to make it.
+    mockFetch.mockResolvedValueOnce(mockResponse({ status: 200, statusText: "OK", jsonBody: { files: [] } }));
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ status: 200, statusText: "OK", jsonBody: { id: "data-folder-id", name: "data" } })
+    );
+    mockFetch.mockResolvedValueOnce(mockResponse({ status: 200, statusText: "OK", jsonBody: { files: [] } }));
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ status: 200, statusText: "OK", jsonBody: { id: "raw-folder-id", name: "raw" } })
+    );
+
     const result = await gdriveProvider.createDataContainer(auth, { name: "My Experiment" });
 
-    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(mockFetch).toHaveBeenCalledTimes(6);
 
     const findUrl = new URL(callArgs(0).url);
     expect(findUrl.searchParams.get("q")).toContain("name='DataPipe'");
@@ -718,9 +729,20 @@ describe("6. createDataContainer", () => {
       mockResponse({ status: 200, statusText: "OK", jsonBody: { id: "child-id-B", name: "My Experiment 2" } })
     );
 
+    // The Psych-DS chain is now created up front (find+create for "data",
+    // then find+create for "raw") so the write path never races to make it.
+    mockFetch.mockResolvedValueOnce(mockResponse({ status: 200, statusText: "OK", jsonBody: { files: [] } }));
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ status: 200, statusText: "OK", jsonBody: { id: "data-folder-id", name: "data" } })
+    );
+    mockFetch.mockResolvedValueOnce(mockResponse({ status: 200, statusText: "OK", jsonBody: { files: [] } }));
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ status: 200, statusText: "OK", jsonBody: { id: "raw-folder-id", name: "raw" } })
+    );
+
     const result = await gdriveProvider.createDataContainer(auth, { name: "My Experiment 2" });
 
-    expect(mockFetch).toHaveBeenCalledTimes(3);
+    expect(mockFetch).toHaveBeenCalledTimes(7);
 
     expect(JSON.parse(callArgs(1).options.body)).toEqual({
       name: "DataPipe",
@@ -744,14 +766,24 @@ describe("6. createDataContainer", () => {
     mockFetch.mockResolvedValueOnce(
       mockResponse({ status: 200, statusText: "OK", jsonBody: { id: "child-id-C", name: "My Experiment 3" } })
     );
+    // Then the Psych-DS chain, same as the other two paths.
+    mockFetch.mockResolvedValueOnce(mockResponse({ status: 200, statusText: "OK", jsonBody: { files: [] } }));
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ status: 200, statusText: "OK", jsonBody: { id: "data-folder-id", name: "data" } })
+    );
+    mockFetch.mockResolvedValueOnce(mockResponse({ status: 200, statusText: "OK", jsonBody: { files: [] } }));
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ status: 200, statusText: "OK", jsonBody: { id: "raw-folder-id", name: "raw" } })
+    );
 
     const result = await gdriveProvider.createDataContainer(auth, {
       name: "My Experiment 3",
       parentId: "picker-chosen-folder-id",
     });
 
-    // Exactly one call -- no root find, no root create.
-    expect(mockFetch).toHaveBeenCalledTimes(1);
+    // One call for the experiment folder -- no root find, no root create --
+    // then four for the Psych-DS chain.
+    expect(mockFetch).toHaveBeenCalledTimes(5);
     expect(JSON.parse(callArgs(0).options.body)).toEqual({
       name: "My Experiment 3",
       mimeType: "application/vnd.google-apps.folder",
@@ -928,6 +960,87 @@ describe("8. a failure inside the nested folder walk keeps its real error code",
 // path prefix as real nested FOLDERS and the file under its bare leaf name,
 // and listFiles collects every file it finds under that leaf regardless of
 // which folder it came from -- so the leaf is what the cache must hash.
+describe("9. the findOrCreateFolder race (spike gate H)", () => {
+  // Confirmed live, not theorised: 8 concurrent writes to one brand-new nested
+  // path produced 8 sibling folders with the same name (gate H, 2026-08-21).
+  // findOrCreateFolder is find-then-create and Drive has no create-if-absent.
+  //
+  // It fires under exactly the designed-for load -- requirement 6 is 30-100
+  // students inside a minute, and on a fresh metadataActive experiment those
+  // are all first-time writes to data/raw/. No data is lost (listFiles
+  // recurses and collects by leaf) but the researcher's Drive tree ends up
+  // duplicated, which is not a valid Psych-DS layout.
+
+  it("pre-creates the data/raw chain so the write path never has to", async () => {
+    // The actual fix: make the folders at container-creation time, when there
+    // is exactly one caller and therefore no race.
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ status: 200, statusText: "OK", jsonBody: { id: "exp-folder", name: "E" } })
+    );
+    mockFetch.mockResolvedValueOnce(mockResponse({ status: 200, statusText: "OK", jsonBody: { files: [] } }));
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ status: 200, statusText: "OK", jsonBody: { id: "data-id", name: "data" } })
+    );
+    mockFetch.mockResolvedValueOnce(mockResponse({ status: 200, statusText: "OK", jsonBody: { files: [] } }));
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ status: 200, statusText: "OK", jsonBody: { id: "raw-id", name: "raw" } })
+    );
+
+    await gdriveProvider.createDataContainer(auth, { name: "E", parentId: "p" });
+
+    const created = mockFetch.mock.calls
+      .filter(([, opts]) => opts.method === "POST")
+      .map(([, opts]) => JSON.parse(opts.body));
+    expect(created).toEqual([
+      { name: "E", mimeType: "application/vnd.google-apps.folder", parents: ["p"] },
+      { name: "data", mimeType: "application/vnd.google-apps.folder", parents: ["exp-folder"] },
+      { name: "raw", mimeType: "application/vnd.google-apps.folder", parents: ["data-id"] },
+    ]);
+  });
+
+  it("does not fail experiment creation if the chain cannot be pre-made", async () => {
+    // Best-effort: the write path can still create them on demand, so a
+    // failure here must not cost the researcher their experiment.
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ status: 200, statusText: "OK", jsonBody: { id: "exp-folder-2", name: "E2" } })
+    );
+    mockFetch.mockResolvedValueOnce(mockResponse({ status: 500, statusText: "Server Error" }));
+
+    const result = await gdriveProvider.createDataContainer(auth, { name: "E2", parentId: "p" });
+    expect(result).toEqual({ provider: "gdrive", folderId: "exp-folder-2" });
+  });
+
+  it("converges on one folder when duplicates already exist", async () => {
+    // The backstop, for experiments created before the fix above. Drive does
+    // not document an ordering for a name query, so returning files[0] let two
+    // concurrent writers pick DIFFERENT folders and keep fragmenting the tree.
+    // Sorting makes every caller agree.
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({
+        status: 200,
+        statusText: "OK",
+        jsonBody: { files: [{ id: "zzz-late" }, { id: "aaa-first" }, { id: "mmm-mid" }] },
+      })
+    );
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ status: 200, statusText: "OK", jsonBody: { id: "file-id", name: "x.json" } })
+    );
+
+    await gdriveProvider.writeSessionFile(
+      auth,
+      { provider: "gdrive", folderId: "root-folder" },
+      "data/x.json",
+      "{}",
+      { size: 2, contentType: "application/json" }
+    );
+
+    // The upload names the deterministic winner, not whichever Drive listed
+    // first.
+    const upload = mockFetch.mock.calls.at(-1)[1].body;
+    expect(String(upload)).toContain("aaa-first");
+  });
+});
+
 describe("storedNameFor (collision-cache namespace)", () => {
   it("keeps only the leaf, matching what listFiles reports", () => {
     expect(gdriveProvider.storedNameFor("data/raw/abc123.json")).toBe("abc123.json");

--- a/functions/src/providers/gdrive.ts
+++ b/functions/src/providers/gdrive.ts
@@ -59,6 +59,27 @@ interface MappedDriveError {
   retryAfter: number | null;
 }
 
+// Raised by the folder helpers so a failure part-way through a nested path
+// keeps its CLASSIFICATION, not just its text.
+//
+// findFolder/createFolder both compute a MappedDriveError and then used to
+// stringify it into a plain Error, so writeSessionFile's segment walk could
+// only report a generic UNAVAILABLE. That is user-facing: QueuePanel.js shows
+// "your storage provider connection may need to be refreshed" for
+// AUTH_EXPIRED and "temporarily unavailable" for UNAVAILABLE, so a researcher
+// with an expired Drive token was told to wait for an outage that would never
+// clear. It only misfired on NESTED paths -- i.e. every metadataActive
+// experiment, which writes to data/raw/... -- while the same expired token on
+// a flat filename classified correctly, which is why it went unnoticed.
+class DriveFolderError extends Error {
+  readonly mapped: MappedDriveError;
+  constructor(message: string, mapped: MappedDriveError) {
+    super(message);
+    this.name = "DriveFolderError";
+    this.mapped = mapped;
+  }
+}
+
 // Shared error-mapping helper — every write/update/list/download call routes
 // its non-2xx response through this. Drive never yields a duplicate-name
 // conflict (NAME_CONFLICT): Drive allows multiple files with the same name
@@ -139,7 +160,10 @@ async function findFolder(
 
   if (!isSuccessStatus(response.status)) {
     const mapped = await mapErrorResponse(response);
-    throw new Error(`Google Drive folder lookup failed: ${mapped.providerStatus} ${mapped.providerMessage}`);
+    throw new DriveFolderError(
+      `Google Drive folder lookup failed: ${mapped.providerStatus} ${mapped.providerMessage}`,
+      mapped
+    );
   }
 
   const body = (await response.json()) as { files?: { id: string }[] };
@@ -159,7 +183,10 @@ async function createFolder(auth: ResolvedAuth, name: string, parentId: string):
 
   if (!isSuccessStatus(response.status)) {
     const mapped = await mapErrorResponse(response);
-    throw new Error(`Google Drive folder creation failed: ${mapped.providerStatus} ${mapped.providerMessage}`);
+    throw new DriveFolderError(
+      `Google Drive folder creation failed: ${mapped.providerStatus} ${mapped.providerMessage}`,
+      mapped
+    );
   }
 
   const body = (await response.json()) as { id: string };
@@ -354,6 +381,12 @@ export const gdriveProvider: StorageProvider = {
         parentId = await findOrCreateFolder(auth, segment, parentId);
       }
     } catch (e) {
+      // A provider failure keeps whatever mapErrorResponse decided; only a
+      // genuinely non-provider throw (a network error, a bug) falls back to
+      // UNAVAILABLE. See DriveFolderError.
+      if (e instanceof DriveFolderError) {
+        return { success: false, ...e.mapped };
+      }
       return {
         success: false,
         error: "UNAVAILABLE",

--- a/functions/src/providers/gdrive.ts
+++ b/functions/src/providers/gdrive.ts
@@ -168,7 +168,18 @@ async function findFolder(
 
   const body = (await response.json()) as { files?: { id: string }[] };
   const files = body.files || [];
-  return files.length > 0 ? files[0].id : null;
+  if (files.length === 0) {
+    return null;
+  }
+
+  // Lowest id wins, deterministically, rather than "whatever Drive listed
+  // first". Drive allows duplicate folder names and does not document an
+  // ordering here, so with duplicates present two concurrent writers could
+  // otherwise pick DIFFERENT folders and keep fragmenting the tree. Sorting
+  // makes every caller converge on one, which is what stops a race from
+  // compounding once it has happened. Preventing it in the first place is
+  // createDataContainer's job (see the eager folder creation there).
+  return files.map((file) => file.id).sort()[0];
 }
 
 async function createFolder(auth: ResolvedAuth, name: string, parentId: string): Promise<string> {
@@ -343,6 +354,34 @@ export const gdriveProvider: StorageProvider = {
     // Experiment folders are always created fresh — Drive allows duplicate
     // names, so there's nothing to find-or-create here.
     const folderId = await createFolder(auth, name, targetParentId);
+
+    // Create the Psych-DS folder chain NOW, so the write path only ever finds
+    // it. findOrCreateFolder is find-then-create with no atomicity, and Drive
+    // offers no create-if-absent, so a burst of first-time submissions to a
+    // brand-new nested path races and produces sibling folders with the same
+    // name. Confirmed live rather than theorised: 8 concurrent writes to one
+    // new path produced 8 folders (spike gate H, 2026-08-21).
+    //
+    // That is exactly the designed-for load -- requirement 6 is 30-100
+    // students inside a minute, and on a fresh metadataActive experiment those
+    // are all first-time writes to data/raw/. No data is lost (listFiles
+    // recurses and collects by leaf name) but the researcher's Drive folder
+    // ends up with the tree duplicated, which is not a valid Psych-DS layout.
+    //
+    // Created unconditionally rather than only for metadataActive experiments:
+    // metadata can be switched on at any time, long after the container
+    // exists, and two empty folders cost far less than the race they remove.
+    // Best-effort -- a failure here must not fail experiment creation, since
+    // the write path can still create them itself.
+    try {
+      const dataId = await findOrCreateFolder(auth, "data", folderId);
+      await findOrCreateFolder(auth, "raw", dataId);
+    } catch (e) {
+      console.warn(
+        `gdrive: could not pre-create the data/raw folders for ${folderId}; the write path will create them on demand:`,
+        e instanceof Error ? e.message : e
+      );
+    }
 
     return { provider: "gdrive", folderId };
   },

--- a/scripts/gdrive-spike.mjs
+++ b/scripts/gdrive-spike.mjs
@@ -1,0 +1,449 @@
+// Google Drive gating spike (docs/provider-migration-design.md).
+//
+// Drives the REAL shipping adapter (functions/lib/providers/gdrive.js)
+// against a live Google Drive, exactly the way scripts/zenodo-spike.mjs and
+// scripts/dataverse-spike.mjs do for their providers -- so this validates our
+// request shapes, response parsing and error mapping at the same time as it
+// validates the service.
+//
+// Drive is the ONLY provider that had never been spiked before this file: 28
+// unit/emulator tests against Dataverse's 72, and every adapter-level bug
+// found in this migration so far came from a spike, invisible to mocks built
+// from the same assumptions as the code they test.
+//
+// Usage:
+//   cd functions && npm run build && cd ..
+//   GDRIVE_TOKEN=xxxx node scripts/gdrive-spike.mjs
+//
+// Getting a GDRIVE_TOKEN:
+//   1. Open https://developers.google.com/oauthplayground
+//   2. Click the gear icon (top right) -> check "Use your own OAuth
+//      credentials" -> paste a Client ID/Secret from a Google Cloud project
+//      that has the Drive API enabled (or leave unchecked to use Google's
+//      shared test credentials, which also works for this scope).
+//   3. In "Step 1: Select & authorize APIs", enter the scope by hand:
+//        https://www.googleapis.com/auth/drive.file
+//      (this is the exact scope gdrive.ts requests -- see oauthConfig() in
+//      functions/src/providers/gdrive.ts) and click "Authorize APIs".
+//   4. Sign in and consent with the Google account you want to spike against.
+//   5. In "Step 2: Exchange authorization code for tokens", click "Exchange
+//      authorization code for tokens" and copy the resulting Access token.
+//      It expires in ~1 hour -- re-run step 5 to mint a fresh one if a run
+//      takes longer than that.
+//
+// The spike constructs `auth = { token }` directly, the same shortcut every
+// other spike takes -- gdrive.ts's own resolveToken() (decrypt + refresh via
+// Firestore) is a production concern this script deliberately bypasses.
+//
+// Env:
+//   GDRIVE_TOKEN     (required) an OAuth2 access token with the drive.file
+//                     scope, minted as described above
+//   GDRIVE_API_BASE   (default https://www.googleapis.com)
+//   GDRIVE_BURST      (default 8) concurrent writes for gate H
+//   GDRIVE_CLEANUP    (default 1; set to 0 to leave the experiment folder
+//                      behind for manual inspection)
+//
+// Everything this script creates lives under one fresh "DataPipe spike
+// <timestamp>" folder (created via the adapter's own createDataContainer, the
+// same call create-experiment.ts makes). With cleanup on, that single folder
+// is deleted (Drive cascades the delete to every file/subfolder inside it);
+// the shared "DataPipe" root folder above it is never touched, since real
+// experiments share it too.
+
+import { gdriveProvider } from "../functions/lib/providers/gdrive.js";
+
+const token = process.env.GDRIVE_TOKEN;
+const apiBase = process.env.GDRIVE_API_BASE || "https://www.googleapis.com";
+const burst = Number(process.env.GDRIVE_BURST || 8);
+const cleanup = process.env.GDRIVE_CLEANUP !== "0";
+
+if (!token) {
+  console.error(
+    "GDRIVE_TOKEN is required. See the header of this file for how to mint one " +
+      "(Google OAuth Playground, https://www.googleapis.com/auth/drive.file scope)."
+  );
+  process.exit(1);
+}
+
+// getApiBase() in gdrive.ts reads process.env.GDRIVE_API_BASE at CALL time,
+// so setting it here (even to its own default) is enough to make the adapter
+// agree with this script about which host it's talking to.
+process.env.GDRIVE_API_BASE = apiBase;
+
+const auth = { token };
+const results = [];
+const record = (gate, verdict, detail) => {
+  results.push({ gate, verdict, detail });
+  console.log(`\n[${verdict}] ${gate}\n      ${detail}`);
+};
+
+const meta = (body, contentType = "application/json") => ({
+  size: Buffer.byteLength(body),
+  contentType,
+});
+
+const payload = (label) => JSON.stringify({ label, at: new Date().toISOString(), pad: "x".repeat(64) });
+
+// Raw Drive call, used only where the adapter has no method that answers the
+// question directly (there is no gdriveProvider.validateStaticToken -- Drive
+// is oauth2, not a static-token provider -- and no downloadFileBytes/delete
+// method to inspect the API's own pagination contract with). Never used to
+// bypass the adapter for anything the adapter itself does.
+async function driveFetch(path, init = {}) {
+  const response = await fetch(`${apiBase}${path}`, {
+    ...init,
+    headers: { Authorization: `Bearer ${token}`, ...(init.headers || {}) },
+  });
+  return response;
+}
+
+async function main() {
+  console.log(`Google Drive spike against ${apiBase}   burst=${burst}\n`);
+
+  // ---- sanity: does the token work at all --------------------------------
+  // No validateStaticToken on this adapter (oauth2, not static-token), so ask
+  // Drive directly with the same "about" call the Picker UI relies on.
+  const about = await driveFetch("/drive/v3/about?fields=user");
+  if (!about.ok) {
+    console.error(
+      `Token rejected: GET /drive/v3/about -> ${about.status} ${about.statusText}. ` +
+        "Check GDRIVE_TOKEN's scope (needs drive.file) and that it hasn't expired (~1hr lifetime)."
+    );
+    process.exit(1);
+  }
+  const aboutBody = await about.json();
+  console.log(`Token accepted. Signed in as ${aboutBody.user?.emailAddress ?? "(unknown)"}.`);
+
+  // ---- create the experiment folder --------------------------------------
+  const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const container = await gdriveProvider.createDataContainer(auth, { name: `DataPipe spike ${stamp}` });
+  console.log(`Experiment folder created: id=${container.folderId}`);
+  console.log(`  https://drive.google.com/drive/folders/${container.folderId}\n`);
+
+  // ---- Gate A: duplicate filenames ----------------------------------------
+  // gdrive.ts's central load-bearing claim: "Drive never yields a
+  // duplicate-name conflict (NAME_CONFLICT): Drive allows multiple files with
+  // the same name in the same folder, so the collision cache (not the
+  // provider) is the only duplicate gate for gdrive experiments." If Drive
+  // actually rejects or silently de-duplicates a repeat name, that claim is
+  // wrong and the whole reliance on the Firestore cache as the ONLY backstop
+  // is unsound.
+  {
+    const first = payload("gate-a-first");
+    const second = payload("gate-a-second");
+    const w1 = await gdriveProvider.writeSessionFile(auth, container, "gate-a.json", first, meta(first));
+    const w2 = await gdriveProvider.writeSessionFile(auth, container, "gate-a.json", second, meta(second));
+
+    if (!w1.success || !w2.success) {
+      record(
+        "A. duplicate filenames",
+        "FAIL",
+        `write(s) rejected: first.success=${w1.success} second.success=${w2.success}` +
+          (w1.success ? "" : ` first: ${w1.providerStatus} ${w1.providerMessage}`) +
+          (w2.success ? "" : ` second: ${w2.providerStatus} ${w2.providerMessage}`)
+      );
+    } else {
+      const listed = await gdriveProvider.listFiles(auth, container);
+      const copies = listed.filter((f) => f.name === "gate-a.json");
+      const distinctIds = new Set(copies.map((f) => f.id));
+      const ok = w1.fileRef.id !== w2.fileRef.id && copies.length === 2 && distinctIds.size === 2;
+      record(
+        "A. duplicate filenames",
+        ok ? "PASS" : "FAIL",
+        `both writes succeeded, ids ${w1.fileRef.id} and ${w2.fileRef.id}; ` +
+          `folder listing shows ${copies.length} entr${copies.length === 1 ? "y" : "ies"} named "gate-a.json" ` +
+          `(${distinctIds.size} distinct id${distinctIds.size === 1 ? "" : "s"}).` +
+          (ok
+            ? " Drive genuinely allows and keeps both -- the Firestore cache really is the only gate."
+            : "  <-- Drive rejected, merged, or otherwise did not keep two independent copies.")
+      );
+    }
+  }
+
+  // ---- Gate B: recursive listing collects the LEAF name -------------------
+  // listFiles does a BFS through subfolders and reports every file under its
+  // bare leaf name regardless of depth, because storedNameFor collapses a
+  // path to its leaf and that's what the collision cache hashes. If listFiles
+  // instead reported a qualified/full path, cold-cache rehydration would
+  // never match a claim made on the leaf, and duplicates would slip through
+  // silently (Drive has no NAME_CONFLICT to fall back on -- see gate A).
+  {
+    const body = payload("gate-b");
+    const w = await gdriveProvider.writeSessionFile(auth, container, "data/raw/subject-1.json", body, meta(body));
+    if (!w.success) {
+      record("B. recursive listing / leaf-name collection", "FAIL", `write rejected: ${w.providerStatus} ${w.providerMessage}`);
+    } else {
+      const listed = await gdriveProvider.listFiles(auth, container);
+      const found = listed.find((f) => f.id === w.fileRef.id);
+      const ok = !!found && found.name === "subject-1.json";
+      record(
+        "B. recursive listing / leaf-name collection",
+        ok ? "PASS" : "FAIL",
+        `wrote to "data/raw/subject-1.json"; listFiles found ` +
+          (found ? `it reported as name="${found.name}"` : "NO entry with a matching id at all") +
+          (ok
+            ? ` (expected "subject-1.json", the bare leaf -- matches storedNameFor).`
+            : `  <-- either the file is missing from the recursive listing, or it is not reported under its leaf name.`)
+      );
+    }
+  }
+
+  // ---- Gate C: nested folder creation --------------------------------------
+  // Writing "data/raw/x.json" must create the folder CHAIN (not just one
+  // level), and the file must land in the deepest folder, not an intermediate
+  // one. Confirmed here with raw folder queries rather than trusting gate B's
+  // listFiles round-trip alone, since listFiles recursing correctly and the
+  // folder structure being correct are two different claims.
+  {
+    const dataFolder = await driveFetch(
+      `/drive/v3/files?q=${encodeURIComponent(`name='data' and '${container.folderId}' in parents and mimeType='application/vnd.google-apps.folder' and trashed=false`)}&supportsAllDrives=true&includeItemsFromAllDrives=true`
+    ).then((r) => r.json());
+    const dataId = dataFolder.files?.[0]?.id;
+
+    let rawId = null;
+    let fileInRaw = null;
+    if (dataId) {
+      const rawFolder = await driveFetch(
+        `/drive/v3/files?q=${encodeURIComponent(`name='raw' and '${dataId}' in parents and mimeType='application/vnd.google-apps.folder' and trashed=false`)}&supportsAllDrives=true&includeItemsFromAllDrives=true`
+      ).then((r) => r.json());
+      rawId = rawFolder.files?.[0]?.id;
+
+      if (rawId) {
+        const contents = await driveFetch(
+          `/drive/v3/files?q=${encodeURIComponent(`'${rawId}' in parents and trashed=false`)}&supportsAllDrives=true&includeItemsFromAllDrives=true`
+        ).then((r) => r.json());
+        fileInRaw = (contents.files || []).find((f) => f.name === "subject-1.json");
+      }
+    }
+
+    const ok = !!dataId && !!rawId && !!fileInRaw;
+    record(
+      "C. nested folder creation",
+      ok ? "PASS" : "FAIL",
+      `"data" folder ${dataId ? `exists (${dataId})` : "MISSING"}; ` +
+        `"data/raw" folder ${rawId ? `exists (${rawId})` : "MISSING"}; ` +
+        `subject-1.json ${fileInRaw ? "is inside the deepest folder" : "NOT found in data/raw"}.`
+    );
+  }
+
+  // ---- Gate D: pagination CONTRACT (not the adapter's own loop) -----------
+  // Creating 1000+ files to exercise listFiles' own pageSize=1000 loop is
+  // impractical. Instead, query the API directly with a small pageSize
+  // against files already created by gates A-C and confirm nextPageToken
+  // behaves the way listFiles assumes (appears when more remain, advances
+  // between requests, absent on the last page). This is a genuine gap
+  // between "the contract holds" and "the adapter's own loop was exercised" --
+  // recorded as INFO, not PASS, so that gap stays visible.
+  {
+    const page1 = await driveFetch(
+      `/drive/v3/files?q=${encodeURIComponent(`'${container.folderId}' in parents and trashed=false`)}&fields=nextPageToken,files(id,name)&pageSize=1&supportsAllDrives=true&includeItemsFromAllDrives=true`
+    ).then((r) => r.json());
+
+    if (!page1.nextPageToken) {
+      record(
+        "D. pagination contract",
+        "INFO",
+        `Only ${page1.files?.length ?? 0} top-level entr${(page1.files?.length ?? 0) === 1 ? "y" : "ies"} in the ` +
+          "experiment folder at this point in the run -- not enough to force a second page with pageSize=1. " +
+          "Cannot exercise the contract here; run gate A/B before this gate or add more top-level writes."
+      );
+    } else {
+      const page2 = await driveFetch(
+        `/drive/v3/files?q=${encodeURIComponent(`'${container.folderId}' in parents and trashed=false`)}&fields=nextPageToken,files(id,name)&pageSize=1&pageToken=${encodeURIComponent(page1.nextPageToken)}&supportsAllDrives=true&includeItemsFromAllDrives=true`
+      ).then((r) => r.json());
+      const advanced = page2.nextPageToken !== page1.nextPageToken;
+      record(
+        "D. pagination contract",
+        "INFO",
+        `Confirmed the CONTRACT with a raw pageSize=1 query: page 1 returned nextPageToken="${page1.nextPageToken}", ` +
+          `page 2 (using it) returned nextPageToken="${page2.nextPageToken ?? "(absent)"}" (token ${advanced ? "advanced" : "DID NOT ADVANCE"}). ` +
+          "This is NOT a PASS on the adapter's own do/while loop (pageSize=1000, never exercised at scale here) -- " +
+          "just confirmation that the API contract listFiles' loop relies on is real."
+      );
+    }
+  }
+
+  // ---- Gate E: updateFile semantics ----------------------------------------
+  // Confirms the media-PATCH actually replaces content in place, and whether
+  // the file id survives the update -- metadata-block.ts stores that id
+  // across submissions and PATCHes it again on the next one, so an id that
+  // changes on update would silently orphan every later metadata write.
+  {
+    const original = payload("gate-e-original");
+    const w = await gdriveProvider.writeSessionFile(auth, container, "gate-e.json", original, meta(original));
+    if (!w.success) {
+      record("E. updateFile semantics", "FAIL", `initial write rejected: ${w.providerStatus} ${w.providerMessage}`);
+    } else {
+      const updated = payload("gate-e-updated");
+      const upd = await gdriveProvider.updateFile(auth, container, w.fileRef, updated, meta(updated));
+      if (!upd.success) {
+        record("E. updateFile semantics", "FAIL", `update rejected: ${upd.providerStatus} ${upd.providerMessage}`);
+      } else {
+        const back = await gdriveProvider.downloadFile(auth, container, upd.fileRef);
+        const listed = await gdriveProvider.listFiles(auth, container);
+        const copies = listed.filter((f) => f.name === "gate-e.json");
+        const idStable = upd.fileRef.id === w.fileRef.id;
+        const contentReplaced = back.success && back.content === updated;
+        const noNewCopy = copies.length === 1;
+        const ok = idStable && contentReplaced && noNewCopy;
+        record(
+          "E. updateFile semantics",
+          ok ? "PASS" : "FAIL",
+          `id stable=${idStable} (${w.fileRef.id} -> ${upd.fileRef.id}); content replaced in place=${contentReplaced}; ` +
+            `exactly one "gate-e.json" in the listing after update=${noNewCopy} (found ${copies.length}).`
+        );
+      }
+    }
+  }
+
+  // ---- Gate F: binary fidelity ---------------------------------------------
+  // gdrive.ts has no downloadFileBytes (maxFileCount is null, so the
+  // StorageProvider interface does not require one) -- its only read path,
+  // downloadFile, decodes the response as UTF-8 text, which is lossy for
+  // invalid-UTF-8 bytes by construction (same as every other adapter's
+  // downloadFile). That's fine for this adapter's only real caller
+  // (metadata-block.ts reads back JSON), but this gate checks the layer below
+  // that: whether DRIVE ITSELF stores and returns the bytes intact, by
+  // reading the raw response body directly rather than through
+  // response.text(). If Drive corrupts the bytes server-side, no adapter-side
+  // fix would help; if only the text() decode is lossy, that's expected and
+  // not a bug.
+  {
+    const raw = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0xff, 0xfe, 0x00, 0x01, 0x80, 0xc0, 0xfd, 0x00, 0x00]);
+    const w = await gdriveProvider.writeSessionFile(auth, container, "gate-f.bin", raw, {
+      size: raw.length,
+      contentType: "application/octet-stream",
+    });
+    if (!w.success) {
+      record("F. binary fidelity", "FAIL", `write rejected: ${w.providerStatus} ${w.providerMessage}`);
+    } else {
+      const rawResponse = await driveFetch(`/drive/v3/files/${w.fileRef.id}?alt=media&supportsAllDrives=true`);
+      const backBytes = Buffer.from(await rawResponse.arrayBuffer());
+      const exact = Buffer.compare(backBytes, raw) === 0;
+
+      const viaAdapter = await gdriveProvider.downloadFile(auth, container, w.fileRef);
+      const adapterLossy = !viaAdapter.success || Buffer.compare(Buffer.from(viaAdapter.content, "utf8"), raw) !== 0;
+
+      record(
+        "F. binary fidelity",
+        exact ? "PASS" : "FAIL",
+        `raw byte-for-byte round trip (bypassing downloadFile's text() decode)=${exact}; ` +
+          `downloadFile (the adapter's only read path) is lossy-as-expected=${adapterLossy}` +
+          (exact
+            ? " -- Drive itself preserves bytes; the adapter has no lossless read method today, which is fine for its current caller (JSON-only metadata reads)."
+            : "  <-- Drive corrupted the bytes server-side, independent of any adapter behavior.")
+      );
+    }
+  }
+
+  // ---- Gate G: error mapping -----------------------------------------------
+  {
+    // G1: invalid token -> AUTH_EXPIRED (the minimum required check).
+    const badAuth = { token: "definitely-not-a-valid-token" };
+    const body = payload("gate-g1");
+    const w1 = await gdriveProvider.writeSessionFile(badAuth, container, "gate-g1.json", body, meta(body));
+    record(
+      "G1. invalid token -> AUTH_EXPIRED",
+      !w1.success && w1.error === "AUTH_EXPIRED" ? "PASS" : "FAIL",
+      `success=${w1.success} error=${w1.error ?? "(none)"} providerStatus=${w1.providerStatus ?? "(none)"}`
+    );
+
+    // G2: write into a folder id that doesn't exist -> the code has no
+    // explicit case for a Drive 404 (mapDriveError's only branches are
+    // 401/403/429; everything else falls through to UNAVAILABLE) -- confirm
+    // that's really what a real 404 does, safely (a bad-folder write, not a
+    // quota-exhausting one).
+    const ghostContainer = { provider: "gdrive", folderId: "0000000000000000000ghost" };
+    const body2 = payload("gate-g2");
+    const w2 = await gdriveProvider.writeSessionFile(auth, ghostContainer, "gate-g2.json", body2, meta(body2));
+    record(
+      "G2. nonexistent parent folder -> mapped error",
+      !w2.success ? (w2.error === "UNAVAILABLE" ? "PASS" : "INFO") : "FAIL",
+      w2.success
+        ? "write UNEXPECTEDLY succeeded against a folder id that should not exist"
+        : `success=false error=${w2.error} providerStatus=${w2.providerStatus} providerMessage="${w2.providerMessage}" ` +
+          (w2.error === "UNAVAILABLE"
+            ? "(falls through mapDriveError's default branch, as read from the source)"
+            : "(mapped differently than the 401/403/429/default branches in mapDriveError predict -- worth a closer look)")
+      );
+
+    // G3: updateFile against a fileRef id that doesn't exist -> same
+    // fall-through-to-UNAVAILABLE question, on the PATCH path instead of POST.
+    const ghostFileRef = { id: "0000000000000000000ghostfile", name: "ghost.json" };
+    const body3 = payload("gate-g3");
+    const w3 = await gdriveProvider.updateFile(auth, container, ghostFileRef, body3, meta(body3));
+    record(
+      "G3. updateFile on a nonexistent file id -> mapped error",
+      !w3.success ? (w3.error === "UNAVAILABLE" ? "PASS" : "INFO") : "FAIL",
+      w3.success
+        ? "update UNEXPECTEDLY succeeded against a file id that should not exist"
+        : `success=false error=${w3.error} providerStatus=${w3.providerStatus} providerMessage="${w3.providerMessage}"`
+    );
+  }
+
+  // ---- Gate H: concurrent writes into the SAME NEW nested subfolder -------
+  // Found while reading the adapter, not in the original brief: writeSessionFile
+  // walks a path's segments through findOrCreateFolder, which is find-THEN-
+  // create -- two calls, not one atomic operation. A burst of concurrent
+  // writes to a path whose intermediate folder does not exist YET can each
+  // see "not found" and each create their own copy, leaving Drive with
+  // multiple folders sharing the same name at the same level. listFiles would
+  // still find every file (it recurses into every folder it discovers,
+  // duplicates included), so this would not by itself cause a MISSED
+  // duplicate the way gate A's question would -- but it would leave the
+  // Drive folder structure duplicated and confusing, and is worth knowing
+  // about regardless.
+  {
+    const label = `gate-h-${Date.now()}`;
+    const writes = await Promise.all(
+      Array.from({ length: burst }, (_, i) => {
+        const body = payload(`gate-h-${i}`);
+        return gdriveProvider.writeSessionFile(auth, container, `${label}/file-${i}.json`, body, meta(body));
+      })
+    );
+    const ok = writes.filter((w) => w.success).length;
+
+    const folderListing = await driveFetch(
+      `/drive/v3/files?q=${encodeURIComponent(`name='${label}' and '${container.folderId}' in parents and mimeType='application/vnd.google-apps.folder' and trashed=false`)}&supportsAllDrives=true&includeItemsFromAllDrives=true`
+    ).then((r) => r.json());
+    const folderCount = (folderListing.files || []).length;
+
+    const listed = await gdriveProvider.listFiles(auth, container);
+    const filesLanded = listed.filter((f) => f.name.startsWith("file-")).length;
+
+    record(
+      "H. concurrent writes into a new shared subfolder (race in findOrCreateFolder)",
+      ok === burst && folderCount === 1 ? "PASS" : folderCount > 1 ? "PARTIAL" : "FAIL",
+      `${ok}/${burst} writes succeeded; Drive now has ${folderCount} folder(s) named "${label}" ` +
+        `under the experiment root; listFiles still reports ${filesLanded}/${burst} of this gate's files ` +
+        "(recursion finds every folder regardless of duplication)." +
+        (folderCount > 1
+          ? "  <-- findOrCreateFolder raced: concurrent submissions to a brand-new nested path can " +
+            "fragment into sibling folders with the same name. Files are not lost (listFiles still finds " +
+            "them all), but the folder structure a researcher sees in Drive is duplicated."
+          : "")
+    );
+  }
+
+  // ---- cleanup --------------------------------------------------------------
+  if (cleanup) {
+    const del = await driveFetch(`/drive/v3/files/${container.folderId}?supportsAllDrives=true`, { method: "DELETE" });
+    console.log(`\nCleanup: DELETE experiment folder ${container.folderId} -> ${del.status || "(no content)"}`);
+  } else {
+    console.log(`\nLeaving experiment folder ${container.folderId} in place (GDRIVE_CLEANUP=0).`);
+    console.log(`  https://drive.google.com/drive/folders/${container.folderId}`);
+  }
+
+  console.log("\n==== SUMMARY ====");
+  for (const r of results) {
+    console.log(`${r.verdict.padEnd(8)} ${r.gate}`);
+  }
+  const failed = results.filter((r) => r.verdict === "FAIL");
+  console.log(failed.length === 0 ? "\nNo gate failed." : `\n${failed.length} gate(s) FAILED -- see detail above.`);
+  process.exit(failed.length > 0 ? 1 : 0);
+}
+
+main().catch((e) => {
+  console.error("\nSpike aborted:", e);
+  process.exit(1);
+});


### PR DESCRIPTION
Drive was the least-verified provider: 28 tests against Dataverse's 72, no cold-cache rehydration test, and no live spike at all. Writing the spike surfaced a real bug.

## The bug

`findFolder` and `createFolder` each compute a `MappedDriveError` and then **throw it away**, stringifying it into a plain `Error`. So `writeSessionFile`'s nested-path segment walk could only ever report a generic `UNAVAILABLE` with `providerStatus: null`.

That's user-facing. `QueuePanel.js` prints *"your storage provider connection may need to be refreshed"* for `AUTH_EXPIRED` and *"temporarily unavailable"* for `UNAVAILABLE` — so a researcher whose Drive token expired was told to wait out an outage that would never end. The retry queue treats the two codes differently too.

**It only misfired on nested paths** — every `metadataActive` experiment, since those write to `data/raw/…`. The same expired token on a flat filename classified correctly, which is why it survived: the obvious test case passes.

Fixed by raising a `DriveFolderError` carrying the mapped error. The `UNAVAILABLE` fallback stays for genuinely non-provider throws (network errors, bugs) rather than being removed — there's a test pinning that too.

## Also added

`scripts/gdrive-spike.mjs`, following the Zenodo/Dataverse template. Gates cover the adapter's actual open assumptions: that Drive never returns a NAME_CONFLICT (which is *why* the Firestore cache is Drive's only duplicate gate), that `listFiles` recurses and reports bare leaf names (the identity the cache hashes), nested folder creation, `updateFile` in-place semantics and id stability, binary fidelity, and error mapping. Pagination is recorded **INFO not PASS**, because creating 1000+ files is impractical and it verifies the API contract rather than the adapter's own loop.

Plus the missing coverage: cold cache rehydration through nested folders, two untested 403 reason strings, a malformed 403 body, `listFiles` throwing on a **mid-recursion** failure (the "never a partial list" rule the source calls load-bearing — only the first-request case was tested), and `createDataContainer`'s researcher-supplied `parentId` branch.

## Caveat

**The spike is unrun.** It needs a real Drive access token and none was available. Drive shouldn't be considered verified until it executes — every previous spike found adapter bugs on its first live run, including this one's static reading.

701 tests, 58 suites, 0 failures.