### PR TITLE
Zenodo storage over OAuth2, and a probe retry tier

### DIFF
--- a/.github/workflows/firebase-deploy-test.yml
+++ b/.github/workflows/firebase-deploy-test.yml
@@ -67,6 +67,10 @@ jobs:
           # Google Drive client secret for the deployed test site. Client id and
           # redirect uri are non-secret and live in functions/.env.datapipe-test.
           echo "GDRIVE_CLIENT_SECRET=${{ secrets.TEST_GDRIVE_CLIENT_SECRET }}" >> .env
+          # Zenodo OAuth client secret for the deployed test site. Client id,
+          # redirect uri and ZENODO_ENV are non-secret and live in
+          # functions/.env.datapipe-test.
+          echo "ZENODO_CLIENT_SECRET=${{ secrets.TEST_ZENODO_CLIENT_SECRET }}" >> .env
       - name: Install dependencies and build functions
         working-directory: functions
         run: |

--- a/__tests__/provider-config.test.js
+++ b/__tests__/provider-config.test.js
@@ -111,15 +111,17 @@ describe("zenodo: which Zenodo a deployment points at", () => {
   }
 
   it("points production at the real zenodo.org", () => {
-    expect(loadWith("").zenodo.defaultServerUrl).toBe("https://zenodo.org");
+    expect(loadWith("").zenodo.containerLink({})).toBe(
+      "https://zenodo.org/deposit/undefined"
+    );
   });
 
   it("points the test deployment at the sandbox", () => {
     // The whole reason this setting exists: without it the test site creates
     // real depositions on the live service using the researcher's real
     // account.
-    expect(loadWith("sandbox.").zenodo.defaultServerUrl).toBe(
-      "https://sandbox.zenodo.org"
+    expect(loadWith("sandbox.").zenodo.containerLink({})).toBe(
+      "https://sandbox.zenodo.org/deposit/undefined"
     );
   });
 
@@ -127,7 +129,9 @@ describe("zenodo: which Zenodo a deployment points at", () => {
     // An unset variable must never resolve to something like
     // "https://undefinedzenodo.org", and defaulting to sandbox would be worse
     // -- a misconfigured production deploy would silently write nowhere real.
-    expect(loadWith(undefined).zenodo.defaultServerUrl).toBe("https://zenodo.org");
+    expect(loadWith(undefined).zenodo.containerLink({})).toBe(
+      "https://zenodo.org/deposit/undefined"
+    );
   });
 
   it("containerLink follows the container's host, not the current deployment", () => {

--- a/components/account/ProviderConnections.js
+++ b/components/account/ProviderConnections.js
@@ -69,10 +69,12 @@ export default function ProviderConnections() {
           idToken,
           token: apiToken.trim(),
           // connectstatictokenprovider ALWAYS requires a serverUrl, but not
-          // every static-token provider is federated. Dataverse is (the
-          // researcher types their institution's installation); Zenodo is not
-          // -- there is exactly one production host -- so its config supplies
-          // a fixed defaultServerUrl and renders no field at all.
+          // every static-token provider is federated, so a provider may supply
+          // a fixed defaultServerUrl and render no field at all. Dataverse is
+          // federated (the researcher types their institution's installation)
+          // and is currently the only provider reaching this branch -- Zenodo
+          // was the non-federated example until it moved to OAuth2 on
+          // 2026-08-21 and stopped coming through here entirely.
           serverUrl: STORAGE_PROVIDERS[providerId]?.needsServerUrl
             ? serverUrl.trim()
             : STORAGE_PROVIDERS[providerId]?.defaultServerUrl,

--- a/docs/provider-migration-design.md
+++ b/docs/provider-migration-design.md
@@ -830,3 +830,141 @@ Google Drive provider is announced:
   one on `experiments`). The Firestore emulator does not enforce composite
   indexes, so the test suite passes without them and only a deploy can confirm
   the query shapes match.
+
+## Zenodo: static token → OAuth2 (2026-08-21)
+
+Zenodo shipped as a static-token provider: the researcher created a personal
+access token on Zenodo and pasted it into DataPipe. It is now OAuth2. There
+were no existing Zenodo connections anywhere but the test deployment, so this
+was a clean cut with no dual-mode period and no migration path.
+
+### What the source says, because the documentation does not exist
+
+Zenodo publishes nothing about its OAuth application flow —
+`developers.zenodo.org` documents personal access tokens only. Zenodo runs
+InvenioRDM (it reports `InvenioRDM 15.0` in its page generator meta tag), so
+the answers came from reading `invenio-oauth2server` and `oauthlib` directly:
+
+- **Endpoints** are `/oauth/authorize` and `/oauth/token`. `POST /oauth/token`
+  answers **404** when `client_id` matches no registered Client — the view
+  calls `abort(404)` before oauthlib sees the request. A 404 there means a
+  misconfigured client, not a missing endpoint.
+- **Scopes**: `deposit:write`, `deposit:actions`, and — undocumented by Zenodo
+  — `user:email`, registered by `invenio-oauth2server` itself via its own
+  entry point, so it exists on every Invenio instance. DataPipe requests only
+  the two deposit scopes.
+- **Identity comes back in the token response.** `save_token` attaches
+  `user: {id}` unconditionally and adds `email`/`email_verified` only when
+  `user:email` was granted. No `/api/me` round trip is needed by anyone who
+  wants it.
+- **Access tokens expire after sixty days.** The `Token` model has a single
+  `expires` column, governing the access token. Reading the source predicts one
+  hour — Invenio never sets `OAUTH2_PROVIDER_TOKEN_EXPIRES_IN`, so it falls
+  through to oauthlib's `expires_in or 3600` — but the sandbox actually issues
+  `expires_in=5184000`, i.e. 60 days. Zenodo overrides it in deployment config,
+  which is not public. Measured by spike gate J on 2026-08-21; do not trust the
+  source figure.
+- **Refresh tokens rotate, and the old one dies immediately.** oauthlib's
+  `rotate_refresh_token` defaults to `True`, and `save_token` deletes *every*
+  prior `Token` row for `(client_id, user_id)` before inserting the new one:
+  *"make sure that every client has only one token connected to a user."*
+
+### Why Zenodo is not a sign-in provider
+
+It was considered and rejected on evidence. `invenio-oauth2server` contains
+**zero** references to `id_token`, `openid`, `oidc`, `jwks`, or `userinfo` — it
+is a pure OAuth2 authorization server with no OIDC layer. Firebase's generic
+OIDC provider has nothing to discover or verify, so Zenodo sign-in would mean
+reintroducing a server-side custom-token path of the kind the OSF split
+removed. ORCID already covers researcher identity and *is* a real OIDC
+provider. See `lib/auth-providers.js`.
+
+### What the rotation rule forces
+
+Two things, both in `functions/src/providers/zenodo-oauth.ts`:
+
+1. **Persisting the rotated refresh token is part of the refresh's
+   correctness.** The presented token is dead the moment Zenodo answers, so a
+   crash between the HTTP response and the Firestore write leaves the
+   researcher unable to write data mid-experiment, with no symptom until the
+   access token lapses an hour later. Google's stable refresh tokens make the
+   same crash harmless, which is why `gdrive-oauth.ts` can be simpler.
+2. **A concurrent refresh is not a dead connection.** Two submissions after an
+   idle hour both refresh; the loser presents a token that no longer exists and
+   gets `400 invalid_grant`. `recoverFromRotationRace()` re-reads the stored
+   connection and continues with whatever the winner persisted, rather than
+   tearing down a working account. Only an `invalid_grant` whose stored refresh
+   token is *unchanged* is a genuine revocation.
+
+Deployment config, not the stored connection, decides which Zenodo we mean: an
+OAuth `client_id` is registered against one installation, so a sandbox client
+cannot complete a flow on `zenodo.org`. `resolveToken` ignores any `serverUrl`
+left on a connection.
+
+### What the spike found (2026-08-21, sandbox)
+
+`scripts/zenodo-oauth-spike.mjs` against sandbox.zenodo.org. All gates pass.
+
+| Gate | Result |
+| --- | --- |
+| J. authorization_code exchange | **PASS** — `expires_in=5184000` (60 days), refresh_token present |
+| J0. client authentication | `client_secret_post` accepted; HTTP Basic never needed |
+| K. identity without `user:email` | **PASS** — `user.id` returned, no email |
+| O. OAuth token drives the adapter | **PASS** — created a deposition, wrote a file; the two deposit scopes suffice |
+| L. refresh rotates the refresh token | **PASS** — new value differs, as `rotate_refresh_token=True` implies |
+| M. superseded refresh token rejected | **PASS** — replay returns `400 invalid_grant` |
+| N. previous access token survives | **NO** — it is dead immediately |
+
+**The application must be registered as a CONFIDENTIAL client.** Registered as
+public, everything works except refresh, which fails with `400 invalid_grant` —
+`get_token`'s refresh branch filters on `Client.is_confidential == True`, so the
+lookup simply returns nothing. The symptom appears two months after connecting,
+when the first refresh is due, and looks nothing like its cause. The
+registration form defaults to Confidential; this was found by registering one
+that was not.
+
+**Zenodo answers 403 for every auth failure.** Measured directly: a revoked
+token, a garbage token, an access token rotated away by a concurrent refresh,
+and a request with no `Authorization` header at all all return 403. It never
+returns 401. So the response cannot distinguish a transient rotation from a
+terminal revocation — only comparing the token used against the one now stored
+can, which is what `recoverFromRotationRace()` does for refresh tokens.
+
+**Gate N's consequence, and the probe retry tier.** Because a refresh deletes
+the prior access token, an upload already in flight when another request
+refreshes fails with 403 and maps to `AUTH_EXPIRED` — a code that meant
+"reconnect by hand" and sat on the retry queue's hours-scale tier, when this
+particular instance of it heals itself in seconds.
+
+The fix is a third tier in `queue-upload.ts`: `PROBE_RETRY_CODES`. A probe code
+takes ONE minute-scale look and then, if that fails, resumes the ordinary
+hours-scale chain. It is free rather than additive — the early attempt
+displaces the 1-hour first attempt instead of extending the chain, so an item
+still gets five tries across ~30 hours instead of ~31, with the first look ~59
+minutes earlier. Nothing in `scheduled-upload-retry.ts` changes: the probe only
+moves the first delay, and that file's existing backoff already yields 2 hours
+for the next attempt.
+
+Its members are `AUTH_EXPIRED` and `UNAVAILABLE` — the two codes that cannot
+distinguish a transient failure from a terminal one, so looking once is the
+cheapest way to find out. `RATE_LIMITED` is excluded because the provider has
+stated how long it will keep refusing and probing inside its own window is the
+one thing it asked us not to do; `QUOTA_EXCEEDED` because it needs compaction
+or a human and neither happens within a minute. `CONTENTION` keeps its full
+fast tier, which is a different thing: a minutes-scale schedule for all five
+attempts rather than a single early look.
+
+Note that the retry worker runs on `*/5`, so a 60-second delay really means
+"the next five-minute tick" — that is the number to judge this against, and it
+is still an order of magnitude better than an hour.
+
+This generalizes beyond Zenodo: any provider that conflates a transient auth
+failure with a terminal one now gets one cheap look before the long wait.
+
+### Production checklist
+
+Register an application at `zenodo.org/account/settings/applications/`
+(confidential client, redirect `https://pipe.jspsych.org/oauth2/connect`), then
+set `ZENODO_CLIENT_ID` / `ZENODO_REDIRECT_URI` in the production functions env
+and add the secret to the production deploy workflow. Leave `ZENODO_ENV` unset
+so it resolves to `zenodo.org`.

--- a/functions/.env.datapipe-test
+++ b/functions/.env.datapipe-test
@@ -20,3 +20,22 @@ GDRIVE_REDIRECT_URI=https://datapipe-test.web.app/oauth2/connect
 # .env.<project> beats .env. Left as-is to avoid orphaning already-encrypted
 # test tokens; worth revisiting as a separate change.
 TOKEN_ENCRYPTION_KEY=abababababababababababababababababababababababababababababababab
+
+# --- Zenodo OAuth2 (since 2026-08-21; previously a pasted personal token) ---
+# ZENODO_ENV picks the installation the OAuth client is registered against:
+# "sandbox." here, UNSET in production. This is not a preference -- a sandbox
+# client_id cannot complete a flow on zenodo.org, so this and the credentials
+# below have to agree.
+#
+# ZENODO_AUTHORIZE_URL / ZENODO_TOKEN_URL are intentionally unset so the code
+# derives them from ZENODO_ENV, mirroring the GDRIVE_* convention above.
+#
+# The client SECRET is not here (this file is committed). It is injected at
+# deploy time from the TEST_ZENODO_CLIENT_SECRET GitHub secret, and for a local
+# `firebase deploy` from the git-ignored functions/.env.
+ZENODO_ENV=sandbox.
+ZENODO_REDIRECT_URI=https://datapipe-test.web.app/oauth2/connect
+# TODO: fill in from the OAuth application registered at
+# https://sandbox.zenodo.org/account/settings/applications/ -- connecting a
+# Zenodo account fails until this is set.
+ZENODO_CLIENT_ID=b7FnwoIGfECAs3UCSuJNQqHvXizQG9TYargM52Vu

--- a/functions/src/__tests__/compaction-emulator.test.js
+++ b/functions/src/__tests__/compaction-emulator.test.js
@@ -284,11 +284,19 @@ beforeAll(async () => {
   await db.collection("users").doc(OWNER_ID).set({
     connectedAccounts: {
       zenodo: {
-        authMethod: "static-token",
+        authMethod: "oauth2",
+        // Zenodo moved from a pasted personal access token to OAuth2 on
+        // 2026-08-21. tokenExpiresAt has to sit comfortably in the future or
+        // resolveToken would try to refresh -- these suites exercise the write
+        // path against the mock, not the OAuth path, which
+        // providers-zenodo-oauth.test.js covers against the emulator.
+        // serverUrl is deliberately absent: it is deployment config now, and
+        // in any case ZENODO_API_BASE overrides it for every call here.
         // Plaintext: no "v1:" prefix, so decrypt() passes it through. Same
         // convention as gdrive-emulator.test.js.
         encryptedToken: "compaction-token",
-        serverUrl: ZENODO_SERVER_URL,
+        encryptedRefreshToken: "compaction-refresh",
+        tokenExpiresAt: Date.now() + 24 * 60 * 60 * 1000,
       },
     },
   });

--- a/functions/src/__tests__/dataverse-emulator.test.js
+++ b/functions/src/__tests__/dataverse-emulator.test.js
@@ -483,7 +483,7 @@ describe("D5. contention is classified as transient and retried on the fast tier
 });
 
 describe("D6. duplicate CONTENT is not mistaken for contention", () => {
-  it("the same-content 400 queues on the slow tier, not the 60-second one", async () => {
+  it("the same-content 400 queues as UNAVAILABLE, never as CONTENTION", async () => {
     const experimentID = `dataverse-e2e-6-${randomUUID()}`;
     const filename = `d6-${randomUUID()}.json`;
     await createDataverseExperiment(experimentID);
@@ -499,8 +499,28 @@ describe("D6. duplicate CONTENT is not mistaken for contention", () => {
 
     const docId = `${experimentID}:${filename}`.replace(/[/\\]/g, "_");
     const queueData = (await db.collection("uploadQueue").doc(docId).get()).data();
+    // The point of this test, and unchanged: NOT CONTENTION. Misclassifying it
+    // would put a permanently-failing upload on the fast tier, spending all
+    // five attempts inside ~31 minutes on bytes Dataverse will reject
+    // identically every time.
     expect(queueData.providerErrorCode).toBe("UNAVAILABLE");
-    expect(queueData.nextRetryAt.toMillis()).toBeGreaterThan(queuedAt + 30 * 60 * 1000);
+
+    // This assertion used to require >30 minutes. UNAVAILABLE joined
+    // PROBE_RETRY_CODES on 2026-08-21, so the first look is now ~60 seconds
+    // (really the next */5 tick) before the ordinary hours-scale chain
+    // resumes.
+    //
+    // THIS CASE IS THE COST OF THAT DECISION, AND IT IS DELIBERATE. A
+    // same-content 400 is deterministic -- the probe cannot possibly succeed,
+    // so it is one wasted request, every time, for this specific Dataverse
+    // rejection. It is accepted because UNAVAILABLE overwhelmingly means a
+    // transient 5xx or network fault that clears in seconds, and because the
+    // probe DISPLACES the 1-hour first attempt rather than adding to the
+    // chain: the retry budget and the ~30-hour total window are unchanged, so
+    // the worst case is one extra request, not a shortened lifetime.
+    const deltaMs = queueData.nextRetryAt.toMillis() - queuedAt;
+    expect(deltaMs).toBeGreaterThanOrEqual(59 * 1000);
+    expect(deltaMs).toBeLessThan(10 * 60 * 1000);
   });
 });
 

--- a/functions/src/__tests__/finalization-emulator.test.js
+++ b/functions/src/__tests__/finalization-emulator.test.js
@@ -246,9 +246,17 @@ beforeAll(async () => {
   await db.collection("users").doc(OWNER_ID).set({
     connectedAccounts: {
       zenodo: {
-        authMethod: "static-token",
+        authMethod: "oauth2",
+        // Zenodo moved from a pasted personal access token to OAuth2 on
+        // 2026-08-21. tokenExpiresAt has to sit comfortably in the future or
+        // resolveToken would try to refresh -- these suites exercise the write
+        // path against the mock, not the OAuth path, which
+        // providers-zenodo-oauth.test.js covers against the emulator.
+        // serverUrl is deliberately absent: it is deployment config now, and
+        // in any case ZENODO_API_BASE overrides it for every call here.
         encryptedToken: "finalization-token",
-        serverUrl: ZENODO_SERVER_URL,
+        encryptedRefreshToken: "finalization-refresh",
+        tokenExpiresAt: Date.now() + 24 * 60 * 60 * 1000,
       },
     },
   });

--- a/functions/src/__tests__/providers-zenodo-oauth.test.js
+++ b/functions/src/__tests__/providers-zenodo-oauth.test.js
@@ -1,0 +1,290 @@
+/**
+ * @jest-environment node
+ */
+
+// Firestore-emulator-backed tests for zenodo-oauth.ts, following
+// resolve-token-gdrive.test.js's harness exactly (own admin app for fixtures,
+// one fresh uid per test, global.fetch mocked because zenodo-oauth.ts uses the
+// runtime's fetch rather than the node-fetch package).
+//
+// WHAT MAKES THIS WORTH A SEPARATE FILE FROM providers-zenodo.test.js: Zenodo
+// rotates the refresh token on EVERY refresh and deletes the previous one
+// server-side (invenio-oauth2server's save_token: "make sure that every client
+// has only one token connected to a user"). That is not a detail -- it means
+// persistence is part of the refresh's correctness, not a side effect, so
+// these cases have to assert what landed in Firestore rather than just what
+// the function returned. Mocks alone cannot express the failure it guards
+// against.
+
+jest.mock("node-fetch", () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+import { initializeApp, getApp } from "firebase-admin/app";
+import { getFirestore } from "firebase-admin/firestore";
+import { randomUUID } from "crypto";
+import { refreshZenodoToken, EXPIRY_MARGIN_MS } from "../../lib/providers/zenodo-oauth.js";
+import { decrypt, encrypt } from "../../lib/crypto-utils.js";
+
+process.env.FIRESTORE_EMULATOR_HOST = "localhost:8080";
+
+jest.setTimeout(30000);
+
+let db;
+
+const ORIGINAL_ENV = {
+  TOKEN_ENCRYPTION_KEY: process.env.TOKEN_ENCRYPTION_KEY,
+  ZENODO_TOKEN_URL: process.env.ZENODO_TOKEN_URL,
+  ZENODO_CLIENT_ID: process.env.ZENODO_CLIENT_ID,
+  ZENODO_CLIENT_SECRET: process.env.ZENODO_CLIENT_SECRET,
+};
+const ORIGINAL_FETCH = global.fetch;
+
+const TOLERANCE_MS = 5000;
+
+beforeAll(() => {
+  let app;
+  try {
+    app = getApp("zenodo-oauth-test");
+  } catch {
+    app = initializeApp({ projectId: "datapipe-test" }, "zenodo-oauth-test");
+  }
+  db = getFirestore(app);
+
+  process.env.TOKEN_ENCRYPTION_KEY = "22".repeat(32);
+  process.env.ZENODO_TOKEN_URL = "https://zenodo-token.mock.test/oauth/token";
+  process.env.ZENODO_CLIENT_ID = "test-zenodo-client-id";
+  process.env.ZENODO_CLIENT_SECRET = "test-zenodo-client-secret";
+});
+
+afterAll(() => {
+  process.env.TOKEN_ENCRYPTION_KEY = ORIGINAL_ENV.TOKEN_ENCRYPTION_KEY;
+  process.env.ZENODO_TOKEN_URL = ORIGINAL_ENV.ZENODO_TOKEN_URL;
+  process.env.ZENODO_CLIENT_ID = ORIGINAL_ENV.ZENODO_CLIENT_ID;
+  process.env.ZENODO_CLIENT_SECRET = ORIGINAL_ENV.ZENODO_CLIENT_SECRET;
+  global.fetch = ORIGINAL_FETCH;
+});
+
+beforeEach(() => {
+  global.fetch = jest.fn();
+});
+
+function tokenResponse(body, { ok = true, status = 200 } = {}) {
+  return {
+    ok,
+    status,
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(typeof body === "string" ? body : JSON.stringify(body)),
+  };
+}
+
+function errorResponse(text, status = 400) {
+  return {
+    ok: false,
+    status,
+    json: () => Promise.resolve({}),
+    text: () => Promise.resolve(text),
+  };
+}
+
+// Seeds users/{uid} and returns both the uid and the connection object a
+// caller would have read a moment earlier. Tests that model a race pass a
+// DIFFERENT connection than what was stored.
+async function seedUser(overrides = {}) {
+  const uid = `zenodo-oauth-${randomUUID()}`;
+  const connection = {
+    authMethod: "oauth2",
+    encryptedToken: encrypt("access-old"),
+    encryptedRefreshToken: encrypt("refresh-old"),
+    tokenExpiresAt: Date.now() - 1000,
+    ...overrides,
+  };
+  await db.doc(`users/${uid}`).set({ connectedAccounts: { zenodo: connection } });
+  return { uid, connection };
+}
+
+async function readConnection(uid) {
+  const snap = await db.doc(`users/${uid}`).get();
+  return snap.data().connectedAccounts.zenodo;
+}
+
+describe("refreshZenodoToken: the ordinary path", () => {
+  it("exchanges the refresh token and persists the new access token", async () => {
+    const { uid, connection } = await seedUser();
+    global.fetch.mockResolvedValueOnce(
+      tokenResponse({ access_token: "access-new", refresh_token: "refresh-new", expires_in: 3600 })
+    );
+
+    const result = await refreshZenodoToken(uid, connection);
+
+    expect(result).toEqual({ success: true, accessToken: "access-new" });
+
+    const [url, options] = global.fetch.mock.calls[0];
+    expect(url).toBe("https://zenodo-token.mock.test/oauth/token");
+    const body = new URLSearchParams(options.body);
+    expect(body.get("grant_type")).toBe("refresh_token");
+    expect(body.get("refresh_token")).toBe("refresh-old");
+    expect(body.get("client_id")).toBe("test-zenodo-client-id");
+
+    const stored = await readConnection(uid);
+    expect(decrypt(stored.encryptedToken)).toBe("access-new");
+    expect(stored.tokenExpiresAt).toBeGreaterThan(Date.now() + 3600 * 1000 - TOLERANCE_MS);
+  });
+
+  // THE ONE THAT MATTERS MOST. Zenodo has already deleted "refresh-old" by the
+  // time we get this response; failing to store "refresh-new" would leave the
+  // researcher permanently unable to write data, mid-experiment, with no
+  // symptom until the access token lapses an hour later.
+  it("persists the rotated refresh token, not just the access token", async () => {
+    const { uid, connection } = await seedUser();
+    global.fetch.mockResolvedValueOnce(
+      tokenResponse({ access_token: "access-new", refresh_token: "refresh-new", expires_in: 3600 })
+    );
+
+    await refreshZenodoToken(uid, connection);
+
+    const stored = await readConnection(uid);
+    expect(decrypt(stored.encryptedRefreshToken)).toBe("refresh-new");
+  });
+
+  it("keeps the previous refresh token when the response omits one", async () => {
+    const { uid, connection } = await seedUser();
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+    global.fetch.mockResolvedValueOnce(
+      tokenResponse({ access_token: "access-new", expires_in: 3600 })
+    );
+
+    const result = await refreshZenodoToken(uid, connection);
+
+    expect(result.success).toBe(true);
+    // Keeping a probably-dead token beats clearing the field: it leaves the
+    // next refresh something to fail loudly on rather than a missing property.
+    expect(decrypt((await readConnection(uid)).encryptedRefreshToken)).toBe("refresh-old");
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it("reports a response missing access_token as a failure", async () => {
+    const { uid, connection } = await seedUser();
+    global.fetch.mockResolvedValueOnce(tokenResponse({ expires_in: 3600 }));
+
+    const result = await refreshZenodoToken(uid, connection);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("INVALID_REFRESH_TOKEN");
+    // Nothing partial written.
+    expect(decrypt((await readConnection(uid)).encryptedToken)).toBe("access-old");
+  });
+});
+
+describe("refreshZenodoToken: the rotation race", () => {
+  // Two submissions arrive after an idle hour, both see an expired access
+  // token, both refresh. The first rotates refresh-old -> refresh-winner; the
+  // second still holds refresh-old in memory and Zenodo no longer knows it.
+  // The connection is HEALTHY -- treating this as a dead grant would tear down
+  // a working account in the middle of data collection.
+  it("recovers by using the credentials the winner persisted", async () => {
+    const { uid } = await seedUser({
+      encryptedToken: encrypt("access-winner"),
+      encryptedRefreshToken: encrypt("refresh-winner"),
+      tokenExpiresAt: Date.now() + 60 * 60 * 1000,
+    });
+    const staleConnection = {
+      authMethod: "oauth2",
+      encryptedToken: encrypt("access-old"),
+      encryptedRefreshToken: encrypt("refresh-old"),
+      tokenExpiresAt: Date.now() - 1000,
+    };
+    global.fetch.mockResolvedValueOnce(errorResponse('{"error": "invalid_grant"}'));
+
+    const result = await refreshZenodoToken(uid, staleConnection);
+
+    expect(result).toEqual({ success: true, accessToken: "access-winner" });
+    // One exchange only -- the winner's token was still fresh, so there was
+    // nothing to ask Zenodo for.
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("exchanges once more when the winner's access token is also stale", async () => {
+    const { uid } = await seedUser({
+      encryptedToken: encrypt("access-winner"),
+      encryptedRefreshToken: encrypt("refresh-winner"),
+      tokenExpiresAt: Date.now() + EXPIRY_MARGIN_MS - 1000,
+    });
+    const staleConnection = {
+      authMethod: "oauth2",
+      encryptedToken: encrypt("access-old"),
+      encryptedRefreshToken: encrypt("refresh-old"),
+      tokenExpiresAt: Date.now() - 1000,
+    };
+    global.fetch
+      .mockResolvedValueOnce(errorResponse('{"error": "invalid_grant"}'))
+      .mockResolvedValueOnce(
+        tokenResponse({ access_token: "access-final", refresh_token: "refresh-final", expires_in: 3600 })
+      );
+
+    const result = await refreshZenodoToken(uid, staleConnection);
+
+    expect(result).toEqual({ success: true, accessToken: "access-final" });
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+    // The retry must present the WINNER's refresh token, not the dead one.
+    expect(new URLSearchParams(global.fetch.mock.calls[1][1].body).get("refresh_token")).toBe(
+      "refresh-winner"
+    );
+    expect(decrypt((await readConnection(uid)).encryptedRefreshToken)).toBe("refresh-final");
+  });
+
+  // Same invalid_grant, but nothing rotated -- the stored token is still the
+  // one we presented. This is a genuinely revoked grant and must be reported
+  // as such, or a researcher who disconnected DataPipe on Zenodo would see
+  // retries forever instead of being told to reconnect.
+  it("reports a genuinely revoked grant when nothing rotated", async () => {
+    const { uid, connection } = await seedUser();
+    global.fetch.mockResolvedValueOnce(errorResponse('{"error": "invalid_grant"}'));
+
+    const result = await refreshZenodoToken(uid, connection);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("INVALID_REFRESH_TOKEN");
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports PROVIDER_NOT_CONNECTED when the account vanished mid-flight", async () => {
+    const { uid, connection } = await seedUser();
+    await db.doc(`users/${uid}`).set({ connectedAccounts: {} });
+    global.fetch.mockResolvedValueOnce(errorResponse('{"error": "invalid_grant"}'));
+
+    const result = await refreshZenodoToken(uid, connection);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("PROVIDER_NOT_CONNECTED");
+  });
+
+  // invalid_client and unsupported_grant_type are also 400s, but they are
+  // configuration faults -- a wrong client secret, say. Sending those down the
+  // race-recovery path would waste a Firestore read hunting for a rotation
+  // that never happened, and could mask a broken deployment as a transient.
+  it("does not treat other 400s as a race", async () => {
+    const { uid, connection } = await seedUser();
+    global.fetch.mockResolvedValueOnce(errorResponse('{"error": "invalid_client"}'));
+
+    const result = await refreshZenodoToken(uid, connection);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("INVALID_REFRESH_TOKEN");
+    expect(result.detail).toContain("invalid_client");
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports a network error without touching stored credentials", async () => {
+    const { uid, connection } = await seedUser();
+    global.fetch.mockRejectedValueOnce(new Error("socket hang up"));
+
+    const result = await refreshZenodoToken(uid, connection);
+
+    expect(result.success).toBe(false);
+    expect(result.detail).toContain("socket hang up");
+    expect(decrypt((await readConnection(uid)).encryptedRefreshToken)).toBe("refresh-old");
+  });
+});

--- a/functions/src/__tests__/providers-zenodo.test.js
+++ b/functions/src/__tests__/providers-zenodo.test.js
@@ -21,6 +21,14 @@ const DEPOSITION_ID = 987654;
 
 beforeEach(() => {
   mockFetch.mockClear();
+  // zenodoOAuthHost() reads this at CALL time, so it has to be set per test
+  // rather than at import. Pinned to the sandbox so it agrees with SERVER_URL
+  // below and a stray real-host URL in an assertion stands out.
+  process.env.ZENODO_ENV = "sandbox.";
+});
+
+afterAll(() => {
+  delete process.env.ZENODO_ENV;
 });
 
 function mockResponse({ status, statusText, jsonBody, textBody, headers }) {
@@ -56,21 +64,29 @@ const container = {
 const meta = { size: 12, contentType: "application/json" };
 
 describe("1. resolveToken", () => {
-  it("returns the decrypted token and serverUrl for a connected account", async () => {
-    const userData = {
+  // decrypt() falls back to plaintext for values without the "v1:" prefix, so
+  // plain strings round-trip without needing TOKEN_ENCRYPTION_KEY here. The
+  // refresh path -- which encrypts and persists -- is exercised against the
+  // Firestore emulator in providers-zenodo-oauth.test.js instead.
+  function connected(overrides) {
+    return {
       connectedAccounts: {
         zenodo: {
-          authMethod: "static-token",
-          // decrypt() falls back to plaintext for values without the "v1:"
-          // prefix, so a plain string round-trips without needing
-          // TOKEN_ENCRYPTION_KEY set up for this test.
+          authMethod: "oauth2",
           encryptedToken: "plain-token",
-          serverUrl: SERVER_URL,
+          encryptedRefreshToken: "plain-refresh",
+          tokenExpiresAt: Date.now() + 60 * 60 * 1000,
+          ...overrides,
         },
       },
     };
-    const result = await zenodoProvider.resolveToken(userData, "owner-uid");
+  }
+
+  it("returns the stored token while it is still comfortably fresh", async () => {
+    const result = await zenodoProvider.resolveToken(connected(), "owner-uid");
     expect(result).toEqual({ success: true, token: "plain-token", serverUrl: SERVER_URL });
+    // No refresh request: a live token must not cost a round trip.
+    expect(mockFetch).not.toHaveBeenCalled();
   });
 
   it("fails with PROVIDER_NOT_CONNECTED when there is no zenodo account", async () => {
@@ -79,27 +95,47 @@ describe("1. resolveToken", () => {
     expect(result.error).toBe("PROVIDER_NOT_CONNECTED");
   });
 
-  // Zenodo tokens have no documented expiry so tokenExpiresAt is normally
-  // absent -- but if one is ever stored it must still be honored rather than
-  // ignored.
-  it("honors a stored tokenExpiresAt in the past", async () => {
-    const userData = {
-      connectedAccounts: {
-        zenodo: {
-          authMethod: "static-token",
-          encryptedToken: "plain-token",
-          serverUrl: SERVER_URL,
-          tokenExpiresAt: Date.now() - 1000,
-        },
-      },
-    };
-    const result = await zenodoProvider.resolveToken(userData, "owner-uid");
-    expect(result.success).toBe(false);
-    expect(result.error).toBe("PROVIDER_TOKEN_EXPIRED");
+  // The host is now deployment configuration, not per-connection data. An
+  // OAuth client_id is registered against ONE installation, so a serverUrl
+  // left on a stored connection -- by a migration, a hand edit, or an old
+  // static-token document -- must never be able to point a live client at the
+  // other Zenodo.
+  it("ignores any serverUrl left on the stored connection", async () => {
+    const result = await zenodoProvider.resolveToken(
+      connected({ serverUrl: "https://zenodo.org" }),
+      "owner-uid"
+    );
+    expect(result.success).toBe(true);
+    expect(result.serverUrl).toBe(SERVER_URL);
   });
 
-  it("does not implement staticTokenExpiry (Zenodo reports no expiry)", () => {
+  it("defaults to production zenodo.org when ZENODO_ENV is unset", async () => {
+    delete process.env.ZENODO_ENV;
+    const result = await zenodoProvider.resolveToken(connected(), "owner-uid");
+    // Never "https://undefinedzenodo.org", and never the sandbox: a
+    // misconfigured production deploy must fail loudly against the real host
+    // rather than quietly writing test data nobody looks at.
+    expect(result.serverUrl).toBe("https://zenodo.org");
+  });
+
+  it("no longer implements the static-token hooks", () => {
+    // connect-provider.ts's connectStaticTokenProvider rejects any provider
+    // missing validateStaticToken, which is what stops a researcher pasting a
+    // personal access token into a flow that now expects OAuth.
+    expect(zenodoProvider.validateStaticToken).toBeUndefined();
     expect(zenodoProvider.staticTokenExpiry).toBeUndefined();
+  });
+
+  // Zenodo access tokens last an hour, short enough that one checked as valid
+  // at the top of a request can die during a slow upload -- a compaction pass
+  // moves up to MAX_BATCH_BYTES in a single call.
+  it("treats a token expiring within the margin as already stale", async () => {
+    const userData = connected({ tokenExpiresAt: Date.now() + 30 * 1000 });
+    // Refreshing needs Firestore, which this suite has no emulator for, so
+    // assert the decision rather than the outcome: it must NOT hand back the
+    // nearly-dead token.
+    const result = await zenodoProvider.resolveToken(userData, "owner-uid").catch(() => null);
+    expect(result?.token).not.toBe("plain-token");
   });
 });
 
@@ -512,18 +548,47 @@ describe("8. downloadFile", () => {
   });
 });
 
-describe("9. validateStaticToken", () => {
-  it("returns true on 200", async () => {
-    mockFetch.mockResolvedValueOnce(mockResponse({ status: 200, jsonBody: [] }));
-    expect(await zenodoProvider.validateStaticToken(auth)).toBe(true);
-    expect(callArgs(0).url).toBe(`${SERVER_URL}/api/deposit/depositions?size=1`);
+describe("9. oauthConfig", () => {
+  it("targets the installation named by ZENODO_ENV", () => {
+    const config = zenodoProvider.oauthConfig();
+    expect(config.authorizeUrl).toBe("https://sandbox.zenodo.org/oauth/authorize");
+    expect(config.tokenUrl).toBe("https://sandbox.zenodo.org/oauth/token");
   });
 
-  // An under-scoped token is "not valid" here rather than an exception --
-  // catching it at connect time is the point.
-  it("returns false on 403 without throwing", async () => {
-    mockFetch.mockResolvedValueOnce(mockResponse({ status: 403, jsonBody: { message: "Insufficient scope" } }));
-    expect(await zenodoProvider.validateStaticToken(auth)).toBe(false);
+  it("defaults to production when ZENODO_ENV is unset", () => {
+    delete process.env.ZENODO_ENV;
+    const config = zenodoProvider.oauthConfig();
+    expect(config.authorizeUrl).toBe("https://zenodo.org/oauth/authorize");
+  });
+
+  // THE SCOPE LIST IS A DECISION, NOT A DETAIL. invenio-oauth2server also
+  // registers a user:email scope, and asking for it would hand us the
+  // researcher's identity in the token response itself. We deliberately do
+  // not: identity is Firebase's job (lib/auth-providers.js), and Zenodo could
+  // not serve as a sign-in provider regardless -- invenio-oauth2server
+  // implements no OIDC layer at all, so there is no id_token for Firebase to
+  // verify. Widening this list would widen the consent screen for nothing.
+  it("requests exactly the two deposit scopes and no identity scope", () => {
+    const scopes = zenodoProvider.oauthConfig().scope.split(" ").sort();
+    expect(scopes).toEqual(["deposit:actions", "deposit:write"]);
+  });
+
+  // Google needs access_type=offline&prompt=consent to issue a refresh token
+  // at all. Zenodo issues one unconditionally on the authorization_code
+  // grant, so there is nothing to add here -- but the field must still be an
+  // object, because generate-oauth-state.ts iterates it unguarded.
+  it("adds no extra authorize parameters, but still supplies the object", () => {
+    expect(zenodoProvider.oauthConfig().extraAuthParams).toEqual({});
+  });
+
+  it("reads client credentials from the environment at call time", () => {
+    process.env.ZENODO_CLIENT_ID = "test-client";
+    process.env.ZENODO_REDIRECT_URI = "https://datapipe-test.web.app/oauth2/connect";
+    const config = zenodoProvider.oauthConfig();
+    expect(config.clientId).toBe("test-client");
+    expect(config.redirectUri).toBe("https://datapipe-test.web.app/oauth2/connect");
+    delete process.env.ZENODO_CLIENT_ID;
+    delete process.env.ZENODO_REDIRECT_URI;
   });
 });
 
@@ -744,7 +809,7 @@ describe("9e. writeStreamedFile", () => {
 describe("10. registry wiring", () => {
   it("declares the capability surface the framework reads", () => {
     expect(zenodoProvider.id).toBe("zenodo");
-    expect(zenodoProvider.authMethod).toBe("static-token");
+    expect(zenodoProvider.authMethod).toBe("oauth2");
     // No folder concept in either Zenodo API generation -- the framework's
     // filename-prefix fallback has to apply.
     expect(zenodoProvider.capabilities.nativeSubfolders).toBe(false);

--- a/functions/src/__tests__/upload-queue.test.js
+++ b/functions/src/__tests__/upload-queue.test.js
@@ -45,6 +45,7 @@ let db;
 let app;
 let queueUpload;
 let isFastRetry;
+let isProbeRetry;
 
 beforeAll(async () => {
   try {
@@ -61,7 +62,7 @@ beforeAll(async () => {
   // first), and its app.js does a bare, unnamed initializeApp() -- distinct
   // from this suite's own NAMED "upload-queue-test" app above, so the two
   // don't collide.
-  ({ default: queueUpload, isFastRetry } = await import("../../lib/queue-upload.js"));
+  ({ default: queueUpload, isFastRetry, isProbeRetry } = await import("../../lib/queue-upload.js"));
 });
 
 // Only the docs THIS suite created. A collection-wide wipe here used to
@@ -228,6 +229,37 @@ describe("scheduled-upload-retry tiered backoff arithmetic", () => {
   test("a missing or cleared providerErrorCode is slow tier", () => {
     expect(isFastRetry(undefined)).toBe(false);
     expect(isFastRetry(null)).toBe(false);
+    expect(isProbeRetry(undefined)).toBe(false);
+    expect(isProbeRetry(null)).toBe(false);
+  });
+
+  // The probe tier is NOT the fast tier: it buys one early look, not a
+  // minutes-scale schedule. AUTH_EXPIRED must therefore be a probe code and
+  // NOT a fast code -- if it ever became both, five attempts would burn
+  // inside ~31 minutes against what is usually a genuinely revoked token.
+  test("probe codes take one early look but are not on the fast tier", () => {
+    for (const code of ["AUTH_EXPIRED", "UNAVAILABLE"]) {
+      expect(isProbeRetry(code)).toBe(true);
+      expect(isFastRetry(code)).toBe(false);
+    }
+  });
+
+  // RATE_LIMITED is excluded because the provider has stated how long it will
+  // keep refusing; QUOTA_EXCEEDED because nothing clears it within a minute.
+  test("RATE_LIMITED and QUOTA_EXCEEDED never probe", () => {
+    for (const code of ["RATE_LIMITED", "QUOTA_EXCEEDED", "NAME_CONFLICT", "CONTENTION"]) {
+      expect(isProbeRetry(code)).toBe(false);
+    }
+  });
+
+  // What makes the probe free rather than additive: once it fails, the worker
+  // reads AUTH_EXPIRED as slow tier and resumes the ordinary chain, so the
+  // item still gets five attempts across ~30 hours instead of ~31. Mirrors the
+  // production formula, same convention as the rest of this block.
+  test("a failed probe reverts to the hours-scale chain, not a second minute", () => {
+    const baseMs = isFastRetry("AUTH_EXPIRED") ? 60 * 1000 : 60 * 60 * 1000;
+    const afterProbe = Math.min(Math.pow(2, 1) * baseMs, SLOW_MAX_BACKOFF_MS);
+    expect(afterProbe).toBe(2 * 60 * 60 * 1000);
   });
 
   test("slow tier (everything else) is unchanged: ~2, 4, 8, 16, 24 hours", () => {
@@ -309,6 +341,39 @@ describe("queueUpload tiers the first nextRetryAt by providerErrorCode", () => {
     expect(deltaMs).toBeLessThanOrEqual(60 * 60 * 1000 + 5000);
   });
 
+  // The gate-N case: a Zenodo 403 caused by a concurrent refresh rotating the
+  // access token away is indistinguishable from a revoked one in the response,
+  // but heals itself in seconds. An hour is the wrong first look.
+  test("an AUTH_EXPIRED providerErrorCode sets nextRetryAt ~60 seconds out (probe)", async () => {
+    const experimentID = `queue-probe-auth-${randomUUID()}`;
+    const filename = `file-${randomUUID()}.json`;
+    const docId = `${experimentID}:${filename}`.replace(/[/\\]/g, "_");
+    queueDoc(docId);
+
+    const before = Date.now();
+    await queueUpload({
+      experimentID,
+      owner: "upload-queue-test-owner",
+      filename,
+      data: "[]",
+      dataType: "data",
+      osfFilesLink: "https://osf.io/files/",
+      errorCode: 403,
+      providerErrorCode: "AUTH_EXPIRED",
+      sessionIncremented: true,
+    });
+    const after = Date.now();
+
+    const doc = await db.collection("uploadQueue").doc(docId).get();
+    expect(doc.exists).toBe(true);
+    expect(doc.data().providerErrorCode).toBe("AUTH_EXPIRED");
+
+    const deltaMs = doc.data().nextRetryAt.toMillis() - before;
+    expect(deltaMs).toBeGreaterThanOrEqual(59 * 1000);
+    // Comfortably short of the hour it would be without the probe tier.
+    expect(deltaMs).toBeLessThan(after - before + 5 * 60 * 1000);
+  });
+
   // Regression guard: RATE_LIMITED was briefly fast-tiered, which cut the
   // whole retry budget for an OSF/Drive 429 from ~31 hours to ~2.
   test("a RATE_LIMITED providerErrorCode sets nextRetryAt ~1 hour out (slow tier)", async () => {
@@ -339,8 +404,11 @@ describe("queueUpload tiers the first nextRetryAt by providerErrorCode", () => {
     expect(deltaMs).toBeLessThanOrEqual(60 * 60 * 1000 + 5000);
   });
 
-  test("an UNAVAILABLE providerErrorCode also sets nextRetryAt ~1 hour out (slow tier)", async () => {
-    const experimentID = `queue-slow-tier-unavailable-${randomUUID()}`;
+  // Was a slow-tier assertion until UNAVAILABLE joined PROBE_RETRY_CODES. A
+  // 5xx is usually a blip that clears in seconds, and the cost of being wrong
+  // is a single extra request before the same hours-scale chain resumes.
+  test("an UNAVAILABLE providerErrorCode sets nextRetryAt ~60 seconds out (probe)", async () => {
+    const experimentID = `queue-probe-unavailable-${randomUUID()}`;
     const filename = `file-${randomUUID()}.json`;
     const docId = `${experimentID}:${filename}`.replace(/[/\\]/g, "_");
     queueDoc(docId);
@@ -357,14 +425,15 @@ describe("queueUpload tiers the first nextRetryAt by providerErrorCode", () => {
       providerErrorCode: "UNAVAILABLE",
       sessionIncremented: true,
     });
+    const after = Date.now();
 
     const doc = await db.collection("uploadQueue").doc(docId).get();
     expect(doc.exists).toBe(true);
     expect(doc.data().providerErrorCode).toBe("UNAVAILABLE");
 
     const deltaMs = doc.data().nextRetryAt.toMillis() - before;
-    expect(deltaMs).toBeGreaterThan(55 * 60 * 1000);
-    expect(deltaMs).toBeLessThanOrEqual(60 * 60 * 1000 + 5000);
+    expect(deltaMs).toBeGreaterThanOrEqual(59 * 1000);
+    expect(deltaMs).toBeLessThan(after - before + 5 * 60 * 1000);
   });
 });
 

--- a/functions/src/__tests__/zenodo-emulator.test.js
+++ b/functions/src/__tests__/zenodo-emulator.test.js
@@ -245,9 +245,17 @@ beforeAll(async () => {
   await db.collection("users").doc(ZENODO_OWNER_ID).set({
     connectedAccounts: {
       zenodo: {
-        authMethod: "static-token",
+        authMethod: "oauth2",
+        // Zenodo moved from a pasted personal access token to OAuth2 on
+        // 2026-08-21. tokenExpiresAt has to sit comfortably in the future or
+        // resolveToken would try to refresh -- these suites exercise the write
+        // path against the mock, not the OAuth path, which
+        // providers-zenodo-oauth.test.js covers against the emulator.
+        // serverUrl is deliberately absent: it is deployment config now, and
+        // in any case ZENODO_API_BASE overrides it for every call here.
         encryptedToken: "zenodo-integration-token", // plaintext fallback, see header
-        serverUrl: ZENODO_SERVER_URL,
+        encryptedRefreshToken: "zenodo-integration-refresh",
+        tokenExpiresAt: Date.now() + 24 * 60 * 60 * 1000,
       },
     },
   });

--- a/functions/src/api-messages.ts
+++ b/functions/src/api-messages.ts
@@ -47,12 +47,14 @@ const MESSAGES = {
     error: "PROVIDER_NOT_CONNECTED",
     message: "The experiment owner has not connected an account for this experiment's storage provider",
   },
-  // Named no provider. Both static-token adapters emit this code (dataverse.ts
-  // and zenodo.ts), so hardcoding "Dataverse" told a Zenodo owner to go fix a
-  // token on a service they may not even use. The wording still carries what
-  // makes this code distinct from AUTH_EXPIRED -- a static token cannot be
-  // refreshed, so the researcher has to CREATE a new one and reconnect, not
-  // just re-authorize.
+  // Names no provider. It once had to cover two static-token adapters, and
+  // hardcoding "Dataverse" told a Zenodo owner to go fix a token on a service
+  // they may not even use. Zenodo moved to OAuth2 on 2026-08-21 and no longer
+  // emits this at all, leaving dataverse.ts as the only source -- but the
+  // wording stays provider-neutral, since the next static-token provider would
+  // reintroduce exactly the same bug. What it carries is what makes this code
+  // distinct from AUTH_EXPIRED: a static token cannot be refreshed, so the
+  // researcher has to CREATE a new one and reconnect, not just re-authorize.
   PROVIDER_TOKEN_EXPIRED: {
     error: "PROVIDER_TOKEN_EXPIRED",
     message:

--- a/functions/src/providers/types.ts
+++ b/functions/src/providers/types.ts
@@ -355,11 +355,16 @@ export interface ConnectedAccounts {
   gdrive?: OAuth2AccountConnection;
   figshare?: OAuth2AccountConnection;
   dataverse?: StaticTokenAccountConnection;
-  // Zenodo reuses the static-token shape, but its tokenExpiresAt is expected
-  // to stay ABSENT: Zenodo personal access tokens have no documented expiry
-  // and no endpoint reports one, so zenodo.ts implements no staticTokenExpiry
-  // and connect-provider.ts therefore omits the field.
-  zenodo?: StaticTokenAccountConnection;
+  // Zenodo was a static-token provider until 2026-08-21 and is now OAuth2.
+  // Its tokenExpiresAt is always PRESENT, unlike the personal access tokens
+  // this replaced, which never expired at all -- but it is SIXTY DAYS out, not
+  // the one hour the upstream source implies (Zenodo overrides oauthlib's
+  // default in deployment config; measured by spike gate J, 2026-08-21).
+  // The refresh token behind it carries no expiry of its own, so a connection
+  // can survive indefinitely -- but only if every rotation is persisted,
+  // because Zenodo destroys the previous refresh token on each refresh. See
+  // zenodo-oauth.ts.
+  zenodo?: OAuth2AccountConnection;
 }
 
 // experiments/{id}.collisionCache (additive Firestore schema). The salt is a

--- a/functions/src/providers/zenodo-oauth.ts
+++ b/functions/src/providers/zenodo-oauth.ts
@@ -1,0 +1,264 @@
+// Zenodo OAuth token refresh.
+//
+// SEPARATE FROM gdrive-oauth.ts DESPITE THE SIMILAR SHAPE, because Zenodo's
+// refresh semantics differ in one way that changes the whole failure model:
+// ZENODO ROTATES THE REFRESH TOKEN ON EVERY REFRESH AND DESTROYS THE OLD ONE.
+//
+// Verified by reading invenio-oauth2server (Zenodo runs InvenioRDM, which
+// reports itself in the page generator meta tag), 2026-08-21 -- none of this
+// is in Zenodo's developer documentation, which only covers personal access
+// tokens:
+//
+//   oauthlib RequestValidator.rotate_refresh_token   -> defaults to True
+//   invenio_oauth2server.provider.save_token         -> deletes EVERY prior
+//     Token row for (client_id, user_id) before inserting the new one
+//     ("make sure that every client has only one token connected to a user")
+//
+// Google keeps a refresh token stable for years and reissues the same value,
+// so gdrive's path can treat a lost refresh response as harmless. Here it is
+// not. Two consequences, both handled below:
+//
+//  1. LOSING THE RESPONSE LOSES THE ACCOUNT. The old refresh token is dead the
+//     instant Zenodo answers, so a crash between the HTTP response and the
+//     Firestore write leaves the researcher unable to write data until they
+//     reconnect by hand -- mid-experiment. persistRefreshedToken() is
+//     therefore the very next thing that happens after parsing, and a failure
+//     there is logged distinctly rather than folded into "refresh failed".
+//
+//  2. CONCURRENT REFRESHES RACE. Two submissions arriving after an idle hour
+//     both see an expired access token and both refresh. The first rotates
+//     R -> R1; the second presents R, which no longer exists, and Zenodo
+//     answers 400 invalid_grant. That is NOT a dead connection -- R1 is
+//     perfectly good -- and treating it as one would tear down a working
+//     account in the middle of data collection. recoverFromRotationRace()
+//     re-reads the stored connection and continues with whatever the winner
+//     persisted.
+//
+// Uses the runtime's global `fetch` rather than the "node-fetch" package,
+// matching gdrive-oauth.ts and refresh-token.ts so tests can mock global.fetch.
+
+import { decrypt, encrypt } from "../crypto-utils.js";
+import { db } from "../app.js";
+import { OAuth2AccountConnection } from "./types.js";
+
+export type ZenodoRefreshResult =
+  | { success: true; accessToken: string }
+  | { success: false; error: string; detail: string };
+
+const CONNECTION_PATH = "connectedAccounts.zenodo";
+
+// Treat a token as expired this long before it actually is, so a token checked
+// as valid at the top of a request cannot expire during a slow upload -- a
+// compaction pass moves up to MAX_BATCH_BYTES in a single call.
+//
+// MEASURED, NOT ASSUMED: sandbox.zenodo.org issues expires_in=5184000, i.e.
+// SIXTY DAYS (spike gate J, 2026-08-21). Reading the source would tell you one
+// hour -- Invenio never sets OAUTH2_PROVIDER_TOKEN_EXPIRES_IN, so it falls
+// through to oauthlib's `expires_in or 3600` -- but Zenodo overrides it in
+// deployment config, which is not public. This is exactly the class of fact a
+// spike exists to establish.
+//
+// A five-minute margin against a sixty-day lifetime is therefore vanishingly
+// small, and deliberately so: it is here to stop a mid-request expiry, not to
+// schedule refreshes. What the long lifetime really means is that refresh is a
+// RARE event -- roughly one per connection per two months -- so it will almost
+// never be exercised in testing and has to be right by construction.
+export const EXPIRY_MARGIN_MS = 5 * 60 * 1000;
+
+// The Zenodo installation this DEPLOYMENT talks to: "" -> zenodo.org,
+// "sandbox." -> sandbox.zenodo.org. Mirrors NEXT_PUBLIC_ZENODO_ENV on the
+// frontend and NEXT_PUBLIC_OSF_ENV's host-prefix shape.
+//
+// Unlike the static-token era, this is NOT a per-researcher choice any more
+// and must not be read off the stored connection: an OAuth client_id is
+// registered against ONE installation, so a sandbox client simply cannot
+// complete a flow on zenodo.org. Deployment config is the only thing that can
+// legitimately decide which host we mean.
+export function zenodoOAuthHost(): string {
+  return `https://${process.env.ZENODO_ENV ?? ""}zenodo.org`;
+}
+
+export function zenodoAuthorizeUrl(): string {
+  return process.env.ZENODO_AUTHORIZE_URL || `${zenodoOAuthHost()}/oauth/authorize`;
+}
+
+export function zenodoTokenUrl(): string {
+  return process.env.ZENODO_TOKEN_URL || `${zenodoOAuthHost()}/oauth/token`;
+}
+
+type ExchangeOutcome =
+  | { kind: "ok"; data: Record<string, unknown> }
+  | { kind: "invalid-grant"; detail: string }
+  | { kind: "failed"; detail: string };
+
+/**
+ * One POST to Zenodo's token endpoint with the refresh_token grant.
+ *
+ * `invalid-grant` is split out from `failed` because only that one is
+ * ambiguous: it means the presented refresh token does not exist, which is
+ * true both when the grant was revoked AND when a concurrent refresh rotated
+ * it a moment ago. The caller resolves that ambiguity; everything else here
+ * is a plain failure.
+ */
+async function exchangeRefreshToken(refreshToken: string): Promise<ExchangeOutcome> {
+  const params = new URLSearchParams({
+    grant_type: "refresh_token",
+    refresh_token: refreshToken,
+    client_id: process.env.ZENODO_CLIENT_ID as string,
+    client_secret: process.env.ZENODO_CLIENT_SECRET as string,
+  });
+
+  let response: Response;
+  try {
+    response = await fetch(zenodoTokenUrl(), {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: params.toString(),
+    });
+  } catch (e) {
+    const detail = e instanceof Error ? e.message : "Unknown network error";
+    return { kind: "failed", detail };
+  }
+
+  if (!response.ok) {
+    const body = await response.text();
+    // oauthlib answers 400 {"error": "invalid_grant"}. Matched on the body
+    // rather than the status alone: 400 also covers invalid_client and
+    // unsupported_grant_type, which are configuration faults, not races, and
+    // must not send us hunting for a rotation that never happened.
+    if (body.includes("invalid_grant")) {
+      return { kind: "invalid-grant", detail: body };
+    }
+    return { kind: "failed", detail: body || `Token endpoint returned ${response.status}` };
+  }
+
+  return { kind: "ok", data: (await response.json()) as Record<string, unknown> };
+}
+
+/**
+ * Writes a freshly issued token back to the user document.
+ *
+ * This is the dangerous half of a Zenodo refresh: by the time it runs, the
+ * refresh token we presented has ALREADY been deleted server-side, so if this
+ * write does not land the researcher's connection is unrecoverable without a
+ * manual reconnect. Hence the explicit, greppable error log -- a silent throw
+ * here would be indistinguishable from an ordinary transient failure.
+ */
+async function persistRefreshedToken(
+  uid: string,
+  data: Record<string, unknown>
+): Promise<ZenodoRefreshResult> {
+  const accessToken = data.access_token as string | undefined;
+  const expiresIn = data.expires_in as number | undefined;
+  const refreshToken = data.refresh_token as string | undefined;
+
+  if (!accessToken || typeof expiresIn !== "number") {
+    return {
+      success: false,
+      error: "INVALID_REFRESH_TOKEN",
+      detail: "Zenodo token response was missing access_token or expires_in",
+    };
+  }
+
+  const update: Record<string, unknown> = {
+    [`${CONNECTION_PATH}.encryptedToken`]: encrypt(accessToken),
+    [`${CONNECTION_PATH}.tokenExpiresAt`]: Date.now() + expiresIn * 1000,
+  };
+
+  if (refreshToken) {
+    update[`${CONNECTION_PATH}.encryptedRefreshToken`] = encrypt(refreshToken);
+  } else {
+    // Should not happen -- oauthlib's refresh grant always issues one -- but
+    // if it ever does, keeping the old value is strictly better than clearing
+    // it, and the warning says why the next refresh may fail.
+    console.warn(
+      `zenodo: refresh for ${uid} returned no refresh_token; keeping the previous one, ` +
+        "which Zenodo has probably already invalidated"
+    );
+  }
+
+  try {
+    await db.doc(`users/${uid}`).update(update);
+  } catch (e) {
+    const detail = e instanceof Error ? e.message : "Unknown Firestore error";
+    console.error(
+      `zenodo: FAILED TO PERSIST ROTATED CREDENTIALS for ${uid} -- the previous refresh ` +
+        `token is already dead server-side, so this account must be reconnected by hand: ${detail}`
+    );
+    return { success: false, error: "INVALID_REFRESH_TOKEN", detail };
+  }
+
+  return { success: true, accessToken };
+}
+
+/**
+ * Resolves an invalid_grant by asking whether somebody else rotated the token.
+ *
+ * Re-reads the stored connection and compares it against the refresh token we
+ * just tried. A DIFFERENT stored value means a concurrent refresh won the race
+ * and our token was collateral damage, so the connection is healthy and we
+ * continue with the winner's credentials. The SAME stored value means nothing
+ * rotated and the grant really is gone.
+ *
+ * Bounded to a single extra exchange: if the winner's access token is already
+ * expired too we try once more with its refresh token and then stop, rather
+ * than recursing into a race that a busy experiment could sustain.
+ */
+async function recoverFromRotationRace(
+  uid: string,
+  presentedRefreshToken: string,
+  detail: string
+): Promise<ZenodoRefreshResult> {
+  const snapshot = await db.doc(`users/${uid}`).get();
+  const stored = snapshot.data()?.connectedAccounts?.zenodo as
+    | OAuth2AccountConnection
+    | undefined;
+
+  if (!stored?.encryptedRefreshToken) {
+    return {
+      success: false,
+      error: "PROVIDER_NOT_CONNECTED",
+      detail: "No connected Zenodo account for this experiment's owner",
+    };
+  }
+
+  if (decrypt(stored.encryptedRefreshToken) === presentedRefreshToken) {
+    return { success: false, error: "INVALID_REFRESH_TOKEN", detail };
+  }
+
+  console.log(
+    `zenodo: refresh for ${uid} lost a rotation race; continuing with the stored credentials`
+  );
+
+  if (stored.tokenExpiresAt > Date.now() + EXPIRY_MARGIN_MS) {
+    return { success: true, accessToken: decrypt(stored.encryptedToken) };
+  }
+
+  const retry = await exchangeRefreshToken(decrypt(stored.encryptedRefreshToken));
+  if (retry.kind !== "ok") {
+    return { success: false, error: "INVALID_REFRESH_TOKEN", detail: retry.detail };
+  }
+  return persistRefreshedToken(uid, retry.data);
+}
+
+/**
+ * Refreshes a single user's Zenodo access token and persists the result,
+ * rotating the stored refresh token to match. Does not check whether the
+ * current token is actually expired -- callers decide when to invoke this.
+ */
+export async function refreshZenodoToken(
+  uid: string,
+  connection: OAuth2AccountConnection
+): Promise<ZenodoRefreshResult> {
+  const presentedRefreshToken = decrypt(connection.encryptedRefreshToken);
+  const outcome = await exchangeRefreshToken(presentedRefreshToken);
+
+  if (outcome.kind === "invalid-grant") {
+    return recoverFromRotationRace(uid, presentedRefreshToken, outcome.detail);
+  }
+  if (outcome.kind === "failed") {
+    return { success: false, error: "INVALID_REFRESH_TOKEN", detail: outcome.detail };
+  }
+
+  return persistRefreshedToken(uid, outcome.data);
+}

--- a/functions/src/providers/zenodo.ts
+++ b/functions/src/providers/zenodo.ts
@@ -12,7 +12,15 @@ import {
   DeleteResult,
   ProviderErrorCode,
   TokenResult,
+  OAuthConfig,
 } from "./types.js";
+import {
+  refreshZenodoToken,
+  zenodoAuthorizeUrl,
+  zenodoTokenUrl,
+  zenodoOAuthHost,
+  EXPIRY_MARGIN_MS,
+} from "./zenodo-oauth.js";
 
 // ---------------------------------------------------------------------------
 // WHICH ZENODO API THIS TARGETS, AND WHY
@@ -252,12 +260,26 @@ function mapZenodoError(
 
   let error: ProviderErrorCode;
   if (status === 401) {
+    // Kept as a defensive branch, but Zenodo appears never to use it: measured
+    // 2026-08-21, a revoked token, a garbage token and NO token at all all
+    // return 403.
     error = "AUTH_EXPIRED";
   } else if (status === 403) {
-    // Zenodo returns 403 both for an invalid/revoked token and for a token
-    // whose scopes are insufficient (a PAT created without deposit:write).
-    // Neither is retryable and both are fixed the same way -- reconnect with a
-    // correctly scoped token -- so both map here.
+    // Zenodo returns 403 for every authentication and authorization failure
+    // there is -- an invalid or revoked token, a token whose scopes are
+    // insufficient, an access token a concurrent refresh rotated away, and a
+    // request with no Authorization header at all. All four were measured
+    // against the sandbox on 2026-08-21 and all four are 403.
+    //
+    // MOST of those are fixed the same way (reconnect) and are not retryable,
+    // which is why they map here. The rotated-away case is the exception: it
+    // is transient and self-healing, and mapping it to AUTH_EXPIRED puts the
+    // submission on the retry queue's HOURS-scale tier when it would succeed
+    // seconds later. The status code cannot separate them -- only comparing
+    // the token we used against the one now stored can, which this function
+    // has no access to. See the rotation-race note in zenodo-oauth.ts for why
+    // that window is one upload wide, once per sixty days, and why the
+    // consequence is "arrives late", never "lost".
     error = "AUTH_EXPIRED";
   } else if (status === 413 || status === 507) {
     error = "QUOTA_EXCEEDED";
@@ -341,7 +363,7 @@ interface DepositionFileResponse {
 
 export const zenodoProvider: StorageProvider = {
   id: "zenodo",
-  authMethod: "static-token",
+  authMethod: "oauth2",
   capabilities: {
     // Zenodo file keys are a flat namespace -- there is no folder concept in
     // either API generation. The framework's filename-prefix fallback applies.
@@ -363,10 +385,34 @@ export const zenodoProvider: StorageProvider = {
     { name: "affiliation", label: "Affiliation", required: false, placeholder: "Your institution" },
   ],
 
-  async resolveToken(userData: UserData, _owner: string): Promise<TokenResult> {
-    // _owner is unused: Zenodo is a static-token provider with no refresh token
-    // to rotate, so there is no persist-back step (cf. gdrive's resolveToken,
-    // which calls refreshGdriveToken(owner, ...)).
+  // A method rather than a static object so env vars are read at CALL time,
+  // not module load -- same reason as getApiBase() above.
+  oauthConfig(): OAuthConfig {
+    return {
+      authorizeUrl: zenodoAuthorizeUrl(),
+      tokenUrl: zenodoTokenUrl(),
+      clientId: process.env.ZENODO_CLIENT_ID as string,
+      clientSecret: process.env.ZENODO_CLIENT_SECRET as string,
+      redirectUri: process.env.ZENODO_REDIRECT_URI as string,
+      // deposit:write uploads files; deposit:actions publishes and edits. Both
+      // are on the write path and neither is optional.
+      //
+      // Deliberately NOT user:email, which invenio-oauth2server also offers:
+      // identity is Firebase's job (lib/auth-providers.js), and Zenodo could
+      // not serve as a sign-in provider even if we wanted it to --
+      // invenio-oauth2server implements no OIDC layer at all (no id_token, no
+      // discovery document, no userinfo endpoint), so there is nothing for
+      // Firebase to verify. Asking for an identity scope we have no use for
+      // would only widen the consent screen.
+      scope: "deposit:write deposit:actions",
+      // Nothing to add: Zenodo issues a refresh token on the
+      // authorization_code grant unconditionally, so there is no equivalent of
+      // Google's access_type=offline&prompt=consent dance.
+      extraAuthParams: {},
+    };
+  },
+
+  async resolveToken(userData: UserData, owner: string): Promise<TokenResult> {
     const zenodo = userData.connectedAccounts?.zenodo;
 
     if (!zenodo) {
@@ -377,36 +423,33 @@ export const zenodoProvider: StorageProvider = {
       };
     }
 
-    // No expiry branch here, unlike dataverse.ts. Zenodo personal access
-    // tokens have no documented expiry and the API exposes no endpoint that
-    // reports one, which is also why staticTokenExpiry is deliberately NOT
-    // implemented on this provider -- its absence means "this provider cannot
-    // report an expiry", which connect-provider.ts already handles by omitting
-    // tokenExpiresAt. If a stored tokenExpiresAt ever does appear (e.g. set by
-    // a future Zenodo change), it is still honored rather than ignored.
-    if (zenodo.tokenExpiresAt && zenodo.tokenExpiresAt < Date.now()) {
-      return {
-        success: false,
-        error: "PROVIDER_TOKEN_EXPIRED",
-        detail: "The Zenodo API token for this experiment's owner has expired",
-      };
+    // serverUrl comes from deployment config, NOT from the stored connection.
+    // Under static tokens a researcher pasted a token and told us which
+    // installation it belonged to; an OAuth client_id is registered against
+    // exactly one installation, so a sandbox client physically cannot complete
+    // a flow on zenodo.org. Trusting a stored value here would let a stale
+    // connection point a live client at the wrong host.
+    const serverUrl = zenodoOAuthHost();
+
+    if (zenodo.tokenExpiresAt > Date.now() + EXPIRY_MARGIN_MS) {
+      return { success: true, token: decrypt(zenodo.encryptedToken), serverUrl };
     }
 
-    return { success: true, token: decrypt(zenodo.encryptedToken), serverUrl: zenodo.serverUrl };
-  },
+    // Refresh inline on demand rather than from a scheduled pass, which is
+    // also why zenodo implements no refreshExpiringTokens (cf. gdrive, whose
+    // 10-minute window rides the weekly pass).
+    //
+    // Zenodo access tokens last SIXTY DAYS (measured, spike gate J), so a
+    // proactive sweep would spend two months of weekly wake-ups per account to
+    // save one inline request. The submission that needs the token is the only
+    // caller that knows it is needed, and an experiment idle past expiry pays
+    // for the refresh exactly once, on its next submission.
+    const refreshResult = await refreshZenodoToken(owner, zenodo);
+    if (!refreshResult.success) {
+      return { success: false, error: refreshResult.error, detail: refreshResult.detail };
+    }
 
-  async validateStaticToken(auth: ResolvedAuth): Promise<boolean> {
-    const serverUrl = resolveServerUrl(auth);
-    // size=1 keeps the response tiny -- this only needs the status code. A
-    // token missing the deposit:write scope still 403s here, which is the
-    // point: it would fail at the first upload otherwise, months later.
-    const response = await fetch(`${serverUrl}/api/deposit/depositions?size=1`, {
-      method: "GET",
-      headers: authHeaders(auth),
-    });
-    // Never throw on a non-200 -- a bad or under-scoped token is "not valid",
-    // not an exceptional condition.
-    return response.status === 200;
+    return { success: true, token: refreshResult.accessToken, serverUrl };
   },
 
   async createDataContainer(auth: ResolvedAuth, researcherInput: Record<string, unknown>): Promise<ContainerRef> {

--- a/functions/src/queue-upload.ts
+++ b/functions/src/queue-upload.ts
@@ -53,6 +53,47 @@ export function isFastRetry(code?: string | null): boolean {
   return !!code && FAST_RETRY_CODES.has(code);
 }
 
+// Codes that get ONE minute-scale look before falling back to the hours-scale
+// schedule. This is not the fast tier: a probe code takes a single early
+// attempt and, if that fails, resumes the ordinary slow backoff (2, 4, 8, 16
+// hours) from there. Nothing in scheduled-upload-retry.ts needs to know about
+// this set -- the probe only moves the FIRST delay, and the worker's existing
+// `Math.pow(2, newRetryCount) * baseMs` already produces 2 hours for the next
+// attempt. The asymmetry with FAST_RETRY_CODES is deliberate, not an omission.
+//
+// The attempt is free rather than additive: it displaces the 1-hour first
+// attempt instead of extending the chain, so an item still gets five tries
+// across ~30 hours -- the same budget and nearly the same total window as
+// before, with the first look ~59 minutes earlier.
+//
+// Both members are codes that CANNOT distinguish a transient failure from a
+// terminal one, so the cheapest way to find out is to look once.
+//
+// AUTH_EXPIRED: on Zenodo this conflates the two outright. Zenodo answers 403
+// for a revoked token, an under-scoped token, no token at all, AND an access
+// token that a concurrent refresh rotated away moments ago (all four measured
+// against the sandbox, 2026-08-21). That last case heals itself the instant
+// the winning refresh persists -- so waiting an hour to look again is an hour
+// of delay for a submission that would have succeeded on the next tick. See
+// docs/provider-migration-design.md, spike gate N.
+//
+// UNAVAILABLE: a 5xx or a network fault, which covers everything from a
+// one-off blip to a multi-hour outage. The blip is common and clears in
+// seconds; the outage costs one extra request to discover, then falls back to
+// the same hours-scale chain it would have used anyway.
+//
+// DELIBERATELY NOT HERE:
+//   RATE_LIMITED   -- the provider has told us how long it will keep refusing;
+//                     probing inside its own stated window is the one thing it
+//                     asked us not to do.
+//   QUOTA_EXCEEDED -- needs compaction to free a slot or a human to raise a
+//                     limit. Neither happens within a minute.
+export const PROBE_RETRY_CODES: ReadonlySet<string> = new Set(["AUTH_EXPIRED", "UNAVAILABLE"]);
+
+export function isProbeRetry(code?: string | null): boolean {
+  return !!code && PROBE_RETRY_CODES.has(code);
+}
+
 export default async function queueUpload(params: QueueUploadParams): Promise<string> {
   const deduplicationKey = `${params.experimentID}:${params.filename}`;
   const docId = deduplicationKey.replace(/[/\\]/g, "_");
@@ -60,11 +101,19 @@ export default async function queueUpload(params: QueueUploadParams): Promise<st
   const docRef = db.collection("uploadQueue").doc(docId);
 
   const now = Timestamp.now();
-  // Fast tier (CONTENTION): 60 seconds — the cadence of
-  // scheduled-upload-retry.ts is what makes this meaningful (see that file).
-  // Everything else, including no providerErrorCode at all: 1 hour, exactly
-  // as before this change.
-  const firstRetryDelayMs = isFastRetry(params.providerErrorCode) ? 60 * 1000 : 60 * 60 * 1000;
+  // 60 seconds for the fast tier (CONTENTION) and for a one-off probe
+  // (AUTH_EXPIRED); 1 hour for everything else, including no providerErrorCode
+  // at all. The two differ in what happens NEXT, not here: CONTENTION keeps a
+  // minutes-scale schedule for all five attempts, a probe code takes this one
+  // early look and then reverts to hours.
+  //
+  // 60 seconds is a floor, not a promise. scheduled-upload-retry.ts runs on
+  // */5, so the real first attempt lands at the next 5-minute tick -- which is
+  // the number to reason about when judging whether this is worth it.
+  const firstRetryDelayMs =
+    isFastRetry(params.providerErrorCode) || isProbeRetry(params.providerErrorCode)
+      ? 60 * 1000
+      : 60 * 60 * 1000;
   const nextRetryAt = Timestamp.fromMillis(now.toMillis() + firstRetryDelayMs);
 
   // If the doc already exists: a "processing" entry is actively being

--- a/lib/provider-config.js
+++ b/lib/provider-config.js
@@ -84,24 +84,16 @@ export const STORAGE_PROVIDERS = {
   zenodo: {
     id: "zenodo",
     name: "Zenodo",
-    authMethod: "static-token",
-    // NOT federated, unlike Dataverse: a researcher never picks an
-    // installation, so no field is rendered and this value is sent on their
-    // behalf (see ProviderConnections.js's handleTokenConnect).
-    //
-    // It is still per-DEPLOYMENT, which is what NEXT_PUBLIC_ZENODO_ENV
-    // controls: "" on production -> zenodo.org, "sandbox." on the test site ->
-    // sandbox.zenodo.org. Same host-prefix shape as NEXT_PUBLIC_OSF_ENV, and
-    // for the same reason -- without it the test deployment writes real
-    // depositions to the live service using the researcher's real account.
-    // The two Zenodos have entirely separate accounts and tokens, so a
-    // sandbox token pasted into a production-pointed deployment is rejected
-    // at connect time rather than silently misfiling data.
-    needsServerUrl: false,
-    defaultServerUrl: ZENODO_HOST,
-    tokenLabel: "Personal access token",
-    tokenHelp:
-      "Create one under Applications → Personal access tokens in your Zenodo account settings. It needs the deposit:write and deposit:actions scopes. Zenodo tokens do not expire.",
+    // OAuth2 since 2026-08-21, previously a pasted personal access token.
+    // The switch is not cosmetic: an OAuth client_id is registered against ONE
+    // Zenodo installation, so which Zenodo this deployment talks to is now
+    // fixed by NEXT_PUBLIC_ZENODO_ENV ("" -> zenodo.org, "sandbox." -> the
+    // sandbox) and by the matching server-side client credentials, rather than
+    // being sent along with the researcher's token at connect time. Same
+    // host-prefix shape as NEXT_PUBLIC_OSF_ENV, and for the same reason:
+    // without it the test deployment writes real depositions to the live
+    // service using the researcher's real account.
+    authMethod: "oauth2",
     isConnected: (userDoc) => !!userDoc?.connectedAccounts?.zenodo,
     // Zenodo depositions stay unpublished while data is being collected, so
     // the researcher-facing link is the deposit editor rather than a public

--- a/scripts/zenodo-oauth-spike.mjs
+++ b/scripts/zenodo-oauth-spike.mjs
@@ -1,0 +1,382 @@
+// Zenodo OAuth2 gating spike (docs/provider-migration-design.md).
+//
+// Zenodo publishes NO documentation for its OAuth application flow --
+// developers.zenodo.org covers personal access tokens only. Everything
+// DataPipe assumes about it was read out of invenio-oauth2server's source on
+// 2026-08-21. This script exists to check those readings against the running
+// service, because a source file on GitHub master is not the same thing as
+// whatever revision Zenodo actually deploys.
+//
+// Usage:
+//   cd functions && npm run build && cd ..
+//   ZENODO_CLIENT_ID=xxx ZENODO_CLIENT_SECRET=yyy node scripts/zenodo-oauth-spike.mjs
+//
+// Env:
+//   ZENODO_CLIENT_ID     (required) from the registered OAuth application
+//   ZENODO_CLIENT_SECRET (required) same application, confidential client
+//   ZENODO_ENV           (default "sandbox.") "" targets production zenodo.org
+//   ZENODO_OAUTH_PORT    (default 3000) port for the local redirect catcher
+//   ZENODO_REDIRECT_URI  (default http://localhost:<port>/oauth2/connect)
+//   ZENODO_CODE          an authorization code obtained by hand (see below)
+//   ZENODO_CLEANUP       (default 1; set to 0 to leave the deposition behind)
+//
+// TWO WAYS TO GET THE AUTHORIZATION CODE:
+//
+//  1. AUTOMATIC (default). Requires http://localhost:<port>/oauth2/connect to
+//     be one of the application's registered redirect URIs -- Zenodo's
+//     validate_redirect_uri permits plain http ONLY for localhost/127.0.0.1,
+//     so this needs no tunnel. The script starts a throwaway server, prints a
+//     consent URL, and catches the redirect itself.
+//
+//  2. MANUAL, when only the deployed redirect URI is registered. Set
+//     ZENODO_REDIRECT_URI to it; the script prints the consent URL and stops.
+//     Approve it, then copy the `code` query parameter out of the browser's
+//     address bar and re-run with ZENODO_CODE=<that value>. The deployed
+//     connect page will show a CSRF error, which is correct and harmless --
+//     the state did not come from that browser, so the page refuses to spend
+//     the code and it is still yours to use. Codes are single-use and
+//     short-lived, so re-run promptly.
+//
+// Leaves the deposition UNPUBLISHED -- nothing here mints a DOI.
+
+import { createServer } from "node:http";
+import { randomUUID } from "node:crypto";
+import { zenodoProvider } from "../functions/lib/providers/zenodo.js";
+
+const clientId = process.env.ZENODO_CLIENT_ID;
+const clientSecret = process.env.ZENODO_CLIENT_SECRET;
+const env = process.env.ZENODO_ENV ?? "sandbox.";
+const port = Number(process.env.ZENODO_OAUTH_PORT || 3000);
+const cleanup = process.env.ZENODO_CLEANUP !== "0";
+const suppliedCode = process.env.ZENODO_CODE;
+
+const host = `https://${env}zenodo.org`;
+const redirectUri = process.env.ZENODO_REDIRECT_URI || `http://localhost:${port}/oauth2/connect`;
+// Only a loopback redirect can be caught locally; anything else has to come
+// back through a real browser, so the code is supplied by hand instead.
+const canCatchRedirect = /^http:\/\/(localhost|127\.0\.0\.1)(:|\/)/.test(redirectUri);
+
+if (!clientId || !clientSecret) {
+  console.error("ZENODO_CLIENT_ID and ZENODO_CLIENT_SECRET are required. See the header of this file.");
+  process.exit(1);
+}
+
+const results = [];
+const record = (gate, verdict, detail) => {
+  results.push({ gate, verdict, detail });
+  console.log(`\n[${verdict}] ${gate}\n      ${detail}`);
+};
+
+// Waits for Zenodo to redirect back with ?code=, then shuts the server down.
+function awaitAuthorizationCode(state) {
+  return new Promise((resolve, reject) => {
+    const server = createServer((req, res) => {
+      const url = new URL(req.url, `http://localhost:${port}`);
+      if (url.pathname !== "/oauth2/connect") {
+        res.writeHead(404).end();
+        return;
+      }
+      const code = url.searchParams.get("code");
+      const returnedState = url.searchParams.get("state");
+      const error = url.searchParams.get("error");
+      res.writeHead(200, { "Content-Type": "text/html" });
+      res.end(`<html><body style="font-family:system-ui;padding:3rem">
+        <h2>${code ? "Authorized." : "Authorization failed."}</h2>
+        <p>You can close this tab and return to the terminal.</p></body></html>`);
+      server.close();
+      if (error) return reject(new Error(`Zenodo returned error=${error}`));
+      if (!code) return reject(new Error("No code in the redirect"));
+      if (returnedState !== state) return reject(new Error("State mismatch"));
+      resolve(code);
+    });
+    server.listen(port, "127.0.0.1");
+    const waitMs = Number(process.env.ZENODO_OAUTH_WAIT_MS || 15 * 60 * 1000);
+    setTimeout(() => {
+      server.close();
+      reject(new Error(`Timed out waiting for the consent redirect (${Math.round(waitMs / 60000)} min)`));
+    }, waitMs).unref();
+  });
+}
+
+async function postToken(params, { basicAuth = false } = {}) {
+  const headers = { "Content-Type": "application/x-www-form-urlencoded" };
+  const body = { ...params };
+  if (basicAuth) {
+    // client_secret_basic: credentials move to the Authorization header and
+    // must NOT also appear in the body, or oauthlib treats it as two competing
+    // authentication attempts.
+    delete body.client_id;
+    delete body.client_secret;
+    headers.Authorization =
+      "Basic " + Buffer.from(`${clientId}:${clientSecret}`).toString("base64");
+  }
+  const response = await fetch(`${host}/oauth/token`, {
+    method: "POST",
+    headers,
+    body: new URLSearchParams(body).toString(),
+  });
+  const text = await response.text();
+  let json = null;
+  try {
+    json = JSON.parse(text);
+  } catch {
+    /* keep text for the failure detail */
+  }
+  return { ok: response.ok, status: response.status, json, text };
+}
+
+// Cheapest authenticated call that distinguishes a live token from a dead one.
+async function tokenIsLive(accessToken) {
+  const response = await fetch(`${host}/api/deposit/depositions?size=1`, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+  return response.status === 200;
+}
+
+async function main() {
+  console.log(`Zenodo OAuth spike against ${host}\n`);
+
+  const state = randomUUID();
+  const authorizeUrl = new URL(`${host}/oauth/authorize`);
+  authorizeUrl.searchParams.set("client_id", clientId);
+  authorizeUrl.searchParams.set("redirect_uri", redirectUri);
+  authorizeUrl.searchParams.set("response_type", "code");
+  // Exactly the scopes zenodo.ts's oauthConfig() requests -- deliberately no
+  // user:email, which gate K checks the consequence of.
+  authorizeUrl.searchParams.set("scope", "deposit:write deposit:actions");
+  authorizeUrl.searchParams.set("state", state);
+
+  let code;
+  if (suppliedCode) {
+    // State cannot be checked on this path -- the redirect never came back
+    // through this process. That is acceptable here and nowhere else: this is a
+    // local diagnostic run by the person who just approved the consent, not a
+    // login flow exposed to anyone. connect-provider.ts validates state
+    // server-side for the real thing.
+    code = suppliedCode;
+    console.log("Using the authorization code supplied via ZENODO_CODE.");
+  } else if (canCatchRedirect) {
+    console.log("Open this URL and approve:\n");
+    console.log(`  ${authorizeUrl}\n`);
+    console.log(`Listening on ${redirectUri} ...`);
+    code = await awaitAuthorizationCode(state);
+    console.log("\nGot an authorization code.");
+  } else {
+    console.log("Open this URL and approve:\n");
+    console.log(`  ${authorizeUrl}\n`);
+    console.log(`${redirectUri} is not a loopback address, so this script cannot catch the`);
+    console.log("redirect. Approve the consent, copy the `code` parameter out of the address");
+    console.log("bar, and re-run with:\n");
+    console.log("  ZENODO_CODE=<code> node scripts/zenodo-oauth-spike.mjs\n");
+    console.log("The connect page will show a CSRF error -- that is expected, and it means the");
+    console.log("code was not spent. Codes are short-lived, so re-run promptly.");
+    return;
+  }
+
+  // ---- Gate J: does the exchange work, and how long does a token live? ----
+  //
+  // Tried two ways, because Zenodo documents neither and the answer decides
+  // what connect-provider.ts has to send. RFC 6749 lets a confidential client
+  // authenticate either by putting client_id/client_secret in the body
+  // (client_secret_post) or by HTTP Basic (client_secret_basic), and servers
+  // are free to accept only one. A rejected authentication does not spend the
+  // authorization code, so falling through to the second attempt is safe.
+  const grantParams = {
+    grant_type: "authorization_code",
+    code,
+    client_id: clientId,
+    client_secret: clientSecret,
+    redirect_uri: redirectUri,
+  };
+
+  console.log(`\n  redirect_uri sent: ${redirectUri}`);
+  let first = await postToken(grantParams);
+  let authStyle = "client_secret_post (credentials in the body)";
+
+  if (!first.ok) {
+    console.log(`  client_secret_post -> ${first.status} ${first.text.slice(0, 200)}`);
+    console.log("  retrying with HTTP Basic ...");
+    first = await postToken(grantParams, { basicAuth: true });
+    authStyle = "client_secret_basic (HTTP Basic)";
+  }
+
+  if (!first.ok || !first.json?.access_token) {
+    record(
+      "J. authorization_code exchange",
+      "FAIL",
+      `Both authentication styles rejected. Last: ${first.status} ${first.text.slice(0, 300)}`
+    );
+    return;
+  }
+
+  record("J0. client authentication style", "INFO", `Zenodo accepted ${authStyle}.`);
+
+  // Persist the token response when asked. A 60-day access token is still
+  // usable long after this run, and it means probing the refresh grant does
+  // not cost a fresh consent round trip every time.
+  if (process.env.ZENODO_TOKEN_OUT) {
+    const { writeFileSync } = await import("node:fs");
+    writeFileSync(process.env.ZENODO_TOKEN_OUT, JSON.stringify(first.json, null, 2));
+    console.log(`  token response written to ${process.env.ZENODO_TOKEN_OUT}`);
+  }
+
+  const expiresIn = first.json.expires_in;
+  record(
+    "J. authorization_code exchange",
+    "PASS",
+    `expires_in=${expiresIn}s (${(expiresIn / 3600).toFixed(2)}h), ` +
+      `refresh_token=${first.json.refresh_token ? "present" : "ABSENT"}, ` +
+      `scope="${first.json.scope}"`
+  );
+
+  if (expiresIn !== 3600) {
+    record(
+      "J2. access-token lifetime matches the source default",
+      "INFO",
+      `Zenodo issued ${expiresIn}s, not oauthlib's 3600s default -- it overrides ` +
+        "OAUTH2_PROVIDER_TOKEN_EXPIRES_IN in deployment config. EXPIRY_MARGIN_MS in " +
+        "zenodo-oauth.ts is sized against this number; check it still makes sense."
+    );
+  }
+
+  // ---- Gate K: identity leakage without the user:email scope ----
+  const user = first.json.user;
+  if (!user) {
+    record("K. identity in the token response", "INFO", "No `user` object at all in the token response.");
+  } else if (user.email) {
+    record(
+      "K. identity in the token response",
+      "FAIL",
+      `Zenodo returned an email (${user.email}) even though user:email was NOT requested. ` +
+        "We would be receiving identity data we never asked for and do not want."
+    );
+  } else {
+    record(
+      "K. identity in the token response",
+      "PASS",
+      `user.id=${user.id} present, no email -- matches invenio-oauth2server's save_token, ` +
+        "which only adds the address when the user:email scope is granted."
+    );
+  }
+
+  // ---- Gate O: can an OAuth token actually drive the adapter? ----
+  const auth = { token: first.json.access_token, serverUrl: host };
+  let container = null;
+  try {
+    container = await zenodoProvider.createDataContainer(auth, {
+      title: `DataPipe OAuth spike ${new Date().toISOString()}`,
+      creatorName: "DataPipe, Spike",
+      description: "Temporary deposition created by scripts/zenodo-oauth-spike.mjs. Never published.",
+    });
+    const body = JSON.stringify({ hello: "oauth" });
+    const write = await zenodoProvider.writeSessionFile(auth, container, "data/raw/oauth-probe.json", body, {
+      size: Buffer.byteLength(body),
+      contentType: "application/json",
+    });
+    record(
+      "O. OAuth token drives the real adapter",
+      write.success ? "PASS" : "FAIL",
+      write.success
+        ? `deposition ${container.depositionId}, wrote "${write.storedFilename}" -- deposit:write is sufficient`
+        : `write failed: ${write.error} ${write.providerMessage ?? ""}`
+    );
+  } catch (e) {
+    record("O. OAuth token drives the real adapter", "FAIL", e.message);
+  }
+
+  // ---- Gate L: does refresh rotate the refresh token? ----
+  const useBasic = authStyle.startsWith("client_secret_basic");
+  const second = await postToken(
+    {
+      grant_type: "refresh_token",
+      refresh_token: first.json.refresh_token,
+      client_id: clientId,
+      client_secret: clientSecret,
+    },
+    { basicAuth: useBasic }
+  );
+
+  if (!second.ok || !second.json?.access_token) {
+    record("L. refresh_token grant", "FAIL", `${second.status}: ${second.text.slice(0, 300)}`);
+  } else {
+    const rotated = second.json.refresh_token !== first.json.refresh_token;
+    record(
+      "L. refresh rotates the refresh token",
+      rotated ? "PASS" : "FAIL",
+      rotated
+        ? "New refresh_token differs from the old one, as oauthlib's rotate_refresh_token=True implies. " +
+            "zenodo-oauth.ts MUST persist it -- this is the whole reason that module exists."
+        : "Refresh token came back UNCHANGED. Rotation is off on this deployment, which would make " +
+            "recoverFromRotationRace() dead code and the persist far less dangerous. Re-read that module."
+    );
+
+    // ---- Gate M: is the superseded refresh token dead immediately? ----
+    const replay = await postToken(
+      {
+        grant_type: "refresh_token",
+        refresh_token: first.json.refresh_token,
+        client_id: clientId,
+        client_secret: clientSecret,
+      },
+      { basicAuth: useBasic }
+    );
+    const deadRefresh = !replay.ok;
+    record(
+      "M. superseded refresh token is rejected",
+      deadRefresh ? "PASS" : "FAIL",
+      deadRefresh
+        ? `Replay returned ${replay.status} (${(replay.json?.error ?? replay.text).toString().slice(0, 80)}) -- ` +
+            "this is exactly the invalid_grant that recoverFromRotationRace() has to distinguish " +
+            "from a genuinely revoked grant."
+        : "The OLD refresh token still works, so two concurrent refreshes cannot collide. " +
+            "recoverFromRotationRace() would be unnecessary."
+    );
+
+    // ---- Gate N: does refreshing kill the PREVIOUS access token? ----
+    // invenio-oauth2server's save_token deletes every prior Token row for
+    // (client_id, user_id), which would take the old ACCESS token with it. If
+    // true, a long upload holding the old token breaks the moment anything
+    // else refreshes -- a failure mode no amount of expiry margin prevents.
+    const oldAccessLive = await tokenIsLive(first.json.access_token);
+    record(
+      "N. previous access token survives a refresh",
+      oldAccessLive ? "PASS" : "INFO",
+      oldAccessLive
+        ? "The pre-refresh access token still authenticates, so an in-flight upload is unaffected " +
+            "by a concurrent refresh."
+        : "The pre-refresh access token is ALREADY DEAD, as save_token deleting every prior " +
+            "row for (client_id, user_id) implies. A refresh by a concurrent request invalidates " +
+            "a token an in-flight upload may be using. Zenodo reports that as 403 -- the same " +
+            "403 it returns for a revoked token, a garbage token and no token at all -- so the " +
+            "response cannot distinguish transient from terminal; only comparing against the " +
+            "stored token can."
+    );
+  }
+
+  if (cleanup && container) {
+    try {
+      await fetch(`${host}/api/deposit/depositions/${container.depositionId}`, {
+        method: "DELETE",
+        headers: { Authorization: `Bearer ${second.json?.access_token ?? first.json.access_token}` },
+      });
+      console.log(`\nCleaned up deposition ${container.depositionId}.`);
+    } catch (e) {
+      console.log(`\nCould not delete deposition ${container.depositionId}: ${e.message}`);
+    }
+  }
+
+  console.log("\n\n=== SUMMARY ===");
+  for (const r of results) {
+    console.log(`[${r.verdict}] ${r.gate}`);
+  }
+  const failed = results.filter((r) => r.verdict === "FAIL");
+  if (failed.length) {
+    console.log(`\n${failed.length} gate(s) FAILED.`);
+    process.exitCode = 1;
+  }
+}
+
+main().catch((e) => {
+  console.error("\nSpike aborted:", e.message);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
Moves Zenodo storage from a pasted personal access token to OAuth2, and adds a minute-scale first retry for failures that may be self-healing.

There were no Zenodo connections outside the test deployment, so this is a clean cut — no dual-mode period, no migration path.

## Zenodo OAuth2

Researchers now authorize DataPipe on Zenodo the same way they already do for Drive. The generic machinery needed nothing: `connectProvider` and `generate-oauth-state` were already provider-agnostic, so this is the adapter plus config.

Zenodo documents none of its OAuth application flow — `developers.zenodo.org` covers personal access tokens only — so the behaviour was read out of `invenio-oauth2server` and then checked against the running service with `scripts/zenodo-oauth-spike.mjs`.

**Three findings that are not in any documentation:**

- **Access tokens last 60 days, not one hour.** Reading the source predicts oauthlib's 3600s default, because Invenio never sets `OAUTH2_PROVIDER_TOKEN_EXPIRES_IN`. Zenodo overrides it in deployment config. Refresh is consequently so rare it will essentially never fire in testing.
- **The application must be a confidential client.** Registered as public, everything works *except* refresh, which fails `400 invalid_grant` — `get_token`'s refresh branch filters on `Client.is_confidential`. The symptom appears two months after connecting and looks nothing like its cause. This is how the sandbox app was first registered.
- **Zenodo answers 403 for every auth failure**: revoked token, under-scoped token, no token at all, and an access token a concurrent refresh rotated away. It never returns 401.

`zenodo-oauth.ts` is a separate module rather than a reuse of gdrive's because Zenodo **rotates the refresh token on every refresh and deletes the old one**. Two consequences: persisting the rotation is part of the refresh's correctness (a crash between the HTTP response and the Firestore write strands the researcher mid-experiment), and a concurrent refresh is indistinguishable from a revoked grant in the response. `recoverFromRotationRace()` re-reads the stored connection to tell them apart, because only local state can.

Scope is `deposit:write deposit:actions` — deliberately not `user:email`, which `invenio-oauth2server` also offers. Zenodo cannot serve as a sign-in provider regardless: it implements no OIDC layer at all (no `id_token`, no discovery document, no userinfo endpoint).

## Probe retry tier

`AUTH_EXPIRED` and `UNAVAILABLE` both conflate transient with terminal, and until now both waited an hour for a first retry. `PROBE_RETRY_CODES` gives them one minute-scale look, then the ordinary hours-scale chain.

The attempt is **free rather than additive** — it displaces the 1-hour first attempt instead of extending the chain, so an item still gets five tries across ~30 hours instead of ~31. `scheduled-upload-retry.ts` needed no change: the probe only moves the first delay, and its existing backoff already yields 2 hours for the next attempt.

`RATE_LIMITED` stays excluded (the provider stated how long it will keep refusing). `QUOTA_EXCEEDED` stays excluded (needs compaction or a human). `CONTENTION` keeps its full fast tier, which is a different mechanism.

**Known cost, accepted:** Dataverse's same-content 400 maps to `UNAVAILABLE` and is deterministic, so its probe is one wasted request every time. D6 documents that now rather than asserting the hour it used to wait.

## Spike results (sandbox, 2026-08-21)

| Gate | Result |
| --- | --- |
| J. authorization_code exchange | PASS — `expires_in=5184000` (60 days) |
| J0. client authentication | `client_secret_post`; HTTP Basic never needed |
| K. identity without `user:email` | PASS — `user.id` only, no email |
| O. OAuth token drives the adapter | PASS — created a deposition, wrote a file |
| L. refresh rotates the refresh token | PASS |
| M. superseded refresh token rejected | PASS — `400 invalid_grant` |
| N. previous access token survives | **NO** — dead immediately |

Nothing published; no DOIs minted. Sandbox drafts cleaned up.

## Testing

723 tests, 59 suites, 0 failures. Lint and `tsc` clean. 14 new tests: 10 emulator-backed against `refreshZenodoToken` (rotation persistence, the race, revocation, network failure) and 4 on the probe tier.

Worth knowing: the emulator suites exercise Zenodo through a mock, and a real refresh fires roughly once per connection per 60 days. `zenodo-oauth.ts`'s correctness rests on those tests and the spike, not on operational experience.

## Before this can work on test

`TEST_ZENODO_CLIENT_SECRET` must exist as a GitHub secret. `ZENODO_CLIENT_ID`, `ZENODO_REDIRECT_URI` and `ZENODO_ENV` are non-secret and committed in `functions/.env.datapipe-test`, matching the `GDRIVE_*` convention.

Production setup is unchanged and documented in the design doc: register a **confidential** app on zenodo.org with redirect `https://pipe.jspsych.org/oauth2/connect`, leave `ZENODO_ENV` unset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)