### PR TITLE
Retire OSF from the researcher-facing guides

### DIFF
--- a/pages/api-docs.js
+++ b/pages/api-docs.js
@@ -54,6 +54,16 @@ function Param({ name, type, children }) {
   );
 }
 
+function ErrorRow({ code, status, children }) {
+  return (
+    <Table.Row>
+      <Table.Cell><Code>{code}</Code></Table.Cell>
+      <Table.Cell><Text fontSize="sm" color="gray.400">{status}</Text></Table.Cell>
+      <Table.Cell>{children}</Table.Cell>
+    </Table.Row>
+  );
+}
+
 export default function ApiDocs() {
   return (
     <Stack w={["95%", 960]} gap={12} py={4}>
@@ -69,6 +79,12 @@ export default function ApiDocs() {
           on DataPipe. Code examples for jsPsych and JavaScript are
           available on each experiment&apos;s dashboard.
         </Text>
+        <Text>
+          The API is the same whichever storage provider an experiment uses.
+          DataPipe routes each submission to that experiment&apos;s own
+          destination — a Google Drive folder, a Dataverse dataset, or a
+          Zenodo deposition — so your experiment code never names a provider.
+        </Text>
       </Stack>
 
       {/* Save text data */}
@@ -77,16 +93,16 @@ export default function ApiDocs() {
           Save text data
         </EndpointHeading>
         <Text>
-          Save a text file (CSV, JSON, etc.) to your OSF project. If you
-          have validation rules configured, the data will be checked before
-          it is sent to the OSF.
+          Save a text file (CSV, JSON, etc.) to your experiment&apos;s
+          storage. If you have validation rules configured, DataPipe checks
+          the data before sending it on.
         </Text>
         <ParamTable>
           <Param name="experimentID" type="string">
             Your experiment ID, found on the experiment dashboard.
           </Param>
           <Param name="filename" type="string">
-            Name for the file on OSF (e.g., <Code>subject01.csv</Code>).
+            Name for the stored file (e.g., <Code>subject01.csv</Code>).
             Must be unique — the request will fail if a file with this name
             already exists.
           </Param>
@@ -114,14 +130,14 @@ export default function ApiDocs() {
         <Text>
           Save a binary file (audio, video, images) encoded as a base64
           string. DataPipe decodes the string and stores the resulting
-          file in your OSF project.
+          file alongside the experiment&apos;s other data.
         </Text>
         <ParamTable>
           <Param name="experimentID" type="string">
             Your experiment ID.
           </Param>
           <Param name="filename" type="string">
-            Name for the decoded file on OSF (e.g., <Code>recording_01.webm</Code>).
+            Name for the decoded file (e.g., <Code>recording_01.webm</Code>).
             Must be unique.
           </Param>
           <Param name="data" type="string">
@@ -161,36 +177,98 @@ export default function ApiDocs() {
           Responses
         </Heading>
         <Text>
-          All responses are JSON. A successful request returns{" "}
-          <Code>{`{ "message": "Success" }`}</Code>. The condition
-          endpoint also includes a <Code>condition</Code> field.
-          On failure, the response contains an <Code>error</Code> code
-          and a <Code>message</Code> describing the problem.
+          All responses are JSON. On failure, the body carries an{" "}
+          <Code>error</Code> code from the table below and a{" "}
+          <Code>message</Code> describing the problem. When metadata
+          production is enabled, write responses also include a{" "}
+          <Code>metadataMessage</Code> field reporting what happened to the
+          metadata file; it never affects whether the data itself was stored.
+        </Text>
+        <Table.Root variant="outline">
+          <Table.Header>
+            <Table.Row>
+              <Table.ColumnHeader color="white">Status</Table.ColumnHeader>
+              <Table.ColumnHeader color="white">Meaning</Table.ColumnHeader>
+            </Table.Row>
+          </Table.Header>
+          <Table.Body>
+            <Table.Row>
+              <Table.Cell><Code>201</Code></Table.Cell>
+              <Table.Cell>
+                Stored. The body is{" "}
+                <Code>{`{ "message": "Success" }`}</Code>. The condition
+                endpoint returns <Code>200</Code> with a{" "}
+                <Code>condition</Code> field instead.
+              </Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell><Code>202</Code></Table.Cell>
+              <Table.Cell>
+                Accepted and queued. DataPipe has your data safely but could
+                not reach your storage provider yet, so it will retry
+                automatically. <Code>error</Code> is <Code>null</Code>.{" "}
+                <strong>Treat this as success and do not resubmit</strong> —
+                retrying would store the participant&apos;s data twice.
+              </Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell><Code>400</Code></Table.Cell>
+              <Table.Cell>
+                The request was rejected and the data was not stored.
+              </Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell><Code>500</Code></Table.Cell>
+              <Table.Cell>
+                Something failed on our side. See the individual codes below
+                for whether the data was stored.
+              </Table.Cell>
+            </Table.Row>
+          </Table.Body>
+        </Table.Root>
+
+        <Heading as="h3" size="sm" mt={4}>
+          Error codes
+        </Heading>
+        <Text fontSize="sm" color="gray.400">
+          Codes beginning <Code>OSF_</Code> are historical names kept for
+          backward compatibility. <Code>OSF_FILE_EXISTS</Code>,{" "}
+          <Code>OSF_UPLOAD_ERROR</Code> and <Code>OSF_UPLOAD_EXCEPTION</Code>{" "}
+          are returned for every storage provider, not only OSF.{" "}
+          <Code>INVALID_OSF_TOKEN</Code> and <Code>INVALID_REFRESH_TOKEN</Code>{" "}
+          occur only on experiments still collecting to OSF.
         </Text>
         <Table.Root variant="outline">
           <Table.Header>
             <Table.Row>
               <Table.ColumnHeader color="white">Error code</Table.ColumnHeader>
+              <Table.ColumnHeader color="white">Status</Table.ColumnHeader>
               <Table.ColumnHeader color="white">Meaning</Table.ColumnHeader>
             </Table.Row>
           </Table.Header>
           <Table.Body>
-            <Table.Row><Table.Cell><Code>MISSING_PARAMETER</Code></Table.Cell><Table.Cell>One or more required fields are missing from the request body.</Table.Cell></Table.Row>
-            <Table.Row><Table.Cell><Code>EXPERIMENT_NOT_FOUND</Code></Table.Cell><Table.Cell>No experiment matches the provided ID.</Table.Cell></Table.Row>
-            <Table.Row><Table.Cell><Code>DATA_COLLECTION_NOT_ACTIVE</Code></Table.Cell><Table.Cell>Data collection is not enabled for this experiment.</Table.Cell></Table.Row>
-            <Table.Row><Table.Cell><Code>BASE64DATA_COLLECTION_NOT_ACTIVE</Code></Table.Cell><Table.Cell>Base64 data collection is not enabled for this experiment.</Table.Cell></Table.Row>
-            <Table.Row><Table.Cell><Code>CONDITION_ASSIGNMENT_NOT_ACTIVE</Code></Table.Cell><Table.Cell>Condition assignment is not enabled for this experiment.</Table.Cell></Table.Row>
-            <Table.Row><Table.Cell><Code>SESSION_LIMIT_REACHED</Code></Table.Cell><Table.Cell>The experiment has reached its session limit. Increase the limit in the dashboard.</Table.Cell></Table.Row>
-            <Table.Row><Table.Cell><Code>INVALID_DATA</Code></Table.Cell><Table.Cell>The data did not pass the validation rules configured for this experiment.</Table.Cell></Table.Row>
-            <Table.Row><Table.Cell><Code>INVALID_BASE64_DATA</Code></Table.Cell><Table.Cell>The data is not valid base64.</Table.Cell></Table.Row>
-            <Table.Row><Table.Cell><Code>OSF_FILE_EXISTS</Code></Table.Cell><Table.Cell>A file with this name already exists in the OSF project. Filenames must be unique.</Table.Cell></Table.Row>
-            <Table.Row><Table.Cell><Code>OSF_UPLOAD_ERROR</Code></Table.Cell><Table.Cell>DataPipe could not upload the file to OSF. Try again later.</Table.Cell></Table.Row>
-            <Table.Row><Table.Cell><Code>INVALID_OWNER</Code></Table.Cell><Table.Cell>The experiment owner does not match a valid user account.</Table.Cell></Table.Row>
-            <Table.Row><Table.Cell><Code>INVALID_OSF_TOKEN</Code></Table.Cell><Table.Cell>The OSF token for this account is invalid or expired. Reconnect your OSF account in settings.</Table.Cell></Table.Row>
-            <Table.Row><Table.Cell><Code>INVALID_METADATA_ERROR</Code></Table.Cell><Table.Cell>The metadata generated from the data is invalid.</Table.Cell></Table.Row>
-            <Table.Row><Table.Cell><Code>OSF_METADATA_UPLOAD_ERROR</Code></Table.Cell><Table.Cell>DataPipe could not upload the metadata file to OSF.</Table.Cell></Table.Row>
-            <Table.Row><Table.Cell><Code>METADATA_ERROR</Code></Table.Cell><Table.Cell>An error occurred while processing metadata.</Table.Cell></Table.Row>
-            <Table.Row><Table.Cell><Code>UNKNOWN_ERROR_GETTING_CONDITION</Code></Table.Cell><Table.Cell>An unexpected error occurred while assigning a condition.</Table.Cell></Table.Row>
+            <ErrorRow code="MISSING_PARAMETER" status={400}>One or more required fields are missing from the request body.</ErrorRow>
+            <ErrorRow code="EXPERIMENT_NOT_FOUND" status={400}>No experiment matches the provided ID.</ErrorRow>
+            <ErrorRow code="EXPERIMENT_DATA_NOT_FOUND" status={400}>The experiment exists but its configuration could not be read.</ErrorRow>
+            <ErrorRow code="USER_DATA_NOT_FOUND" status={400}>The account that owns the experiment could not be read.</ErrorRow>
+            <ErrorRow code="INVALID_OWNER" status={400}>The experiment owner does not match a valid user account.</ErrorRow>
+            <ErrorRow code="EXPERIMENT_FINALIZED" status={400}>The experiment has been finalized and no longer accepts submissions.</ErrorRow>
+            <ErrorRow code="DATA_COLLECTION_NOT_ACTIVE" status={400}>Data collection is not enabled for this experiment.</ErrorRow>
+            <ErrorRow code="BASE64DATA_COLLECTION_NOT_ACTIVE" status={400}>Base64 data collection is not enabled for this experiment.</ErrorRow>
+            <ErrorRow code="CONDITION_ASSIGNMENT_NOT_ACTIVE" status={400}>Condition assignment is not enabled for this experiment.</ErrorRow>
+            <ErrorRow code="SESSION_LIMIT_REACHED" status={400}>The experiment has reached its session limit. Raise the limit in the dashboard.</ErrorRow>
+            <ErrorRow code="INVALID_DATA" status={400}>The data did not pass the validation rules configured for this experiment.</ErrorRow>
+            <ErrorRow code="INVALID_BASE64_DATA" status={400}>The data is not valid base64.</ErrorRow>
+            <ErrorRow code="OSF_FILE_EXISTS" status={400}>A file with this name already exists in the experiment&apos;s storage. Filenames must be unique.</ErrorRow>
+            <ErrorRow code="OSF_UPLOAD_ERROR" status={400}>The storage provider rejected the upload.</ErrorRow>
+            <ErrorRow code="PROVIDER_NOT_CONNECTED" status={400}>The owner has not connected an account for this experiment&apos;s storage provider.</ErrorRow>
+            <ErrorRow code="PROVIDER_TOKEN_EXPIRED" status={400}>The API token for the storage provider has expired. The owner must create a new one and reconnect it.</ErrorRow>
+            <ErrorRow code="INVALID_OSF_TOKEN" status={400}>The OSF token for this account is invalid or expired.</ErrorRow>
+            <ErrorRow code="INVALID_REFRESH_TOKEN" status={400}>The owner&apos;s OSF refresh token is no longer valid.</ErrorRow>
+            <ErrorRow code="UNKNOWN_ERROR_GETTING_CONDITION" status={400}>An unexpected error occurred while assigning a condition.</ErrorRow>
+            <ErrorRow code="TOKEN_RESOLUTION_ERROR" status={500}>DataPipe could not resolve the owner&apos;s storage credentials.</ErrorRow>
+            <ErrorRow code="OSF_UPLOAD_EXCEPTION" status={500}>An unexpected error occurred while uploading to the storage provider.</ErrorRow>
+            <ErrorRow code="DATA_PERSIST_ERROR" status={500}>DataPipe could not save the data. It was not stored, and a live participant may need to resubmit.</ErrorRow>
           </Table.Body>
         </Table.Root>
       </Stack>

--- a/pages/faq.js
+++ b/pages/faq.js
@@ -8,9 +8,14 @@ import {
 } from "@chakra-ui/react";
 import NextLink from "next/link";
 import { useState, useEffect } from "react";
+import { osfSunsetLabel } from "../lib/osf-sunset";
 
 export default function FAQ() {
   const [openItems, setOpenItems] = useState(["item-0"]);
+  // Read from lib/osf-sunset.js rather than restated here, so this answer, the
+  // dashboard banners and the getting-started guide can never disagree about
+  // the date. Tolerates a null date the same way they do.
+  const osfDeadline = osfSunsetLabel();
 
   useEffect(() => {
     function scrollToHash() {
@@ -47,20 +52,44 @@ export default function FAQ() {
             <Link asChild>
               <NextLink href="/getting-started">getting started guide</NextLink>
             </Link>
-            . In short: create an OSF project, link your OSF account to
-            DataPipe, set up an experiment, and add a few lines of code to
-            your study to send data through DataPipe to the OSF. The easiest
-            way to get started is to sign in to DataPipe with your OSF
-            account, which automatically authorizes DataPipe to write data
-            on your behalf.
+            . In short: connect a storage provider — Google Drive,
+            Dataverse, or Zenodo — to your DataPipe account, create an
+            experiment, and add a few lines of code to your study to send data
+            through DataPipe to that provider. Google Drive and Zenodo connect
+            in one click; Dataverse asks for an API token from your
+            institution&apos;s installation.
+          </Text>
+        </FAQItem>
+        <FAQItem value="item-0b" question="I collect data on OSF. What happens now?">
+          <Text mb={2}>
+            OSF is shutting down its projects feature, so DataPipe can no
+            longer create new experiments there.{" "}
+            {osfDeadline
+              ? `Experiments already collecting keep running until ${osfDeadline}, after which DataPipe stops writing to OSF.`
+              : "Experiments already collecting keep running for now."}
+          </Text>
+          <Text mb={2}>
+            Data already on OSF is unaffected. It stays in your OSF account,
+            and DataPipe never removes it.
+          </Text>
+          <Text>
+            To keep collecting, connect Google Drive, Dataverse, or Zenodo in
+            your{" "}
+            <Link asChild>
+              <NextLink href="/admin/account">account settings</NextLink>
+            </Link>
+            , create a new experiment on that provider, and point your study
+            at the new experiment ID. Your existing data does not move, so it
+            is worth finishing a study on OSF if you are close to done rather
+            than switching mid-collection.
           </Text>
         </FAQItem>
         <FAQItem value="item-1" question="Will DataPipe host my experiment?">
           <Text mb={2}>
             No. You need a separate service to host your experiment online
             (e.g., GitHub Pages, Netlify, or university hosting). DataPipe
-            only handles sending data to the OSF, so you do not need to
-            configure any backend or server components yourself.
+            only handles sending data to your storage provider, so you do not
+            need to configure any backend or server components yourself.
           </Text>
           <Text>
             <Link href="https://pages.github.com/" target="_blank" rel="noopener noreferrer">
@@ -72,26 +101,28 @@ export default function FAQ() {
         </FAQItem>
         <FAQItem value="item-2" question="Will DataPipe store my data?">
           <Text mb={2}>
-            Under normal operation, no. DataPipe routes your data to the Open
-            Science Framework but does not keep a copy. Data passes through
-            DataPipe for optional validation and is then sent directly to your
-            OSF project.
+            Under normal operation, no. DataPipe routes your data to the
+            storage provider you connected but does not keep a copy. Data
+            passes through DataPipe for optional validation and then goes
+            straight to your Drive folder, Dataverse dataset, or Zenodo
+            deposition.
           </Text>
           <Text>
-            The one exception is when an upload to the OSF fails (for example,
-            due to a temporary OSF outage or rate limit). In that case,
-            DataPipe temporarily caches the data so it can retry the upload
+            The one exception is when an upload fails (for example, because
+            your provider is briefly unavailable or rate-limits us). In that
+            case, DataPipe temporarily caches the data so it can retry the upload
             automatically. Cached data is encrypted at rest, stored for up to
             one week, and deleted as soon as the upload succeeds. See the
             question below for details.
           </Text>
         </FAQItem>
-        <FAQItem value="item-2b" question="What happens if an upload to the OSF fails?">
+        <FAQItem value="item-2b" question="What happens if an upload fails?">
           <Text mb={2}>
-            If the OSF is temporarily unavailable or returns an error, DataPipe
-            will not lose your data. Failed uploads are automatically cached
-            and retried with increasing intervals (starting at one hour, up to
-            24 hours) for up to five attempts over approximately one week.
+            If your storage provider is temporarily unavailable or returns an
+            error, DataPipe will not lose your data. Failed uploads are
+            automatically cached and retried with increasing intervals
+            (starting at one hour, up to 24 hours) for up to five attempts
+            over approximately one week.
           </Text>
           <Text mb={2}>
             Your experiment dashboard will show an orange badge for pending
@@ -136,9 +167,10 @@ export default function FAQ() {
         <FAQItem value="item-4" question="Why is DataPipe free?">
           <Text>
             The expensive parts of running an online experiment — hosting files
-            and storing data — are handled by free services like GitHub Pages
-            and the OSF. DataPipe is a lightweight bridge between them, which
-            makes it inexpensive to operate.
+            and storing data — are handled by services you already have access
+            to, like GitHub Pages for hosting and Google Drive, Dataverse, or
+            Zenodo for storage. DataPipe is a lightweight bridge between them,
+            which makes it inexpensive to operate.
           </Text>
         </FAQItem>
         <FAQItem value="item-5" question="How expensive is it to run DataPipe?">
@@ -169,9 +201,13 @@ export default function FAQ() {
         <FAQItem value="item-6" question="Who can see the data I collect?">
           <Text>
             DataPipe does not store or log your data. Once data reaches your
-            OSF project, visibility depends on your OSF settings. If the
-            receiving component is private, only you and your collaborators
-            can see the data. If it is public, anyone can.
+            storage provider, visibility is governed entirely by that
+            provider&apos;s own sharing settings. A Google Drive folder is
+            private until you share it. A Zenodo deposition stays a private
+            draft until you publish it. A Dataverse dataset stays a draft
+            until you publish it, and its access is then set by your
+            installation&apos;s policies. In every case DataPipe changes
+            nothing about who can see your data — you do.
           </Text>
         </FAQItem>
         <FAQItem value="item-7" question="What are the risks of using DataPipe?">
@@ -181,17 +217,18 @@ export default function FAQ() {
           <ol style={{ paddingLeft: "1.5em" }}>
             <li style={{ marginBottom: "0.5em" }}>
               <strong>Authorization tokens.</strong> DataPipe needs permission
-              to write to your OSF account. All tokens are stored encrypted.
-              If you sign in with your OSF account, tokens are managed and
-              refreshed automatically. If you use a personal access token
-              instead, create one specifically for DataPipe and revoke it when
-              you are done collecting data.
+              to write to your storage account, and all tokens are stored
+              encrypted. For Google Drive and Zenodo you authorize DataPipe
+              directly, and it manages and refreshes those tokens for you. For
+              Dataverse you supply an API token, so create one specifically for
+              DataPipe and revoke it when you are done collecting data. You can
+              disconnect any provider from your account settings at any time.
             </li>
             <li style={{ marginBottom: "0.5em" }}>
               <strong>Fake or spam data.</strong> As with any online experiment,
               a technically savvy user could submit fabricated data or spam
-              files to your OSF project. DataPipe provides validation rules
-              and session limits to reduce this risk.
+              files to your storage. DataPipe provides validation rules and
+              session limits to reduce this risk.
             </li>
             <li>
               <strong>Support availability.</strong> DataPipe is not a
@@ -207,16 +244,17 @@ export default function FAQ() {
         </FAQItem>
         <FAQItem value="item-8" question="How does data validation work?">
           <Text mb={2}>
-            When enabled, DataPipe checks incoming data before sending it to
-            the OSF. You can validate that files are well-formed JSON or CSV,
+            When enabled, DataPipe checks incoming data before sending it on
+            to your storage provider. You can validate that files are
+            well-formed JSON or CSV,
             and you can specify a list of required columns or fields that must
             be present. For JSON arrays (like jsPsych output), DataPipe checks
             whether the required fields appear in at least one object across
             the array.
           </Text>
           <Text>
-            Invalid files are rejected and not sent to the OSF. Rejected data
-            cannot be recovered. This feature is designed to block malicious
+            Invalid files are rejected and never sent to your storage
+            provider. Rejected data cannot be recovered. This feature is designed to block malicious
             submissions, not to catch errors in legitimate data.
           </Text>
         </FAQItem>
@@ -224,8 +262,9 @@ export default function FAQ() {
           <Text mb={2}>
             Base64 data collection lets you send binary files — like audio
             recordings, video, or images — encoded as base64 strings. DataPipe
-            decodes the string and stores the resulting file in your OSF
-            project. Each request sends one file at a time.
+            decodes the string and stores the resulting file alongside the rest
+            of your experiment&apos;s data. Each request sends one file at a
+            time.
           </Text>
           <Text>
             Validation is not currently supported for base64 data, so enabling
@@ -290,8 +329,8 @@ export default function FAQ() {
         </FAQItem>
         <FAQItem value="item-11" question="How does metadata production work?">
           <Text mb={2}>
-            When enabled, DataPipe generates a dataset_description.json file in
-            your OSF project that describes your dataset and its variables
+            When enabled, DataPipe generates a dataset_description.json file
+            alongside your data that describes the dataset and its variables
             according to the Psych-DS specification. The file is updated
             automatically as new sessions are uploaded.
           </Text>
@@ -315,18 +354,20 @@ export default function FAQ() {
             to learn more.
           </Text>
         </FAQItem>
-        <FAQItem value="item-12" question="What is one-click authentication?">
+        <FAQItem value="item-12" question="How does DataPipe get permission to write to my storage?">
           <Text mb={2}>
-            One-click authentication lets you sign in to DataPipe with your
-            OSF account. DataPipe then manages your authorization tokens
-            automatically, including refreshing them when they expire. This
-            is the recommended approach for most users.
+            It depends on the provider. <strong>Google Drive</strong> and{" "}
+            <strong>Zenodo</strong> use a one-click authorization: you approve
+            DataPipe on their site, and DataPipe then manages the resulting
+            tokens for you, including refreshing them before they expire.
           </Text>
           <Text>
-            The alternative is a personal access token, which you create on
-            the OSF and paste into DataPipe. This gives you direct control
-            but requires you to manage the token yourself. Both methods store
-            tokens encrypted.
+            <strong>Dataverse</strong> uses an API token that you create on
+            your institution&apos;s installation and paste into DataPipe. That
+            gives you direct control, but nothing can renew it for you: when
+            the token expires, data stops arriving until you create a new one
+            and reconnect. Tokens are stored encrypted either way, and you can
+            disconnect a provider at any time from your account settings.
           </Text>
         </FAQItem>
         <FAQItem value="item-13" question="How should I cite DataPipe?">

--- a/pages/getting-started.js
+++ b/pages/getting-started.js
@@ -11,6 +11,12 @@ import {
 } from "@chakra-ui/react";
 import { ChevronDown, ChevronRight, Shield } from "lucide-react";
 import { useState } from "react";
+import { osfSunsetLabel } from "../lib/osf-sunset";
+
+// Which Zenodo this deployment points at -- "" on production, "sandbox." on
+// the test site. Same reasoning as lib/provider-config.js: the test
+// deployment must not send researchers to sign up on the live service.
+const ZENODO_HOST = `https://${process.env.NEXT_PUBLIC_ZENODO_ENV ?? ""}zenodo.org`;
 
 function StepNumber({ number }) {
   return (
@@ -107,7 +113,48 @@ function FeatureItem({ name, children }) {
   );
 }
 
+// One storage provider, in the terms a researcher choosing between them
+// actually needs: whether it is the right fit, where the data physically ends
+// up, how they connect, and the limit that will eventually matter. The
+// decision sentence leads because that is the only line someone skimming for
+// "which one do I pick" needs to read. Plain rows rather than a comparison
+// table so it stays readable on a phone.
+function ProviderOption({ name, summary, landsIn, connect, limits }) {
+  return (
+    <Box borderWidth="1px" borderColor="gray.700" borderRadius={8} p={4}>
+      <Text fontWeight="semibold" color="brandOrange.300" mb={1}>
+        {name}
+      </Text>
+      <Text fontSize="sm" mb={3}>
+        {summary}
+      </Text>
+      <Stack gap={1}>
+        <Text fontSize="sm" color="gray.400">
+          <Text as="span" fontWeight="semibold">Data lands in:</Text> {landsIn}
+        </Text>
+        <Text fontSize="sm" color="gray.400">
+          <Text as="span" fontWeight="semibold">Connect with:</Text> {connect}
+        </Text>
+        <Text fontSize="sm" color="gray.400">
+          <Text as="span" fontWeight="semibold">Limits:</Text> {limits}
+        </Text>
+      </Stack>
+    </Box>
+  );
+}
+
 export default function GettingStarted() {
+  const osfDeadline = osfSunsetLabel();
+  // Consequence first (PRODUCT.md principle 2): what stops working, then why.
+  // Both sentences degrade gracefully when no cutoff has been announced --
+  // lib/osf-sunset.js tolerates a null date and so must every reader of it.
+  const osfStops = osfDeadline
+    ? `DataPipe will stop writing to OSF after ${osfDeadline}.`
+    : "DataPipe is winding down its support for OSF.";
+  const osfUntil = osfDeadline
+    ? "Experiments already collecting keep running until that date."
+    : "Experiments already collecting keep running for now.";
+
   return (
     <Stack w={["95%", 960]} gap={8} py={4}>
       <VStack gap={2} align="start">
@@ -115,80 +162,134 @@ export default function GettingStarted() {
           Getting Started
         </Heading>
         <Text color="gray.400" fontSize="lg">
-          Set up DataPipe to send experiment data directly to the OSF. This
-          guide covers a typical online experiment using free tools.
+          DataPipe sends data from your experiment straight to storage you
+          control — Google Drive, Dataverse, or Zenodo. This guide sets up one
+          experiment end to end, from choosing a provider to your first test
+          run.
         </Text>
       </VStack>
 
-      <StepCard number={1} title="Create an OSF project">
+      <StepCard number={1} title="Choose where your data goes">
         <Text>
-          Create a project at{" "}
-          <Link href={`https://${process.env.NEXT_PUBLIC_OSF_ENV}osf.io`} target="_blank" rel="noopener noreferrer" color="brandOrange.300">
-            osf.io
+          DataPipe writes each participant&apos;s data into your own account
+          with one of the three storage providers below. The data is yours
+          throughout — DataPipe only ever asks for permission to add files.
+          You can use a different provider for each experiment, so this choice
+          is not permanent.
+        </Text>
+        <Stack gap={3}>
+          <ProviderOption
+            name="Google Drive"
+            summary="Your own Google Drive. Choose this if you want the fewest steps and do not need a citable dataset."
+            landsIn="a folder in My Drive/DataPipe, or in a parent folder you pick."
+            connect="your Google account, in one click."
+            limits="free Google accounts share 15 GB across Drive, Gmail, and Photos. Uploads stop once that is full."
+          />
+          <ProviderOption
+            name="Dataverse"
+            summary="Institutional repositories run by universities and consortia — Harvard Dataverse, Borealis, DataverseNL, and others. Choose this if your institution or funder expects data to live there."
+            landsIn="a draft dataset, in a collection you name."
+            connect="an API token from your institution's installation."
+            limits="your installation sets its own file size and storage limits. API tokens expire, often yearly, and DataPipe cannot renew them — data stops arriving until you reconnect."
+          />
+          <ProviderOption
+            name="Zenodo"
+            summary="An open repository run by CERN that issues a DOI for every published record. Choose this if you want your data citable without an institutional repository."
+            landsIn="a deposition that stays private until you publish it."
+            connect="your Zenodo account, in one click."
+            limits="100 files and 50 GB per record. DataPipe merges completed sessions into archives so a long study stays under the file limit."
+          />
+        </Stack>
+        <Text>
+          You need an account with whichever provider you choose:{" "}
+          <Link href="https://drive.google.com" target="_blank" rel="noopener noreferrer" color="brandOrange.300">
+            Google Drive
           </Link>
-          {" "}to store your experiment data. You will need an OSF account
-          — create one if you do not have one already.
-        </Text>
-        <Text>
-          Once you have an account, click <strong>Create Project</strong> and
-          give it any name you like. Your OSF account can also be used to
-          sign in to DataPipe directly.
-        </Text>
-      </StepCard>
-
-      <StepCard number={2} title="Link your OSF account to DataPipe">
-        <Text>
-          DataPipe needs authorization to create files in your OSF projects.
-          If you signed up for DataPipe using your OSF account, this is
-          already done.
-        </Text>
-        <Text>
-          Otherwise, go to your{" "}
-          <Link href="/admin/account" color="brandOrange.300">
-            Account Settings
+          ,{" "}
+          <Link href="https://dataverse.org/institutions" target="_blank" rel="noopener noreferrer" color="brandOrange.300">
+            your Dataverse installation
           </Link>
-          , switch to one-click authentication if not already enabled, and
-          click <strong>Link OSF Account</strong>. You will be redirected to
-          OSF to authorize DataPipe, then sent back automatically.
+          , or{" "}
+          <Link href={ZENODO_HOST} target="_blank" rel="noopener noreferrer" color="brandOrange.300">
+            Zenodo
+          </Link>
+          .
         </Text>
-        <CollapsibleSection title="Using a personal access token instead (legacy)">
+        <CollapsibleSection title="Already collecting data on OSF?">
           <Text>
-            Go to your DataPipe Account Settings and switch to &quot;Personal
-            access token&quot; mode. Then on OSF, go to your account settings,
-            click the <strong>Personal Access Tokens</strong> tab, and create
-            a new token with the <strong>osf.full_write</strong> scope.
+            {osfStops} OSF is shutting down its projects feature, so DataPipe
+            can no longer create new experiments there. {osfUntil}
           </Text>
           <Text>
-            Copy the token value and paste it into your DataPipe Account
-            Settings. A green checkmark will confirm the token is valid.
+            Data already on OSF is unaffected and stays in your OSF account. To
+            keep collecting past that point, connect one of the providers
+            above, create a new experiment on it, and point your experiment
+            code at the new experiment ID.
           </Text>
         </CollapsibleSection>
       </StepCard>
 
+      <StepCard number={2} title="Connect your storage provider">
+        <Text>
+          Go to your{" "}
+          <Link href="/admin/account" color="brandOrange.300">
+            Account Settings
+          </Link>
+          {" "}and find the <strong>Storage Providers</strong> section. Click{" "}
+          <strong>Connect</strong> next to the provider you chose. A green{" "}
+          <strong>Connected</strong> label confirms it worked.
+        </Text>
+        <Text>
+          <strong>Google Drive</strong> and <strong>Zenodo</strong> hand you
+          to their own sign-in page to authorize DataPipe, then bring you
+          straight back.
+        </Text>
+        <Text>
+          <strong>Dataverse</strong> opens a short form instead. It needs the
+          full address of your institution&apos;s installation — for
+          example, <em>https://dataverse.harvard.edu</em> — and an API token,
+          which you create under the <strong>API Token</strong> tab of your
+          Dataverse account.
+        </Text>
+        <Text color="gray.400" fontSize="sm">
+          You can connect more than one provider, and disconnect any of them
+          from the same screen. Disconnecting stops new data from reaching
+          that provider. It never removes data already stored there.
+        </Text>
+      </StepCard>
+
       <StepCard number={3} title="Create a DataPipe experiment">
         <Text>
-          Click <strong>New Experiment</strong> in the navigation bar. You will
-          need to provide:
+          Click <strong>New Experiment</strong> in the navigation bar. Pick
+          your storage provider at the top of the form and give the experiment
+          a <strong>Title</strong>. The rest of the form changes with the
+          provider:
         </Text>
         <Stack gap={2} pl={4}>
           <Text>
-            <Text as="span" fontWeight="semibold">Title</Text> — a name for
-            your experiment.
+            <Text as="span" fontWeight="semibold">Google Drive</Text> — nothing
+            else is required. To keep the data somewhere specific,
+            click <strong>Choose Drive folder</strong> and pick a parent
+            folder. Otherwise DataPipe creates the folder
+            in <em>My Drive/DataPipe</em>.
           </Text>
           <Text>
-            <Text as="span" fontWeight="semibold">OSF Project ID</Text> — the
-            short code from your OSF project URL. For example, if your project
-            is at <em>osf.io/abcde</em>, the ID is <strong>abcde</strong>.
+            <Text as="span" fontWeight="semibold">Dataverse</Text> — the{" "}
+            <strong>collection alias</strong>, which is the short name from
+            your collection&apos;s URL, plus the author name, contact email,
+            and description that Dataverse requires for every dataset. Subject
+            is optional.
           </Text>
           <Text>
-            <Text as="span" fontWeight="semibold">Data Component Name</Text> — DataPipe
-            will create a new component with this name inside your OSF project
-            to store all data files.
+            <Text as="span" fontWeight="semibold">Zenodo</Text> — the{" "}
+            <strong>creator name</strong> and a <strong>description</strong>{" "}
+            for the deposition. Affiliation is optional.
           </Text>
         </Stack>
         <Text>
-          Click <strong>Create</strong> and you will be taken to the experiment
-          dashboard.
+          Click <strong>Create</strong>. DataPipe makes the folder, dataset,
+          or deposition for you and opens the experiment dashboard, which
+          links straight to it.
         </Text>
       </StepCard>
 
@@ -206,8 +307,8 @@ export default function GettingStarted() {
             specify required fields. This helps prevent malicious submissions.
           </FeatureItem>
           <FeatureItem name="Session limit">
-            — cap the number of data files that can be sent to your OSF
-            project. You can increase this later.
+            — cap how many data files DataPipe will accept. You can raise the
+            limit later.
           </FeatureItem>
           <FeatureItem name="Psych-DS metadata">
             — automatically produce metadata adhering to{" "}
@@ -221,8 +322,9 @@ export default function GettingStarted() {
         </Stack>
         <Callout>
           Only activate the features you need, and only during active data
-          collection. DataPipe creates an open path to your OSF project —
-          validation and session limits reduce the risk of unwanted submissions.
+          collection. DataPipe creates an open path into your storage provider
+          — validation and session limits reduce the risk of unwanted
+          submissions.
         </Callout>
       </StepCard>
 
@@ -236,8 +338,10 @@ export default function GettingStarted() {
           . Otherwise, you can use the DataPipe API directly with fetch requests.
         </Text>
         <Text>
-          Your experiment dashboard has ready-to-use code snippets for both
-          jsPsych and plain JavaScript. Go to{" "}
+          The code is the same whichever storage provider you chose — your
+          experiment sends data to DataPipe, and DataPipe handles the rest.
+          Your experiment dashboard has ready-to-use snippets for both jsPsych
+          and plain JavaScript. Go to{" "}
           <Link href="/admin" color="brandOrange.300">My Experiments</Link>,
           select your experiment, and copy the code from the{" "}
           <strong>Code Samples</strong> panel.
@@ -289,7 +393,7 @@ export default function GettingStarted() {
         <Stack gap={2} pl={4}>
           <Text>
             <Text as="span" fontWeight="semibold">Enable data collection</Text> — for
-            sending text files (JSON, CSV) to OSF.
+            sending text files (JSON, CSV).
           </Text>
           <Text>
             <Text as="span" fontWeight="semibold">Enable base64 data collection</Text> — for
@@ -301,9 +405,26 @@ export default function GettingStarted() {
           </Text>
         </Stack>
         <Text>
-          Run through your experiment once to verify data files appear in
-          your OSF data component. You should see them immediately after
-          completing the experiment.
+          Run through your experiment once to check that the data arrives. The
+          experiment dashboard links straight to your Drive folder, Dataverse
+          dataset, or Zenodo deposition — your file should appear there
+          shortly after you finish.
+        </Text>
+      </StepCard>
+
+      <StepCard number={8} title="When data collection ends">
+        <Text>
+          When your study is finished, <strong>finalize</strong> the
+          experiment from its dashboard. DataPipe merges every remaining data
+          file into a single archive on your storage provider and stops
+          accepting new submissions, which makes the dataset easier to share
+          and cite. Finalizing cannot be undone, so do it only when you are
+          certain no more data is coming.
+        </Text>
+        <Text color="gray.400" fontSize="sm">
+          On Zenodo, finalizing prepares the deposition but does not publish
+          it. Publishing the record, and with it issuing the DOI, stays your
+          decision and happens on Zenodo itself.
         </Text>
       </StepCard>
     </Stack>


### PR DESCRIPTION
Getting Started, the FAQ and the API reference still read as though OSF were the only place data could land. This brings all three in line with the multi-backend product.

## Getting Started

Rebuilt around the choice a researcher now has to make first.

- **Step 1 is provider choice**, comparing Google Drive, Dataverse and Zenodo on what DataPipe creates there, how you connect, and the limit that will eventually matter. Those facts come from each adapter's own `capabilities` / `quotaNote` rather than being restated by hand.
- **No default is recommended.** All three get parallel "choose this if" lines tied to the researcher's situation, per `PRODUCT.md`'s "no persuasion" anti-reference.
- **Steps 2 and 3 follow the real UI** — the Storage Providers section, the OAuth vs. API-token split, and the per-provider fields declared in each adapter's `containerInput`.
- **OSF drops to a collapsible** aimed only at researchers already collecting there, reading its date from `osfSunsetLabel()` so it cannot drift from the banners.
- **New closing step on finalization**, the part of the story Zenodo's 100-file cap implies.

## FAQ

All OSF framing removed. Two answers needed more than a find-and-replace:

- **Who can see my data** now differs per provider (Drive folders, Zenodo drafts, Dataverse datasets), so it walks through each.
- **"What is one-click authentication?"** was an OSF-shaped *question*, not just an OSF-shaped answer. It becomes "How does DataPipe get permission to write to my storage?", answered per provider.
- **New entry** for people arriving with "I collect data on OSF — what happens now?"

Numbered `item-0b` following the existing `2b`/`2c` convention; renumbering would break the `/faq#item-11` deep link from Getting Started.

## API reference

Checking the endpoints against `api-messages.ts` turned up errors beyond naming:

- **Three documented codes are never returned to a client** — `INVALID_METADATA_ERROR`, `OSF_METADATA_UPLOAD_ERROR`, and `METADATA_ERROR` (that last one is only written to the log). Removed.
- **Seven returned codes were missing**, including `EXPERIMENT_FINALIZED` and the `PROVIDER_NOT_CONNECTED` / `PROVIDER_TOKEN_EXPIRED` pair that reaches clients through the token-resolution branch at `api-data.ts:136`.
- **The 202 queued response was undocumented.** A client treating "not 201" as failure would resubmit and store a participant's data twice, so it now has its own row saying explicitly not to retry.
- Added HTTP status per code, and documented the `metadataMessage` field.

The `OSF_`-prefixed code names are kept — they are the wire contract and still what the server sends. A note distinguishes the three that fire for every provider (`OSF_FILE_EXISTS`, `OSF_UPLOAD_ERROR`, `OSF_UPLOAD_EXCEPTION`) from the two that only occur on legacy OSF experiments. Renaming them would be a breaking API change and is a backend decision, not a docs one.

## Notes for review

- Docs-only; no runtime code touched.
- `npm run lint` and `npm run build` both pass.
- Branched from `origin/test` so the diff is only these three files. My local working tree also had an in-progress design pass (`components/account/*`, `components/ui/`, `DESIGN.md`) from separate work — deliberately excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJnHtjEQWtadFwWEZkdKac