### PR TITLE
Ship light mode: last pages converted, brandTeal retired, toggle on

### DIFF
--- a/lib/feature-flags.js
+++ b/lib/feature-flags.js
@@ -4,19 +4,24 @@
 // diff, not a refactor.
 
 // Controls the light/dark/system color-mode control (DESIGN.md §2 "Mode
-// strategy"). Flipping this to `true`:
-//   - renders the "Theme" radio group (System / Light / Dark) in the
+// strategy").
+//
+// Precondition met as of this commit: every page and component, including
+// the final three (pages/getting-started.js, pages/faq.js,
+// pages/api-docs.js), has been converted from raw color literals to
+// semantic tokens (DESIGN.md §2 "Migration phases", Phase 2 complete). The
+// deprecated brandTeal alias in lib/theme.js is deleted -- there is nothing
+// left un-renamed for a light-mode visitor to land on.
+//
+// With this flag `true`:
+//   - the "Theme" radio group (System / Light / Dark) renders in the
 //     navbar Account menu (signed-in) and mobile/overflow menu
 //     (signed-out), see components/ThemeSelect.js
-//   - enables next-themes' `enableSystem` in pages/_app.js, so the OS
+//   - next-themes' `enableSystem` is enabled in pages/_app.js, so the OS
 //     preference is honored
-//   - changes the default theme from the hard-coded "dark" to "system"
+//   - the default theme changes from the hard-coded "dark" to "system"
 //
-// Precondition: pages/getting-started.js, pages/faq.js and
-// pages/api-docs.js must be converted to semantic tokens first (DESIGN.md
-// §2 "Migration phases", Phase 2 items #3, #10). Until then those pages
-// still carry literal `color="white"` / `bg="black"` etc., so a
-// light-preferring visitor who reaches them via `system` or an explicit
-// `light` selection would get a half-converted, unreadable page --
-// "Light mode must never render a half-converted page."
-export const COLOR_MODE_TOGGLE = false;
+// Rollback lever: if a conversion gap surfaces post-ship, set this back to
+// `false`. That reverts to the forced-dark default and hides the toggle
+// without requiring any other code change.
+export const COLOR_MODE_TOGGLE = true;

--- a/lib/theme.js
+++ b/lib/theme.js
@@ -46,34 +46,6 @@ const config = defineConfig({
           800: { value: "#2E7D32" },
           900: { value: "#1B5E20" },
         },
-        // DEPRECATED ALIAS -- brandTeal is retired as a color.
-        //
-        // The old primary #13b24b measured 1.83:1 against the logo green
-        // #2E7D32 (close enough to read as a mistake rather than a pairing)
-        // and 2.80:1 on white (it could never be light-mode text). The green
-        // fixes both: #2E7D32 is 5.13:1 on white and 4.77:1 on the planned
-        // #F5F7F8 light page.
-        //
-        // Every step here now resolves to the brandGreen step of the same
-        // index, so `brandTeal.400` and `brandGreen.400` paint the identical
-        // pixel. This exists purely so the rename can land file by file
-        // without a single broken reference in between -- components/Navbar.js
-        // and three in-progress pages (index, getting-started, api-docs) are
-        // owned by other work right now and still say brandTeal. Delete this
-        // block, and the semantic brandTeal block below, once those are
-        // renamed; nothing should be added to it.
-        brandTeal: {
-          50: { value: "{colors.brandGreen.50}" },
-          100: { value: "{colors.brandGreen.100}" },
-          200: { value: "{colors.brandGreen.200}" },
-          300: { value: "{colors.brandGreen.300}" },
-          400: { value: "{colors.brandGreen.400}" },
-          500: { value: "{colors.brandGreen.500}" },
-          600: { value: "{colors.brandGreen.600}" },
-          700: { value: "{colors.brandGreen.700}" },
-          800: { value: "{colors.brandGreen.800}" },
-          900: { value: "{colors.brandGreen.900}" },
-        },
         brandLime: {
           50: { value: "#E0F2E8" },
           100: { value: "#B3DFC8" },
@@ -324,23 +296,6 @@ const config = defineConfig({
         //     this file's pre-existing 800/700 hover/active steps, and light
         //     follows the same one-step-per-slot pattern as `subtle` (50).
         brandGreen: {
-          contrast: { value: { _light: "white", _dark: "{colors.greyBackground}" } },
-          fg: { value: { _light: "{colors.brandGreen.800}", _dark: "{colors.brandGreen.300}" } },
-          subtle: { value: { _light: "{colors.brandGreen.50}", _dark: "{colors.brandGreen.900}" } },
-          muted: { value: { _light: "{colors.brandGreen.100}", _dark: "{colors.brandGreen.800}" } },
-          emphasized: { value: { _light: "{colors.brandGreen.200}", _dark: "{colors.brandGreen.700}" } },
-          solid: { value: { _light: "{colors.brandGreen.800}", _dark: "{colors.brandGreen.500}" } },
-          focusRing: { value: { _light: "{colors.brandGreen.700}", _dark: "{colors.brandGreen.400}" } },
-          border: { value: { _light: "{colors.brandGreen.700}", _dark: "{colors.brandGreen.400}" } },
-        },
-        // DEPRECATED ALIAS -- see the brandTeal ramp above. Every slot mirrors
-        // brandGreen's new light/dark pair exactly, so `colorPalette="brandTeal"`
-        // renders as `colorPalette="brandGreen"` down to the pixel, in both
-        // modes. Transitional only: it exists so components/Navbar.js and the
-        // three in-progress pages can keep saying brandTeal while they are
-        // owned elsewhere, and it dies with them once every reference is
-        // renamed.
-        brandTeal: {
           contrast: { value: { _light: "white", _dark: "{colors.greyBackground}" } },
           fg: { value: { _light: "{colors.brandGreen.800}", _dark: "{colors.brandGreen.300}" } },
           subtle: { value: { _light: "{colors.brandGreen.50}", _dark: "{colors.brandGreen.900}" } },

--- a/pages/api-docs.js
+++ b/pages/api-docs.js
@@ -32,9 +32,9 @@ function ParamTable({ children }) {
     <Table.Root variant="outline">
       <Table.Header>
         <Table.Row>
-          <Table.ColumnHeader color="white">Field</Table.ColumnHeader>
-          <Table.ColumnHeader color="white">Type</Table.ColumnHeader>
-          <Table.ColumnHeader color="white">Description</Table.ColumnHeader>
+          <Table.ColumnHeader color="fg">Field</Table.ColumnHeader>
+          <Table.ColumnHeader color="fg">Type</Table.ColumnHeader>
+          <Table.ColumnHeader color="fg">Description</Table.ColumnHeader>
         </Table.Row>
       </Table.Header>
       <Table.Body>
@@ -48,7 +48,7 @@ function Param({ name, type, children }) {
   return (
     <Table.Row>
       <Table.Cell><Code>{name}</Code></Table.Cell>
-      <Table.Cell><Text fontSize="sm" color="gray.400">{type}</Text></Table.Cell>
+      <Table.Cell><Text fontSize="sm" color="fg.muted">{type}</Text></Table.Cell>
       <Table.Cell>{children}</Table.Cell>
     </Table.Row>
   );
@@ -58,7 +58,7 @@ function ErrorRow({ code, status, children }) {
   return (
     <Table.Row>
       <Table.Cell><Code>{code}</Code></Table.Cell>
-      <Table.Cell><Text fontSize="sm" color="gray.400">{status}</Text></Table.Cell>
+      <Table.Cell><Text fontSize="sm" color="fg.muted">{status}</Text></Table.Cell>
       <Table.Cell>{children}</Table.Cell>
     </Table.Row>
   );
@@ -111,7 +111,7 @@ export default function ApiDocs() {
           </Param>
         </ParamTable>
         <Box>
-          <Text fontSize="sm" color="gray.400" mb={2}>Example request body</Text>
+          <Text fontSize="sm" color="fg.muted" mb={2}>Example request body</Text>
           <CodeBlock>
             {`{
   "experimentID": "abc123",
@@ -162,7 +162,7 @@ export default function ApiDocs() {
           </Param>
         </ParamTable>
         <Box>
-          <Text fontSize="sm" color="gray.400" mb={2}>Example response</Text>
+          <Text fontSize="sm" color="fg.muted" mb={2}>Example response</Text>
           <CodeBlock>
             {`{
   "condition": 2
@@ -187,8 +187,8 @@ export default function ApiDocs() {
         <Table.Root variant="outline">
           <Table.Header>
             <Table.Row>
-              <Table.ColumnHeader color="white">Status</Table.ColumnHeader>
-              <Table.ColumnHeader color="white">Meaning</Table.ColumnHeader>
+              <Table.ColumnHeader color="fg">Status</Table.ColumnHeader>
+              <Table.ColumnHeader color="fg">Meaning</Table.ColumnHeader>
             </Table.Row>
           </Table.Header>
           <Table.Body>
@@ -230,7 +230,7 @@ export default function ApiDocs() {
         <Heading as="h3" size="sm" mt={4}>
           Error codes
         </Heading>
-        <Text fontSize="sm" color="gray.400">
+        <Text fontSize="sm" color="fg.muted">
           Codes beginning <Code>OSF_</Code> are historical names kept for
           backward compatibility. <Code>OSF_FILE_EXISTS</Code>,{" "}
           <Code>OSF_UPLOAD_ERROR</Code> and <Code>OSF_UPLOAD_EXCEPTION</Code>{" "}
@@ -241,9 +241,9 @@ export default function ApiDocs() {
         <Table.Root variant="outline">
           <Table.Header>
             <Table.Row>
-              <Table.ColumnHeader color="white">Error code</Table.ColumnHeader>
-              <Table.ColumnHeader color="white">Status</Table.ColumnHeader>
-              <Table.ColumnHeader color="white">Meaning</Table.ColumnHeader>
+              <Table.ColumnHeader color="fg">Error code</Table.ColumnHeader>
+              <Table.ColumnHeader color="fg">Status</Table.ColumnHeader>
+              <Table.ColumnHeader color="fg">Meaning</Table.ColumnHeader>
             </Table.Row>
           </Table.Header>
           <Table.Body>

--- a/pages/faq.js
+++ b/pages/faq.js
@@ -375,7 +375,11 @@ export default function FAQ() {
             If you use DataPipe to collect data, please cite the following paper:
           </Text>
           <Text
-            bg="gray.800"
+            // Recessed prose citation block, not code -- bg.subtle (DESIGN.md
+            // §1: "Recessed: code blocks, table headers"). No color prop
+            // needed: body text inherits the page's neutral `fg`, which
+            // clears 4.5:1 on bg.subtle in both modes.
+            bg="bg.subtle"
             p={4}
             borderRadius="md"
             fontSize="sm"

--- a/pages/getting-started.js
+++ b/pages/getting-started.js
@@ -25,8 +25,8 @@ function StepNumber({ number }) {
       w="36px"
       h="36px"
       borderRadius="full"
-      bg="brandTeal.600"
-      color="white"
+      bg="brandGreen.solid"
+      color="brandGreen.contrast"
       display="flex"
       alignItems="center"
       justifyContent="center"
@@ -41,7 +41,14 @@ function StepNumber({ number }) {
 function StepCard({ number, title, children }) {
   return (
     <Box
-      bg="black"
+      // Was bg="black" -- a Card per DESIGN.md §1's own bucket ("Cards,
+      // dialogs, menus" -> bg.panel). Dark's bg.panel is #1C1F22, identical
+      // to the page body, so the border is now the only edge (per DESIGN.md:
+      // "panels must carry a border" -- page<->panel separation is 1.07:1
+      // by design in both modes).
+      bg="bg.panel"
+      borderWidth="1px"
+      borderColor="border"
       borderRadius={12}
       p={[4, 6]}
       w="100%"
@@ -62,9 +69,13 @@ function StepCard({ number, title, children }) {
 function Callout({ children }) {
   return (
     <Box
-      bg="brandTeal.900"
+      // Tinted callout: brandGreen.subtle + brandGreen.border. Text below has
+      // no explicit color, so it inherits the page's neutral `fg` -- exactly
+      // the caveat in DESIGN.md §1 ("body text on brandGreen.subtle must be
+      // brandGreen.50 or neutral fg, never brandGreen.300").
+      bg="brandGreen.subtle"
       border="1px solid"
-      borderColor="brandTeal.700"
+      borderColor="brandGreen.border"
       borderRadius={8}
       px={4}
       py={3}
@@ -84,17 +95,19 @@ function CollapsibleSection({ title, children }) {
       <Collapsible.Trigger asChild>
         <Button
           variant="ghost"
-          color="gray.400"
+          color="fg.muted"
           size="sm"
           px={0}
-          _hover={{ color: "white", bg: "transparent" }}
+          _hover={{ color: "fg", bg: "transparent" }}
         >
           {open ? <ChevronDown size={16} /> : <ChevronRight size={16} />}
           {title}
         </Button>
       </Collapsible.Trigger>
       <Collapsible.Content>
-        <Stack gap={3} pt={2} pl={4} borderLeft="1px solid" borderColor="gray.700">
+        {/* Decorative hairline inside an already-grouped (collapsed)
+            region, not the section's own boundary -- border.subtle. */}
+        <Stack gap={3} pt={2} pl={4} borderLeft="1px solid" borderColor="border.subtle">
           {children}
         </Stack>
       </Collapsible.Content>
@@ -106,7 +119,7 @@ function FeatureItem({ name, children }) {
   return (
     <Box>
       <Text>
-        <Text as="span" fontWeight="semibold" color="brandOrange.300">{name}</Text>
+        <Text as="span" fontWeight="semibold" color="brandOrange.fg">{name}</Text>
         {" "}{children}
       </Text>
     </Box>
@@ -121,21 +134,24 @@ function FeatureItem({ name, children }) {
 // table so it stays readable on a phone.
 function ProviderOption({ name, summary, landsIn, connect, limits }) {
   return (
-    <Box borderWidth="1px" borderColor="gray.700" borderRadius={8} p={4}>
-      <Text fontWeight="semibold" color="brandOrange.300" mb={1}>
+    // Sole visual boundary of the row (WCAG 1.4.11 "panel edge"), so this
+    // uses `border` (gray.500, 4.50 light / 3.43 dark) rather than
+    // `border.subtle`, which DESIGN.md bans as a lone grouping device.
+    <Box borderWidth="1px" borderColor="border" borderRadius={8} p={4}>
+      <Text fontWeight="semibold" color="brandOrange.fg" mb={1}>
         {name}
       </Text>
       <Text fontSize="sm" mb={3}>
         {summary}
       </Text>
       <Stack gap={1}>
-        <Text fontSize="sm" color="gray.400">
+        <Text fontSize="sm" color="fg.muted">
           <Text as="span" fontWeight="semibold">Data lands in:</Text> {landsIn}
         </Text>
-        <Text fontSize="sm" color="gray.400">
+        <Text fontSize="sm" color="fg.muted">
           <Text as="span" fontWeight="semibold">Connect with:</Text> {connect}
         </Text>
-        <Text fontSize="sm" color="gray.400">
+        <Text fontSize="sm" color="fg.muted">
           <Text as="span" fontWeight="semibold">Limits:</Text> {limits}
         </Text>
       </Stack>
@@ -161,7 +177,7 @@ export default function GettingStarted() {
         <Heading as="h1" size="2xl">
           Getting Started
         </Heading>
-        <Text color="gray.400" fontSize="lg">
+        <Text color="fg.muted" fontSize="lg">
           DataPipe sends data from your experiment straight to storage you
           control — Google Drive, Dataverse, or Zenodo. This guide sets up one
           experiment end to end, from choosing a provider to your first test
@@ -202,15 +218,15 @@ export default function GettingStarted() {
         </Stack>
         <Text>
           You need an account with whichever provider you choose:{" "}
-          <Link href="https://drive.google.com" target="_blank" rel="noopener noreferrer" color="brandOrange.300">
+          <Link href="https://drive.google.com" target="_blank" rel="noopener noreferrer" color="brandOrange.fg">
             Google Drive
           </Link>
           ,{" "}
-          <Link href="https://dataverse.org/institutions" target="_blank" rel="noopener noreferrer" color="brandOrange.300">
+          <Link href="https://dataverse.org/institutions" target="_blank" rel="noopener noreferrer" color="brandOrange.fg">
             your Dataverse installation
           </Link>
           , or{" "}
-          <Link href={ZENODO_HOST} target="_blank" rel="noopener noreferrer" color="brandOrange.300">
+          <Link href={ZENODO_HOST} target="_blank" rel="noopener noreferrer" color="brandOrange.fg">
             Zenodo
           </Link>
           .
@@ -232,7 +248,7 @@ export default function GettingStarted() {
       <StepCard number={2} title="Connect your storage provider">
         <Text>
           Go to your{" "}
-          <Link href="/admin/account" color="brandOrange.300">
+          <Link href="/admin/account" color="brandOrange.fg">
             Account Settings
           </Link>
           {" "}and find the <strong>Storage Providers</strong> section. Click{" "}
@@ -251,7 +267,7 @@ export default function GettingStarted() {
           which you create under the <strong>API Token</strong> tab of your
           Dataverse account.
         </Text>
-        <Text color="gray.400" fontSize="sm">
+        <Text color="fg.muted" fontSize="sm">
           You can connect more than one provider, and disconnect any of them
           from the same screen. Disconnecting stops new data from reaching
           that provider. It never removes data already stored there.
@@ -312,11 +328,11 @@ export default function GettingStarted() {
           </FeatureItem>
           <FeatureItem name="Psych-DS metadata">
             — automatically produce metadata adhering to{" "}
-            <Link href="https://psychds-docs.readthedocs.io/en/latest/" target="_blank" rel="noopener noreferrer" color="brandOrange.300">
+            <Link href="https://psychds-docs.readthedocs.io/en/latest/" target="_blank" rel="noopener noreferrer" color="brandOrange.fg">
               Psych-DS
             </Link>
             , updated after each session. See{" "}
-            <Link href="/faq#item-11" color="brandOrange.300">how it works</Link>
+            <Link href="/faq#item-11" color="brandOrange.fg">how it works</Link>
             {" "}in the FAQ.
           </FeatureItem>
         </Stack>
@@ -332,7 +348,7 @@ export default function GettingStarted() {
         <Text>
           Add code to send data from your experiment to DataPipe. If you use
           jsPsych, the easiest option is the{" "}
-          <Link href="https://github.com/jspsych/jspsych-contrib/tree/main/packages/plugin-pipe" target="_blank" rel="noopener noreferrer" color="brandOrange.300">
+          <Link href="https://github.com/jspsych/jspsych-contrib/tree/main/packages/plugin-pipe" target="_blank" rel="noopener noreferrer" color="brandOrange.fg">
             jsPsychPipe plugin
           </Link>
           . Otherwise, you can use the DataPipe API directly with fetch requests.
@@ -342,7 +358,7 @@ export default function GettingStarted() {
           experiment sends data to DataPipe, and DataPipe handles the rest.
           Your experiment dashboard has ready-to-use snippets for both jsPsych
           and plain JavaScript. Go to{" "}
-          <Link href="/admin" color="brandOrange.300">My Experiments</Link>,
+          <Link href="/admin" color="brandOrange.fg">My Experiments</Link>,
           select your experiment, and copy the code from the{" "}
           <strong>Code Samples</strong> panel.
         </Text>
@@ -356,11 +372,11 @@ export default function GettingStarted() {
         <CollapsibleSection title="GitHub Pages setup instructions">
           <Text>
             1. Create a GitHub account at{" "}
-            <Link href="https://www.github.com" target="_blank" rel="noopener noreferrer" color="brandOrange.300">
+            <Link href="https://www.github.com" target="_blank" rel="noopener noreferrer" color="brandOrange.fg">
               github.com
             </Link>
             {" "}and{" "}
-            <Link href="https://www.github.com/new" target="_blank" rel="noopener noreferrer" color="brandOrange.300">
+            <Link href="https://www.github.com/new" target="_blank" rel="noopener noreferrer" color="brandOrange.fg">
               create a new repository
             </Link>
             . The repo name becomes part of your experiment URL, so avoid
@@ -421,7 +437,7 @@ export default function GettingStarted() {
           and cite. Finalizing cannot be undone, so do it only when you are
           certain no more data is coming.
         </Text>
-        <Text color="gray.400" fontSize="sm">
+        <Text color="fg.muted" fontSize="sm">
           On Zenodo, finalizing prepares the deposition but does not publish
           it. Publishing the record, and with it issuing the DOI, stays your
           decision and happens on Zenodo itself.


### PR DESCRIPTION
## What this is

The final gate on the light/dark migration, now open. #179 converted every surface except the three docs pages (then still in-flight); their rewrite has since landed on `test`, so this PR finishes the job:

- **`getting-started` / `faq` / `api-docs` converted to semantic tokens** — a color-only pass that preserves the recent content rewrite verbatim. Step cards become bordered `bg.panel` cards, the callout rides `brandGreen.subtle`, links move from raw `brandOrange.300` (which would wash out on a white page) to the computed `brandOrange.fg` slot.
- **`brandTeal` deleted from the theme** — zero live references remained (grep-verified); the transitional alias has done its job.
- **`COLOR_MODE_TOGGLE` → `true`** — the System/Light/Dark control renders in the navbar Account menu and the mobile/overflow menu, the OS preference is honored, and the default theme becomes `system`. Flipping the flag back to `false` is the one-line rollback.

## What merging this does

Researchers whose OS prefers light get the light theme on first visit. Every page renders from the same audited token table (DESIGN.md §1) with computed WCAG AA ratios in both modes. Dark-preferring users and everyone with a stored preference see no change.

## Testing

Frontend suites green (189/189 outside the landing suite, which is being reworked on a separate branch). All routes verified 200 in both modes; the next-themes bootstrap script confirmed carrying `defaultTheme="system"`, `enableSystem=true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)