### PR TITLE
Never merge a loose original that is already sealed in a batch

### DIFF
--- a/functions/src/__tests__/finalization-emulator.test.js
+++ b/functions/src/__tests__/finalization-emulator.test.js
@@ -1107,3 +1107,138 @@ describe("F11. the merged archive is a valid Psych-DS dataset on its own", () =>
     expect(claim.data().sealed).toBe(true);
   });
 });
+
+describe("F12. a loose original that compaction failed to delete is not merged twice", () => {
+  // FOUND LIVE, NOT THEORISED. On 2026-08-22 a compaction pass on the test
+  // site archived 75 files and Zenodo rejected 3 of the follow-up deletes with
+  // "Not a valid value." -- the keys were valid and still addressable
+  // afterwards, so this is a provider fault, not a bug in the delete path.
+  //
+  // Compaction tolerates that by design: the archive was verified before any
+  // delete, the claims are sealed, and the next pass skips the survivors.
+  // Nothing is lost. But it leaves the same bytes in two places, and
+  // finalization merges everything it can see -- so the final archive used to
+  // get the content twice, the second copy under mergeEntries' collision
+  // fallback name ("x.json__data/raw/x.json"). A Psych-DS dataset carrying a
+  // mangled duplicate of every unluckily-undeleted file is not publishable.
+  async function seedWithUndeletedOriginal() {
+    const seeded = await seedFinalizableExperiment();
+    const { experimentID, batch1 } = seeded;
+
+    // The loose original of a file that is ALREADY inside batch1: exactly what
+    // a failed delete leaves behind.
+    const survivor = batch1.memberNames[0];
+    mock.seed(survivor, batch1.contents.get(survivor));
+
+    // Its claim is sealed and recorded against the batch, which is what makes
+    // the duplicate provable rather than guessed at.
+    await db
+      .collection("experiments")
+      .doc(experimentID)
+      .collection("compactionBatches")
+      .doc("0001")
+      .set({
+        index: 1,
+        archiveName: "datapipe-batch-0001.zip",
+        status: "sealed",
+        memberHashes: batch1.memberNames.map((name) => claimDocId(SALT, name)),
+        expectedMd5: "seeded",
+        fileCount: batch1.memberNames.length,
+      });
+
+    return { ...seeded, survivor };
+  }
+
+  it("carries the content exactly once, under its real Psych-DS path", async () => {
+    const { experimentID, survivor, batch1 } = await seedWithUndeletedOriginal();
+
+    const result = await finalizeExperiment(experimentID);
+    expect(result.status).toBe("finalized");
+
+    const entries = readZipEntries(finalArchiveBytes());
+    const paths = [...entries.keys()];
+
+    // No member name carries mergeEntries' "__" collision fallback.
+    expect(paths.filter((p) => p.includes("__"))).toEqual([]);
+
+    // And the real path appears once, with the right bytes.
+    const realPath = archivePathsFor(zenodoProvider, true, [survivor]).get(survivor);
+    expect(paths.filter((p) => p === realPath)).toHaveLength(1);
+    expect(entries.get(realPath).equals(batch1.contents.get(survivor))).toBe(true);
+  });
+
+  it("still REMOVES the redundant original, leaving the record as one file", async () => {
+    const { experimentID, survivor } = await seedWithUndeletedOriginal();
+
+    expect(mock.has(survivor)).toBe(true);
+
+    const result = await finalizeExperiment(experimentID);
+    expect(result.status).toBe("finalized");
+
+    // Skipping it from the MERGE must not spare it from the DELETE -- the
+    // redundant copy has no reason to outlive finalization, and leaving it
+    // would break the "record ends as exactly one file" invariant just as
+    // surely as archiving it twice would.
+    expect(mock.has(survivor)).toBe(false);
+    expect(mock.size()).toBe(1);
+    expect(mock.has("datapipe-final.zip")).toBe(true);
+  });
+
+  // Guard on the belt-and-braces branch: NEVER_ARCHIVE already keeps the
+  // descriptor out of every batch, so it cannot be sealed -- but if that ever
+  // changed, silently dropping it would produce an archive that is not a
+  // Psych-DS dataset at all, which F11 exists to prevent.
+  it("never skips dataset_description.json, even if its hash is sealed", async () => {
+    const { experimentID } = await seedFinalizableExperiment();
+    await db
+      .collection("experiments")
+      .doc(experimentID)
+      .collection("compactionBatches")
+      .doc("0001")
+      .set({
+        index: 1,
+        archiveName: "datapipe-batch-0001.zip",
+        status: "sealed",
+        memberHashes: [claimDocId(SALT, "dataset_description.json")],
+        expectedMd5: "seeded",
+        fileCount: 1,
+      });
+
+    const result = await finalizeExperiment(experimentID);
+    expect(result.status).toBe("finalized");
+    expect([...readZipEntries(finalArchiveBytes()).keys()]).toContain("dataset_description.json");
+  });
+
+  // An "uploading" batch has NOT proven its archive landed. Treating its
+  // members as already-stored is precisely the mistake that would lose data:
+  // skip the loose copy, then discover the archive never uploaded.
+  it("ignores an unsealed batch and merges the loose copy normally", async () => {
+    const seeded = await seedFinalizableExperiment();
+    const { experimentID, batch1 } = seeded;
+    const survivor = batch1.memberNames[0];
+    mock.seed(survivor, batch1.contents.get(survivor));
+
+    await db
+      .collection("experiments")
+      .doc(experimentID)
+      .collection("compactionBatches")
+      .doc("0001")
+      .set({
+        index: 1,
+        archiveName: "datapipe-batch-0001.zip",
+        status: "uploading",
+        memberHashes: batch1.memberNames.map((name) => claimDocId(SALT, name)),
+        expectedMd5: "seeded",
+        fileCount: batch1.memberNames.length,
+      });
+
+    const result = await finalizeExperiment(experimentID);
+    expect(result.status).toBe("finalized");
+
+    // Merged from the loose file rather than skipped, so the content survives
+    // even though the batch zip's own upload was never confirmed.
+    const entries = readZipEntries(finalArchiveBytes());
+    const realPath = archivePathsFor(zenodoProvider, true, [survivor]).get(survivor);
+    expect(entries.has(realPath)).toBe(true);
+  });
+});

--- a/functions/src/compaction.ts
+++ b/functions/src/compaction.ts
@@ -420,6 +420,36 @@ export async function releaseLease(
   });
 }
 
+/**
+ * Every claim hash sealed into a COMPLETED batch archive for this experiment.
+ *
+ * Membership answers one question: "are these bytes already inside a sealed
+ * archive?" Sealing happens only after the archive has been uploaded AND its
+ * md5 verified (see sealAndDelete), so a hash in this set is proof the content
+ * is safely stored, independent of whether the loose original was successfully
+ * deleted afterwards.
+ *
+ * That distinction is the point. Deletes can fail -- Zenodo returned "Not a
+ * valid value." for 3 of 75 on the test site, 2026-08-22 -- and compaction
+ * deliberately tolerates it: the originals stay loose and are skipped by the
+ * next pass. Correct for compaction, but it leaves the same content in two
+ * places, and finalization merges everything it can see.
+ *
+ * Only "sealed" batches count. An "uploading" batch is a pass that has not yet
+ * proven its archive landed; treating its members as already-stored would be
+ * exactly the mistake this set exists to prevent.
+ */
+export async function sealedBatchMemberHashes(experimentID: string): Promise<Set<string>> {
+  const snapshot = await batchesCollection(experimentID).where("status", "==", "sealed").get();
+  const hashes = new Set<string>();
+  for (const doc of snapshot.docs) {
+    for (const hash of (doc.data() as BatchRecord).memberHashes ?? []) {
+      hashes.add(hash);
+    }
+  }
+  return hashes;
+}
+
 interface BatchRecord {
   index: number;
   archiveName: string;

--- a/functions/src/finalization.ts
+++ b/functions/src/finalization.ts
@@ -45,6 +45,7 @@ import {
   isArchiveName,
   acquireLease,
   releaseLease,
+  sealedBatchMemberHashes,
 } from "./compaction.js";
 
 // Fixed name, unlike compaction's numbered datapipe-batch-NNNN.zip: the
@@ -256,8 +257,54 @@ async function runFinalization(experimentID: string): Promise<Omit<FinalizationR
       };
     }
 
