### PR TITLE
Announce the multi-backend switch on the homepage

### DIFF
--- a/__tests__/osf-sunset-banner.test.jsx
+++ b/__tests__/osf-sunset-banner.test.jsx
@@ -1,0 +1,73 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { ChakraProvider } from "@chakra-ui/react";
+import { system } from "../lib/theme";
+import "@testing-library/jest-dom";
+
+import OsfSunsetBanner from "../components/OsfSunsetBanner";
+import { osfSunsetLabel } from "../lib/osf-sunset";
+
+const DISMISS_KEY = "datapipe:announcement:osf-sunset:v1";
+
+function renderBanner() {
+  return render(
+    <ChakraProvider value={system}>
+      <OsfSunsetBanner />
+    </ChakraProvider>
+  );
+}
+
+const heading = () => screen.queryByText(/OSF support is ending/i);
+
+describe("OsfSunsetBanner", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("announces the sunset, naming the date from lib/osf-sunset", () => {
+    renderBanner();
+    expect(heading()).toBeInTheDocument();
+    expect(
+      screen.getByText(new RegExp(osfSunsetLabel(), "i"))
+    ).toBeInTheDocument();
+    expect(screen.getByText(/multi-backend/i)).toBeInTheDocument();
+  });
+
+  it("hides itself when dismissed and records the dismissal", () => {
+    renderBanner();
+
+    fireEvent.click(screen.getByRole("button", { name: /dismiss/i }));
+
+    expect(heading()).not.toBeInTheDocument();
+    expect(window.localStorage.getItem(DISMISS_KEY)).toBe("1");
+  });
+
+  it("stays hidden on a later visit once dismissed", () => {
+    window.localStorage.setItem(DISMISS_KEY, "1");
+    renderBanner();
+    expect(heading()).not.toBeInTheDocument();
+  });
+
+  it("still renders and still closes when localStorage is unavailable", () => {
+    const getItem = jest
+      .spyOn(Storage.prototype, "getItem")
+      .mockImplementation(() => {
+        throw new Error("denied");
+      });
+    const setItem = jest
+      .spyOn(Storage.prototype, "setItem")
+      .mockImplementation(() => {
+        throw new Error("denied");
+      });
+
+    try {
+      renderBanner();
+      expect(heading()).toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole("button", { name: /dismiss/i }));
+      expect(heading()).not.toBeInTheDocument();
+    } finally {
+      getItem.mockRestore();
+      setItem.mockRestore();
+    }
+  });
+});

--- a/components/OsfSunsetBanner.js
+++ b/components/OsfSunsetBanner.js
@@ -1,0 +1,92 @@
+import { useEffect, useState } from "react";
+import { Box, HStack, IconButton, Text } from "@chakra-ui/react";
+import { TriangleAlert, X } from "lucide-react";
+import { osfSunsetLabel } from "../lib/osf-sunset";
+
+// Bump the version suffix to re-show the banner to everyone who dismissed the
+// previous one. Dismissals are per-browser, not per-account, on purpose: the
+// homepage is mostly read by signed-out visitors.
+const DISMISS_KEY = "datapipe:announcement:osf-sunset:v1";
+
+// localStorage throws rather than returning null in a few real configurations
+// (Safari private browsing, "block all cookies", some embedded webviews). A
+// visitor who cannot persist a dismissal should still see the announcement and
+// still be able to close it for the session, so both helpers fail soft.
+function wasDismissed() {
+  try {
+    return window.localStorage.getItem(DISMISS_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+function rememberDismissal() {
+  try {
+    window.localStorage.setItem(DISMISS_KEY, "1");
+  } catch {
+    // Ignored: the banner still closes, it just comes back on the next visit.
+  }
+}
+
+// Homepage announcement that OSF-backed storage is going away and DataPipe is
+// becoming multi-backend. Deliberately self-contained -- there is nowhere on
+// the site to link to for more detail yet.
+export default function OsfSunsetBanner() {
+  // Starts hidden and is revealed in an effect. The site is statically
+  // exported, so the server-rendered HTML cannot know whether this visitor has
+  // dismissed the banner; rendering it on the server would make it flash for
+  // everyone who already closed it.
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    if (!wasDismissed()) setVisible(true);
+  }, []);
+
+  if (!visible) return null;
+
+  const deadline = osfSunsetLabel();
+
+  return (
+    <Box
+      role="status"
+      w="100%"
+      bg="brandOrange.900"
+      borderBottom="1px solid"
+      borderColor="brandOrange.600"
+      px={[4, 8, 12]}
+      py={3}
+    >
+      <HStack maxW="1100px" mx="auto" gap={[3, 4]} align="start">
+        <Box color="brandOrange.300" flexShrink={0} mt="2px">
+          <TriangleAlert size={18} aria-hidden="true" />
+        </Box>
+        <Text fontSize="sm" lineHeight="tall" flex="1">
+          <Text as="span" fontWeight="bold">
+            {deadline
+              ? `OSF support is ending on ${deadline}.`
+              : "OSF support is ending."}
+          </Text>{" "}
+          OSF is shutting down its projects feature, so DataPipe is moving to a
+          multi-backend model with support for Google Drive, Zenodo, and other
+          storage providers. Experiments collecting data today keep running
+          until then, and data already on OSF stays in your OSF account. We
+          will publish migration instructions before anything stops working.
+        </Text>
+        <IconButton
+          aria-label="Dismiss announcement"
+          variant="ghost"
+          size="xs"
+          color="brandOrange.200"
+          flexShrink={0}
+          _hover={{ bg: "brandOrange.800", color: "white" }}
+          onClick={() => {
+            setVisible(false);
+            rememberDismissal();
+          }}
+        >
+          <X size={16} />
+        </IconButton>
+      </HStack>
+    </Box>
+  );
+}

--- a/lib/osf-sunset.js
+++ b/lib/osf-sunset.js
@@ -1,0 +1,26 @@
+// Single source of truth for DataPipe's OSF wind-down.
+//
+// OSF is shutting down its projects feature, so DataPipe is moving to a
+// multi-backend storage model. Everything researcher-facing about the
+// wind-down reads from here so the date is stated in exactly one place.
+
+// ISO date (YYYY-MM-DD) after which DataPipe stops writing to OSF, or null if
+// no date has been announced yet.
+//
+// The code tolerates null (banners appear but name no deadline), so the date
+// can be retracted without touching any of the surfaces that display it.
+export const OSF_SUNSET_DATE = "2026-11-16";
+
+// Human-readable form of OSF_SUNSET_DATE, or null when unset.
+export function osfSunsetLabel() {
+  if (!OSF_SUNSET_DATE) return null;
+  // Parsed as UTC (the "YYYY-MM-DD" form always is) and formatted in UTC, so
+  // the date shown is the date written above regardless of the reader's
+  // timezone -- otherwise researchers west of UTC would see the day before.
+  return new Date(`${OSF_SUNSET_DATE}T00:00:00Z`).toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    timeZone: "UTC",
+  });
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -14,6 +14,7 @@ import { ArrowRight, Database, Shield, Zap, BookOpen } from "lucide-react";
 import Navbar from "../components/Navbar";
 import Footer from "../components/Footer";
 import TestEnvironmentWarning from "../components/TestEnvironmentWarning";
