### PR TITLE
Say which token exchange failed, and why

### DIFF
--- a/functions/src/connect-provider.ts
+++ b/functions/src/connect-provider.ts
@@ -164,7 +164,36 @@ export const connectProvider = onRequest({ cors: true }, async (req, res) => {
 
     if (!tokenResponse.ok) {
       const errorText = await tokenResponse.text();
-      console.error('Token exchange failed:', errorText);
+      // Log WHICH failure this is, not just that one happened. These three
+      // look identical to the researcher ("Token exchange failed") and have
+      // completely different causes, and a bare error body cost a live
+      // debugging cycle on 2026-08-21 working out which one we were seeing:
+      //
+      //   invalid_client -- OUR misconfiguration. The client id/secret the
+      //     function is running with are wrong or absent. Note that a deploy
+      //     can look green and still leave these stale: `firebase deploy`
+      //     reports "Skipped (No changes detected)" when only .env changed,
+      //     so adding a secret and re-running the workflow does NOT
+      //     necessarily update the function.
+      //   invalid_grant -- the authorization code was rejected: already
+      //     spent, or expired. Codes are single-use and short-lived, so a
+      //     page reload after a failed attempt produces exactly this.
+      //   anything else -- provider-side or a request-shape problem.
+      //
+      // Whether the credentials are merely PRESENT is logged as a boolean, so
+      // a stale/empty deploy is distinguishable from a wrong value without
+      // ever putting the credential itself in a log line.
+      const kind = errorText.includes('invalid_client')
+        ? 'invalid_client (our client credentials are wrong or missing)'
+        : errorText.includes('invalid_grant')
+          ? 'invalid_grant (the authorization code was already spent or expired)'
+          : 'unclassified';
+      console.error(
+        `Token exchange failed for ${provider}: ${kind}; ` +
+          `clientId=${config.clientId ? 'present' : 'MISSING'}, ` +
+          `clientSecret=${config.clientSecret ? 'present' : 'MISSING'}, ` +
+          `redirectUri=${config.redirectUri || 'MISSING'}; body: ${errorText}`
+      );
       res.status(400).json({ error: 'Token exchange failed' });
       return;
     }


### PR DESCRIPTION
Connecting Zenodo on the test site fails with `Token exchange failed`. The log said only `{"error": "invalid_grant"}`, which was not enough to act on.

## The deploy problem this uncovered

```
functions[connectprovider(us-central1)]  Skipped (No changes detected)
```

`firebase deploy` skips functions when **only `.env` changed**. `TEST_ZENODO_CLIENT_SECRET` was created at 20:57:32; `connectprovider` was last updated at 20:52:22 and has not been updated since, across two green deploys. Adding a secret and re-running the workflow does not propagate it.

That is worth knowing beyond this incident — any future secret rotation fails the same silent way, and the deploy reports success.

## What this changes

Logs the failure *kind* — `invalid_client` (our credentials are wrong or absent) vs `invalid_grant` (the code was spent or expired) vs unclassified — plus whether client id, secret and redirect URI are present. Booleans and the redirect URI only; no credential ever reaches a log line.

It also changes the functions source, which is what busts the hash and forces the redeploy.

## Unresolved

oauthlib checks client authentication **before** the code, so a missing secret should produce `invalid_client` — confirmed empirically against the sandbox (wrong secret and empty secret both give `invalid_client`). We observed `invalid_grant`, which implies the client authenticated and the code itself was rejected. That contradicts the evidence that the secret was never deployed.

One of those premises is wrong and a single failed attempt cannot say which. This logging resolves it on the next attempt.

Tests: 13/13 in `oauth-connect-emulator.test.js`, lint and `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)