-    // Every file is both archived and removed -- see DESCRIPTOR above.
-    const members = files;
+    // Every file is removed -- see DESCRIPTOR above -- but not every file is
+    // ARCHIVED, and the two sets genuinely differ.
+    //
+    // A loose file whose claim hash is already sealed into a batch archive is
+    // a duplicate of content this record already holds: compaction verified
+    // the archive, sealed the claim, and then failed to delete the original.
+    // That is a tolerated outcome for compaction (nothing is lost, and the
+    // next pass skips it), but finalization merges everything it can see, so
+    // without this filter the same bytes land in the final archive twice --
+    // once at data/raw/x.json from the batch, and once at a mangled
+    // "x.json__data/raw/x.json" from mergeEntries' collision fallback. A
+    // Psych-DS dataset containing a duplicate of every unluckily-undeleted
+    // file is not one anybody would want to publish.
+    //
+    // Observed live rather than theorised: Zenodo rejected 3 of 75 deletes
+    // with "Not a valid value." on 2026-08-22, and the keys were valid and
+    // still addressable afterwards, so this is a provider fault we cannot
+    // prevent -- only decline to propagate.
+    //
+    // They are still REMOVED. The redundant copy has no reason to outlive
+    // finalization, and leaving it would defeat the "record ends as exactly
+    // one file" invariant just as surely as archiving it twice would.
+    const sealedHashes = await sealedBatchMemberHashes(experimentID);
+    const alreadyArchived = new Set(
+      files
+        .filter(
+          (file) =>
+            !isArchiveName(file.name) &&
+            // Belt and braces: NEVER_ARCHIVE keeps the two Psych-DS control
+            // files out of every batch, so neither can be sealed and neither
+            // can reach this branch. Excluding the descriptor explicitly
+            // anyway, because silently dropping it would produce an archive
+            // that is not a Psych-DS dataset, and that failure mode is worth
+            // more than one line of defence.
+            file.name !== DESCRIPTOR &&
+            sealedHashes.has(claimDocId(salt, file.name))
+        )
+        .map((file) => file.name)
+    );
+
+    if (alreadyArchived.size > 0) {
+      console.warn(
+        `finalization: ${experimentID} skipping ${alreadyArchived.size} loose file(s) already sealed ` +
+          `into a batch archive; they will be removed but not merged twice`
+      );
+    }
+
+    const members = files.filter((file) => !alreadyArchived.has(file.name));
     const removable = files;
 
     // "Nothing collected" is judged on DATA, not on file count: an experiment


### PR DESCRIPTION
Found by running the live API check against the deployed test site.

## What happened

A compaction pass archived 75 files, and Zenodo rejected 3 of the follow-up deletes:

```
compaction: failed to delete 6hYaOnsRtA7L member after archiving: Not a valid value.  (x3)
compaction: sealed 75 file(s) into datapipe-batch-0001.zip (82 -> 11 files)
compaction: left 3 original(s) undeleted; they will be skipped next pass
```

**Compaction behaved correctly.** The archive was uploaded and md5-verified before any delete, the claims were sealed, nothing was lost, and the failure was logged. The keys were valid and still addressable afterwards (`GET` returns 200), so this is a provider fault, not a bug in the delete path.

What it leaves is the same content in two places.

## Why that mattered downstream

Finalization merges everything it can see, so each survivor was merged twice — once at `data/raw/x.json` from the batch archive, and once under `mergeEntries`' collision fallback as `x.json__data/raw/x.json`. The zip stays structurally valid, but the resulting Psych-DS dataset carries a mangled duplicate of every unluckily-undeleted file.

The comment above that fallback says such a collision *"cannot happen under any archivePathFor DataPipe ships"*. That is true as written — and still falsified in practice, by a route it did not consider.

## The change

Finalization skips a loose file whose claim hash is already sealed into a **completed** batch, while still **removing** it. The two sets genuinely differ now: archive one copy, delete both.

- Only `sealed` batches count. An `uploading` batch has not proven its archive landed; trusting it would convert a skipped merge into real data loss.
- `dataset_description.json` is excluded explicitly. `NEVER_ARCHIVE` already keeps it out of every batch so it cannot be sealed, but silently dropping it would produce an archive that is not a Psych-DS dataset at all, and that failure mode is worth a second line of defence.

## Tests

727 tests, 59 suites, 0 failures. Lint and `tsc` clean.

Four new cases in `F12`. I verified the main one actually catches the bug by disabling the filter and confirming it fails — the other three are boundary guards (still removes, never skips the descriptor, ignores unsealed batches) and pass either way by construction, which is the point of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)