+import OsfSunsetBanner from "../components/OsfSunsetBanner";
 import { Rubik } from "next/font/google";
 
 const rubik = Rubik({ subsets: ["latin"] });
@@ -239,6 +240,8 @@ export default function Home() {
 
   return (
     <Box w="100%">
+      <OsfSunsetBanner />
+
       {/* Hero */}
       <Box
         px={[4, 8, 12]}


### PR DESCRIPTION
Adds a dismissable banner to the homepage announcing that OSF support is ending and DataPipe is moving to a multi-backend storage model.

**Targets `main` directly**, per request — the changes on `test` shouldn't ship with this.

## Why now

None of the provider-migration work is on `main`. Today the homepage, FAQ, and getting-started all still describe OSF as the only destination, so researchers have no warning at all. This gets the announcement out ahead of the migration rather than letting people find out when data stops arriving.

## What's here

| File | |
|---|---|
| `components/OsfSunsetBanner.js` | The banner |
| `lib/osf-sunset.js` | The cutoff date, in one place |
| `pages/index.js` | Renders the banner above the hero (3 lines) |
| `__tests__/osf-sunset-banner.test.jsx` | 4 tests |

## Notes for review

- **Copy.** Names the November 16, 2026 cutoff, says data already on OSF is unaffected, and promises migration instructions before anything breaks. No link — the FAQ on `main` is still entirely OSF-centric, so there's nowhere to send people yet. Worth a follow-up PR adding an FAQ entry once the migration details firm up.
- **Merges cleanly with `provider-migration`.** `lib/osf-sunset.js` uses the same export names (`OSF_SUNSET_DATE`, `osfSunsetLabel`) as that branch's copy, so it merges rather than conflicts. Both tolerate a `null` date, so the deadline can be pulled without touching display code.
- **Dismissal is per-browser** (`localStorage`), not per-account — the homepage is read mostly by signed-out visitors. The key is versioned (`:v1`); bump it to re-show the banner to everyone.
- **Renders only after mount.** The site is statically exported, so prerendered HTML can't know whether this visitor already dismissed it; server-rendering would make it flash for everyone who had. Trade-off is a small layout shift on first paint.
- **`localStorage` access is wrapped in try/catch** — it throws outright in Safari private browsing and under "block all cookies". Those visitors still see the banner and can still close it for the session.

## Verification

- `npx jest --ci __tests__/osf-sunset-banner.test.jsx __tests__/index.test.jsx` — 5 passed
- `npx next build` — compiles, all 17 routes generate
- Not visually checked in a browser: the Chrome extension wasn't connected in this session. Worth a quick look at the rendered banner before merging.
- `npm run lint` is broken on `main` independently of this PR (repo has `.eslintrc.json`, but ESLint 9 is installed and wants flat config).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJnHtjEQWtadFwWEZkdKac