### PR TITLE
Logo emit animation: the pipe fires on hover

### DIFF
--- a/components/LogoMark.js
+++ b/components/LogoMark.js
@@ -25,12 +25,18 @@
  *   against both #FFFFFF and dark surfaces (#101A14). Do not theme this
  *   value or otherwise vary it by color mode.
  */
+import { useId } from "react";
+
 export default function LogoMark({
   size = 104,
   color = "currentColor",
   echoColor = "#8BC34A",
   ...props
 }) {
+  // Unique per instance -- the navbar and the landing band both render
+  // this component on the same page, and SVG clipPath ids are global.
+  const clipId = useId();
+
   // Decorative (aria-hidden, no role): the visible wordmark beside the mark
   // carries the name, so the SVG is hidden from assistive tech rather than
   // announced twice.
@@ -45,28 +51,40 @@ export default function LogoMark({
       {...props}
     >
       <rect x="10" y="12" width="10" height="80" rx="1" fill={color} />
-      {/* The dp-logo-chevron-* classes are animation hooks only (see
-          globals.css "logo emit"): a wrapping .dp-logo-link animates the
-          chevrons out of the bar on hover/focus. Purely additive -- the
-          mark renders identically wherever those rules are absent. */}
-      <path
-        className="dp-logo-chevron-1"
-        d="M32 26 L62 52 L32 78"
-        fill="none"
-        stroke={color}
-        strokeWidth="10"
-        strokeLinecap="square"
-        strokeLinejoin="round"
-      />
-      <path
-        className="dp-logo-chevron-2"
-        d="M62 26 L92 52 L62 78"
-        fill="none"
-        stroke={echoColor}
-        strokeWidth="10"
-        strokeLinecap="square"
-        strokeLinejoin="round"
-      />
+      {/* Animation infrastructure, inert at rest. The clip window hides
+          everything left of x=22 (just past the bar's right edge at 20),
+          so when globals.css's "logo emit" slides the chevrons in from
+          translateX(-76px) they genuinely emerge from behind the bar
+          rather than fading in place. At rest both chevrons sit fully
+          inside the window (chevron 1's visual left edge is x~27), so the
+          mark renders identically wherever the CSS rules are absent. The
+          dp-logo-chevron-* classes are the CSS hooks; the clip is applied
+          to the group, not the paths, so it stays fixed while they move. */}
+      <defs>
+        <clipPath id={clipId}>
+          <rect x="22" y="0" width="82" height="104" />
+        </clipPath>
+      </defs>
+      <g clipPath={`url(#${clipId})`}>
+        <path
+          className="dp-logo-chevron-1"
+          d="M32 26 L62 52 L32 78"
+          fill="none"
+          stroke={color}
+          strokeWidth="10"
+          strokeLinecap="square"
+          strokeLinejoin="round"
+        />
+        <path
+          className="dp-logo-chevron-2"
+          d="M62 26 L92 52 L62 78"
+          fill="none"
+          stroke={echoColor}
+          strokeWidth="10"
+          strokeLinecap="square"
+          strokeLinejoin="round"
+        />
+      </g>
     </svg>
   );
 }

--- a/components/LogoMark.js
+++ b/components/LogoMark.js
@@ -45,7 +45,12 @@ export default function LogoMark({
       {...props}
     >
       <rect x="10" y="12" width="10" height="80" rx="1" fill={color} />
+      {/* The dp-logo-chevron-* classes are animation hooks only (see
+          globals.css "logo emit"): a wrapping .dp-logo-link animates the
+          chevrons out of the bar on hover/focus. Purely additive -- the
+          mark renders identically wherever those rules are absent. */}
       <path
+        className="dp-logo-chevron-1"
         d="M32 26 L62 52 L32 78"
         fill="none"
         stroke={color}
@@ -54,6 +59,7 @@ export default function LogoMark({
         strokeLinejoin="round"
       />
       <path
+        className="dp-logo-chevron-2"
         d="M62 26 L92 52 L62 78"
         fill="none"
         stroke={echoColor}

--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -68,7 +68,7 @@ export default function Navbar() {
         color={"fg"}
       >
         <HStack gap={4} alignItems={"center"} pe={"2"}>
-          <NextLink href="/">
+          <NextLink href="/" className="dp-logo-link">
             <Box display={"flex"} alignItems={"center"} gap={2.5} pr={10}>
               {/* The mark and wordmark render in the logo's own colors, not
                   the page `fg` -- DESIGN.md §1 "Logo" / "The navbar is

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -77,3 +77,49 @@ pre::-webkit-scrollbar-thumb:hover {
   text-align: center;
   font-size: 1rem;
 }
+
+/* Logo "emit": on hover or keyboard focus of the navbar lockup, the |>
+   mark's chevrons re-fire out of the bar -- the pipe passing data, which
+   is the product. Chevron geometry lives on LogoMark's 104-unit grid and
+   CSS px on SVG children map to user units (transform-box: view-box), so
+   -22px pulls each chevron back to the bar's face at any rendered size.
+   DESIGN.md §7: 200ms, ease-out only; the 70ms stagger keeps the total
+   under 300ms. `backwards` fill hides the delayed echo chevron until its
+   turn. Hover-out simply removes the animation -- instant rest state, and
+   re-hovering replays it. */
+@keyframes dp-logo-emit {
+  from {
+    transform: translateX(-22px);
+    opacity: 0;
+  }
+  to {
+    transform: none;
+    opacity: 1;
+  }
+}
+
+.dp-logo-chevron-1,
+.dp-logo-chevron-2 {
+  transform-box: view-box;
+}
+
+.dp-logo-link:hover .dp-logo-chevron-1,
+.dp-logo-link:focus-visible .dp-logo-chevron-1 {
+  animation: dp-logo-emit 200ms cubic-bezier(0, 0, 0.2, 1) backwards;
+}
+
+.dp-logo-link:hover .dp-logo-chevron-2,
+.dp-logo-link:focus-visible .dp-logo-chevron-2 {
+  animation: dp-logo-emit 200ms cubic-bezier(0, 0, 0.2, 1) 70ms backwards;
+}
+
+/* DESIGN.md §7: every animation needs a reduced-motion story. The mark
+   simply stays at rest -- the hover state loses nothing functional. */
+@media (prefers-reduced-motion: reduce) {
+  .dp-logo-link:hover .dp-logo-chevron-1,
+  .dp-logo-link:focus-visible .dp-logo-chevron-1,
+  .dp-logo-link:hover .dp-logo-chevron-2,
+  .dp-logo-link:focus-visible .dp-logo-chevron-2 {
+    animation: none;
+  }
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -83,18 +83,27 @@ pre::-webkit-scrollbar-thumb:hover {
    is the product. Chevron geometry lives on LogoMark's 104-unit grid and
    CSS px on SVG children map to user units (transform-box: view-box), so
    -22px pulls each chevron back to the bar's face at any rendered size.
-   DESIGN.md §7: 200ms, ease-out only; the 70ms stagger keeps the total
-   under 300ms. `backwards` fill hides the delayed echo chevron until its
-   turn. Hover-out simply removes the animation -- instant rest state, and
-   re-hovering replays it. */
+   Pure motion, no fade: LogoMark clips the chevron group to the region
+   right of the bar, so at translateX(-88px) both chevrons are genuinely
+   hidden "inside" the pipe and slide out through the clip edge. -88 (not
+   the minimal -76) buys the green echo's apex 9 grid units of margin
+   past the clip edge -- at -76 it sat 1 unit in, and subpixel
+   antialiasing leaked a green sliver on the first frame. Both travel the
+   same 88 units over the same 450ms (ease-out) at a 150ms
+   phase offset, so the trailing chevron never catches the leader. Order
+   is owner-ratified: the green echo fires FIRST (it lives furthest from
+   the bar) and the dark chevron comes out behind it.
+   Timing is owner-ratified, deliberately slower than DESIGN.md §7's
+   150-200ms ladder (that ladder is for state feedback; at 200ms this
+   read as a flicker). `backwards` fill holds the delayed echo hidden
+   until its turn. Hover-out removes the animation -- instant rest state
+   -- and re-hovering replays it. */
 @keyframes dp-logo-emit {
   from {
-    transform: translateX(-22px);
-    opacity: 0;
+    transform: translateX(-88px);
   }
   to {
     transform: none;
-    opacity: 1;
   }
 }
 
@@ -103,14 +112,21 @@ pre::-webkit-scrollbar-thumb:hover {
   transform-box: view-box;
 }
 
-.dp-logo-link:hover .dp-logo-chevron-1,
-.dp-logo-link:focus-visible .dp-logo-chevron-1 {
-  animation: dp-logo-emit 200ms cubic-bezier(0, 0, 0.2, 1) backwards;
-}
-
+/* Both chevrons carry a delay + `backwards` fill: on hover they vanish
+   behind the bar INSTANTLY (fill applies the from-state through the
+   delay), the pipe holds visibly empty for 120ms, then the green fires
+   and the dark follows 150ms later. Without the green's hold, the
+   decelerate curve covers ~half its travel in the first ~50ms and the
+   green never perceptibly disappears -- it read as snapping its left
+   edge to the pipe rather than emerging from inside it. */
 .dp-logo-link:hover .dp-logo-chevron-2,
 .dp-logo-link:focus-visible .dp-logo-chevron-2 {
-  animation: dp-logo-emit 200ms cubic-bezier(0, 0, 0.2, 1) 70ms backwards;
+  animation: dp-logo-emit 450ms cubic-bezier(0, 0, 0.2, 1) 120ms backwards;
+}
+
+.dp-logo-link:hover .dp-logo-chevron-1,
+.dp-logo-link:focus-visible .dp-logo-chevron-1 {
+  animation: dp-logo-emit 450ms cubic-bezier(0, 0, 0.2, 1) 270ms backwards;
 }
 
 /* DESIGN.md §7: every animation needs a reduced-motion story. The mark


### PR DESCRIPTION
## What this is

The two commits that landed on `account-settings-design` after #179 was merged — the navbar logo's hover animation, cherry-picked onto a clean branch off `test`.

Hovering (or keyboard-focusing) the navbar lockup plays the mark's own story: both chevrons vanish behind the bar, the pipe holds visibly empty for 120ms, then the green echo fires out and the dark chevron trails 150ms behind — pure motion through a clip window, no fades. ~720ms total, owner-tuned across three rounds of feedback (clip instead of opacity, deeper start position so the green begins fully hidden, and the empty-pipe hold that makes the emission legible).

Details:
- The clip window and class hooks in `LogoMark` are inert at rest — the mark renders identically anywhere the CSS is absent (the landing band's decorative mark doesn't animate).
- `focus-visible` triggers the same moment for keyboard users.
- `prefers-reduced-motion` keeps the mark at rest entirely.

Frontend suite: 195/195 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)