### PR TITLE
Link the homepage banner to COS's OSF announcement

### DIFF
--- a/__tests__/osf-sunset-banner.test.jsx
+++ b/__tests__/osf-sunset-banner.test.jsx
@@ -32,6 +32,19 @@ describe("OsfSunsetBanner", () => {
     expect(screen.getByText(/multi-backend/i)).toBeInTheDocument();
   });
 
+  it("links out to the COS announcement, safely", () => {
+    renderBanner();
+    const link = screen.getByRole("link", { name: /announcement from COS/i });
+    expect(link).toHaveAttribute(
+      "href",
+      "https://www.cos.io/blog/osf-changes-a-note-to-users"
+    );
+    // Opening in a new tab without noopener hands the COS page a window
+    // reference back to DataPipe.
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", expect.stringContaining("noopener"));
+  });
+
   it("hides itself when dismissed and records the dismissal", () => {
     renderBanner();
 

--- a/components/OsfSunsetBanner.js
+++ b/components/OsfSunsetBanner.js
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Box, HStack, IconButton, Text } from "@chakra-ui/react";
+import { Box, HStack, IconButton, Link, Text } from "@chakra-ui/react";
 import { TriangleAlert, X } from "lucide-react";
 import { osfSunsetLabel } from "../lib/osf-sunset";
 
@@ -29,8 +29,9 @@ function rememberDismissal() {
 }
 
 // Homepage announcement that OSF-backed storage is going away and DataPipe is
-// becoming multi-backend. Deliberately self-contained -- there is nowhere on
-// the site to link to for more detail yet.
+// becoming multi-backend. Links out to COS's own announcement rather than to
+// anything on this site: the FAQ and getting-started pages still describe OSF
+// as the only destination, so there is nothing here worth sending people to.
 export default function OsfSunsetBanner() {
   // Starts hidden and is revealed in an effect. The site is statically
   // exported, so the server-rendered HTML cannot know whether this visitor has
@@ -70,7 +71,18 @@ export default function OsfSunsetBanner() {
           multi-backend model with support for Google Drive, Zenodo, and other
           storage providers. Experiments collecting data today keep running
           until then, and data already on OSF stays in your OSF account. We
-          will publish migration instructions before anything stops working.
+          will publish migration instructions before anything stops working.{" "}
+          <Link
+            href="https://www.cos.io/blog/osf-changes-a-note-to-users"
+            target="_blank"
+            rel="noopener noreferrer"
+            color="brandOrange.200"
+            textDecoration="underline"
+            _hover={{ color: "white" }}
+          >
+            Read the announcement from COS
+          </Link>
+          .
         </Text>
         <IconButton
           aria-label="Dismiss announcement"


### PR DESCRIPTION
Follow-up to #175. Adds the link to COS's announcement that was requested but missed before that PR merged.

> Read the announcement from COS → https://www.cos.io/blog/osf-changes-a-note-to-users

## Why

The banner asserts OSF is shutting down its projects feature and asks researchers to plan around a specific date, but gave them nothing to verify that against. This sends them to the source.

Links out rather than to the FAQ deliberately — the FAQ and getting-started pages still describe OSF as the only destination, so there's nothing on-site worth linking to yet.

## Notes

- Opens in a new tab, so it carries `rel="noopener"` — without it the COS page gets a `window` reference back into DataPipe. There's a test asserting it, since that's the kind of attribute a refactor drops silently.
- URL verified: returns HTTP 200, no redirect.

## Verification

- `npx jest --ci __tests__/osf-sunset-banner.test.jsx` — 5 passed
- Not visually checked in a browser (Chrome extension wasn't connected this session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJnHtjEQWtadFwWEZkdKac