### PR TITLE
Layout pass: structural navbar gap, footer edge, spacing ladder sweep

### DIFF
--- a/components/Footer.js
+++ b/components/Footer.js
@@ -16,16 +16,33 @@ export default function Footer() {
     // DESIGN.md §1: the footer is the app's second neutral layer, so it
     // moves to `bg.subtle` rather than matching the page (`bg`) -- that
     // reading survives the light/dark split instead of collapsing into it.
-    <Box as="footer" bg="bg.subtle" color="fg.muted">
-      <Container as={Stack} maxW={"6xl"} py={10}>
+    // The boundary belongs on the band's own top edge, not 40px inside it.
+    // The `borderTopWidth` that used to sit on the inner Stack was added when
+    // the footer shared the page fill and the rule WAS the boundary; once the
+    // band arrived it became a second, lower edge with nothing above it -- a
+    // 4.5:1 gray rule floating in the middle of the footer.
+    //
+    // It is replaced rather than simply removed: bg.subtle against bg measures
+    // 1.077:1 light / 1.067:1 dark, the same separation DESIGN.md §1 already
+    // declares too weak to define an edge on its own ("panels must carry a
+    // border, never rely on the fill alone"). `border.subtle` (1.38:1 vs bg
+    // light, 1.68:1 dark) lands exactly ON the fill transition, so it reads as
+    // the band's edge reinforcing the color change instead of as a stray rule.
+    <Box
+      as="footer"
+      bg="bg.subtle"
+      color="fg.muted"
+      borderTopWidth="1px"
+      borderColor="border.subtle"
+    >
+      {/* 1100px, not 6xl (1152px): DESIGN.md §4's dashboard/marketing measure,
+          so the footer row lines up with the content column above it. */}
+      <Container as={Stack} maxW="1100px" py={{ base: 8, md: 12 }}>
         <Stack
           direction={["column", "row"]}
           justifyContent={["flex-start", "space-between"]}
-          alignItems={["flex-end", "center"]}
-          gap={[4, 1]}
-          borderTopWidth={1}
-          borderColor="border"
-          pt={3}
+          alignItems={["flex-start", "center"]}
+          gap={[6, 6]}
           fontSize={"sm"}
         >
           <Text>

--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -67,9 +67,17 @@ export default function Navbar() {
         w={"100%"}
         color={"fg"}
       >
-        <HStack gap={4} alignItems={"center"} pe={"2"}>
+        {/* The 48px that separates the wordmark from the first nav link is
+            now a `gap` on this row. It used to be `pr={10}` on the logo's own
+            Box, which is inside the <NextLink> -- so 40px of empty nav bar
+            was part of the home link's click target. Gap owns sibling
+            spacing; padding owns hit area. */}
+        <HStack gap={{ base: 4, md: 12 }} alignItems={"center"}>
           <NextLink href="/" className="dp-logo-link">
-            <Box display={"flex"} alignItems={"center"} gap={2.5} pr={10}>
+            {/* 2.5 is off the §4 ladder and stays: this is the optical gap
+                inside the logo lockup (mark to wordmark), not layout
+                spacing between components. */}
+            <Box display={"flex"} alignItems={"center"} gap={2.5}>
               {/* The mark and wordmark render in the logo's own colors, not
                   the page `fg` -- DESIGN.md §1 "Logo" / "The navbar is
                   mode-aware": `logo.mark` resolves #2E7D32 light / #F2F5F1
@@ -111,7 +119,13 @@ export default function Navbar() {
             )}
           </HStack>
         </HStack>
-        <HStack display={{ base: "none", md: "flex" }} gap={8}>
+        {/* gap={4}, not gap={8} plus an extra mr={4} on the first button.
+            The account cluster is ONE group (Sign In + Sign Up, or New
+            Experiment + Account); the nav links to its left are separate
+            destinations at gap={8}. Tighter inside the group than between
+            groups is the grouping cue -- 48px between two halves of a
+            button pair was reading as two unrelated controls. */}
+        <HStack display={{ base: "none", md: "flex" }} gap={4}>
           {!showUser && (
             <>
               <Button
@@ -119,7 +133,6 @@ export default function Navbar() {
                 variant={"ghost"}
                 color="fg"
                 size={"sm"}
-                mr={4}
                 _hover={{ bg: "bg.muted" }}
               >
                 <NextLink href="/signin">Sign In</NextLink>
@@ -155,6 +168,11 @@ export default function Navbar() {
                     Account
                   </Button>
                 </Menu.Trigger>
+                {/* Menu items are py="3" throughout both menus (here and in
+                    the mobile menu below): 12px + the ~20px line box is a
+                    44px row. At py="2" they were 36px, and on the mobile
+                    menu -- where every route on the site is a menu item --
+                    that is nine crowded targets in a column. */}
                 <Menu.Positioner>
                   <Menu.Content bg="bg.panel" borderWidth="1px" borderColor="border" p="2">
                     {COLOR_MODE_TOGGLE && (
@@ -166,7 +184,7 @@ export default function Navbar() {
                     <Menu.Item
                       value="settings"
                       color="fg"
-                      py="2"
+                      py="3"
                       px="3"
                       _hover={{ bg: "bg.muted" }}
                       asChild
@@ -177,7 +195,7 @@ export default function Navbar() {
                     <Menu.Item
                       value="signout"
                       color="fg"
-                      py="2"
+                      py="3"
                       px="3"
                       _hover={{ bg: "bg.muted" }}
                       onClick={() => auth.signOut()}
@@ -193,10 +211,13 @@ export default function Navbar() {
         <HStack display={{ base: "flex", md: "none" }} gap={8}>
           <Menu.Root>
             <Menu.Trigger asChild>
+              {/* `minW={0}` collapsed the only navigation control on mobile
+                  to its icon box. 11 = 44px, the minimum touch target. */}
               <IconButton
                 color="fg"
                 cursor={"pointer"}
-                minW={0}
+                minW={"11"}
+                minH={"11"}
                 variant="ghost"
                 aria-label="Menu"
                 _hover={{ bg: "bg.muted" }}
@@ -209,17 +230,17 @@ export default function Navbar() {
                 <Menu.Item
                   value="getting-started"
                   color="fg"
-                  py="2"
+                  py="3"
                   px="3"
                   _hover={{ bg: "bg.muted" }}
                   asChild
                 >
                   <NextLink href="/getting-started">Getting Started</NextLink>
                 </Menu.Item>
-                <Menu.Item value="api-docs" color="fg" py="2" px="3" _hover={{ bg: "bg.muted" }} asChild>
+                <Menu.Item value="api-docs" color="fg" py="3" px="3" _hover={{ bg: "bg.muted" }} asChild>
                   <NextLink href="/api-docs">API Docs</NextLink>
                 </Menu.Item>
-                <Menu.Item value="faq" color="fg" py="2" px="3" _hover={{ bg: "bg.muted" }} asChild>
+                <Menu.Item value="faq" color="fg" py="3" px="3" _hover={{ bg: "bg.muted" }} asChild>
                   <NextLink href="/faq">FAQ</NextLink>
                 </Menu.Item>
                 {/* The desktop Account menu only exists for signed-in
@@ -239,7 +260,7 @@ export default function Navbar() {
                     <Menu.Item
                       value="experiments"
                       color="fg"
-                      py="2"
+                      py="3"
                       px="3"
                       _hover={{ bg: "bg.muted" }}
                       asChild
@@ -249,7 +270,7 @@ export default function Navbar() {
                     <Menu.Item
                       value="new-experiment"
                       color="fg"
-                      py="2"
+                      py="3"
                       px="3"
                       _hover={{ bg: "bg.muted" }}
                       asChild
@@ -265,7 +286,7 @@ export default function Navbar() {
                     <Menu.Item
                       value="settings"
                       color="fg"
-                      py="2"
+                      py="3"
                       px="3"
                       _hover={{ bg: "bg.muted" }}
                       asChild
@@ -279,10 +300,10 @@ export default function Navbar() {
                   <>
                     {/* Matches the desktop order (Sign In, then Sign Up) --
                         the previous markup reversed them on mobile only. */}
-                    <Menu.Item value="signin" color="fg" py="2" px="3" _hover={{ bg: "bg.muted" }} asChild>
+                    <Menu.Item value="signin" color="fg" py="3" px="3" _hover={{ bg: "bg.muted" }} asChild>
                       <NextLink href="/signin">Sign In</NextLink>
                     </Menu.Item>
-                    <Menu.Item value="signup" color="fg" py="2" px="3" _hover={{ bg: "bg.muted" }} asChild>
+                    <Menu.Item value="signup" color="fg" py="3" px="3" _hover={{ bg: "bg.muted" }} asChild>
                       <NextLink href="/signup">Sign Up</NextLink>
                     </Menu.Item>
                   </>
@@ -291,7 +312,7 @@ export default function Navbar() {
                   <Menu.Item
                     value="signout"
                     color="fg"
-                    py="2"
+                    py="3"
                     px="3"
                     _hover={{ bg: "bg.muted" }}
                     onClick={() => auth.signOut()}

--- a/components/SignInForm.js
+++ b/components/SignInForm.js
@@ -1,4 +1,5 @@
 import {
+  Box,
   Button,
   Card,
   Input,
@@ -77,7 +78,9 @@ export default function SignInForm({ routeAfterSignIn }) {
       w="100%"
       maxW="560px"
       mx="auto"
-      px={4}
+      // No px here: this Card.Root padding sat INSIDE the card border and
+      // added to Card.Body's p={8}, making the card 48px horizontally and
+      // 32px vertically. The page gutter belongs to _app.js.
       variant="unstyled"
       bg="bg.panel"
       borderWidth="1px"
@@ -86,7 +89,7 @@ export default function SignInForm({ routeAfterSignIn }) {
     >
       <Card.Body p={8}>
         <VStack gap={6} as="form" onSubmit={handleSubmit} noValidate>
-          <VStack gap={1} textAlign="center">
+          <VStack gap={2} textAlign="center">
             <Heading as="h1" fontSize="2xl" fontWeight="700" color="fg">
               Sign in
             </Heading>
@@ -153,6 +156,9 @@ export default function SignInForm({ routeAfterSignIn }) {
               <Field.ErrorText>{fieldErrors.password}</Field.ErrorText>
             </Field.Root>
 
+            {/* mt={2} on top of the stack's gap={4} = 24px. Email, password
+                and the submit button were all exactly 16px apart, so the
+                primary action read as a third form field. */}
             <Button
               type="submit"
               colorPalette="brandGreen"
@@ -160,6 +166,7 @@ export default function SignInForm({ routeAfterSignIn }) {
               loadingText="Signing in…"
               w="full"
               size="lg"
+              mt={2}
             >
               Sign in
             </Button>
@@ -172,13 +179,16 @@ export default function SignInForm({ routeAfterSignIn }) {
                 dashboard banner without losing their uid (and with it, their
                 experiments). Remove this in the same release that removes the
                 signup branch of functions/src/oauth2-callback.ts, not before. */}
-            <SignInWithOSF />
+            <Box w="full" mt={4}>
+              <SignInWithOSF />
+            </Box>
 
             <Link
               asChild
               fontSize="sm"
               color="brandGreen.fg"
               textDecoration="underline"
+              mt={2}
             >
               <NextLink href="/reset-password">Forgot password?</NextLink>
             </Link>

--- a/components/ThemeSelect.js
+++ b/components/ThemeSelect.js
@@ -36,7 +36,7 @@ export default function ThemeSelect() {
 
   return (
     <Menu.ItemGroup>
-      <Menu.ItemGroupLabel color="fg.muted" px="3" py="1.5" fontSize="sm">
+      <Menu.ItemGroupLabel color="fg.muted" px="3" py="2" fontSize="sm">
         Theme
       </Menu.ItemGroupLabel>
       <Menu.RadioItemGroup

--- a/components/account/AddSignInMethodBanner.js
+++ b/components/account/AddSignInMethodBanner.js
@@ -50,7 +50,7 @@ export default function AddSignInMethodBanner() {
     >
       <VStack align="stretch" gap={4}>
         <Box>
-          <Text fontWeight="semibold" mb={1}>
+          <Text fontWeight="semibold" mb={2}>
             Add a way to sign in
           </Text>
           <Text fontSize="sm" color="fg.muted">

--- a/components/account/LinkedAccounts.js
+++ b/components/account/LinkedAccounts.js
@@ -127,7 +127,7 @@ export default function LinkedAccounts() {
         const last = linked && !canUnlink(linkedIds, entry.providerId);
 
         return (
-          <VStack key={entry.id} w="100%" align="stretch" gap={1}>
+          <VStack key={entry.id} w="100%" align="stretch" gap={2}>
             <HStack justifyContent="space-between" w="100%" flexWrap="wrap" gap={3}>
               <HStack>
                 {Icon && <Icon />}

--- a/components/account/OAuthTokenStatus.js
+++ b/components/account/OAuthTokenStatus.js
@@ -68,7 +68,7 @@ export default function OAuthTokenStatus({ data }) {
           <Box>
             <Alert.Title>Re-authorization required</Alert.Title>
             <Alert.Description>
-              <VStack align="start" gap={3} mt={1}>
+              <VStack align="start" gap={3} mt={2}>
                 <Text fontSize="sm">
                   DataPipe&apos;s permission to write to your OSF account has
                   expired, so any experiment still sending data to OSF has

--- a/components/account/SelectAuth.js
+++ b/components/account/SelectAuth.js
@@ -90,7 +90,7 @@ export default function SelectAuth({ data }) {
 
     if (!usingPersonalToken) {
         return (
-            <VStack gap={1} w="100%" align="stretch">
+            <VStack gap={2} w="100%" align="stretch">
                 <HStack justifyContent="space-between" w="100%" flexWrap="wrap" gap={3}>
                     <HStack>
                         <Text fontSize="lg">OSF account</Text>
@@ -123,7 +123,7 @@ export default function SelectAuth({ data }) {
     }
 
     return (
-        <VStack gap={1} w="100%" align="stretch">
+        <VStack gap={2} w="100%" align="stretch">
             <HStack justifyContent="space-between" w="100%" flexWrap="wrap" gap={3}>
                 <HStack>
                     <Text fontSize="lg">OSF token</Text>

--- a/components/dashboard/CodeHints.js
+++ b/components/dashboard/CodeHints.js
@@ -46,7 +46,7 @@ export default function CodeHints({ expId }) {
               color="fg"
               borderWidth="1px"
               borderColor="border"
-              p="1"
+              p="2"
             >
               <Menu.Item
                 value="jspsych"

--- a/components/dashboard/ErrorPanel.js
+++ b/components/dashboard/ErrorPanel.js
@@ -69,7 +69,7 @@ export default function ErrorPanel({ errors }) {
     <Alert.Root status="error" colorPalette="brandRed" variant="subtle">
       <Alert.Indicator />
       <Box flex="1" minW={0}>
-        <Alert.Title mb={1}>
+        <Alert.Title mb={2}>
           {all.length === 1
             ? "One submission to this experiment was rejected."
             : `${all.length} submissions to this experiment were rejected.`}
@@ -122,12 +122,12 @@ export default function ErrorPanel({ errors }) {
                               "This submission was rejected, but DataPipe did not record why."}
                           </Text>
                           {error?.detail && error?.message && (
-                            <Text fontSize="sm" color="fg.muted" mt={1}>
+                            <Text fontSize="sm" color="fg.muted" mt={2}>
                               {error.detail}
                             </Text>
                           )}
                           {error?.error && (
-                            <Text fontSize="xs" color="fg.muted" mt={1}>
+                            <Text fontSize="xs" color="fg.muted" mt={2}>
                               Code: {error.error}
                             </Text>
                           )}

--- a/components/dashboard/ExperimentValidation.js
+++ b/components/dashboard/ExperimentValidation.js
@@ -129,7 +129,7 @@ export default function ExperimentValidation({ data }) {
                 setValidationSettings(values);
               }}
             >
-              <Stack gap={5} direction="row">
+              <Stack gap={6} direction="row">
                 <Checkbox.Root value="json" colorPalette="brandGreen">
                   <Checkbox.HiddenInput />
                   <Checkbox.Control>

--- a/components/dashboard/FinalizeControl.js
+++ b/components/dashboard/FinalizeControl.js
@@ -145,7 +145,7 @@ export default function FinalizeControl({ data, experimentId }) {
         borderColor="border"
         borderRadius="md"
         px={4}
-        py={3}
+        py={4}
       >
         <Stack gap={2}>
           <StatusIndicator status="ok" label="This experiment has been finalized." />
@@ -183,7 +183,7 @@ export default function FinalizeControl({ data, experimentId }) {
           variant="subtle"
         >
           <Alert.Indicator />
-          <Stack gap={1}>
+          <Stack gap={2}>
             <Alert.Title>{terminalCopy.title}</Alert.Title>
             <Text fontSize="sm">{terminalCopy.describe(data?.finalization?.detail)}</Text>
           </Stack>

--- a/components/dashboard/QueuePanel.js
+++ b/components/dashboard/QueuePanel.js
@@ -341,7 +341,7 @@ export default function QueuePanel({ entries, experimentId }) {
     >
       <Alert.Indicator />
       <Box flex="1" minW={0}>
-        <Alert.Title mb={1}>{alertTitle}</Alert.Title>
+        <Alert.Title mb={2}>{alertTitle}</Alert.Title>
         <Text fontSize="sm" mb={4}>{alertDescription}</Text>
         {downloadError && (
           <Box mb={4}>
@@ -362,16 +362,16 @@ export default function QueuePanel({ entries, experimentId }) {
                 your storage provider immediately. If that fails, DataPipe saves a
                 copy and retries automatically. Common reasons include:
               </Text>
-              <Box as="ul" fontSize="sm" pl={5} pb={3} listStyleType="disc">
-                <Box as="li" mb={1}>
+              <Box as="ul" fontSize="sm" pl={6} pb={3} listStyleType="disc">
+                <Box as="li" mb={2}>
                   <strong>Server memory limit</strong> — Large data submissions
                   can occasionally exceed the server&apos;s memory capacity.
                 </Box>
-                <Box as="li" mb={1}>
+                <Box as="li" mb={2}>
                   <strong>Storage provider unavailable</strong> — Your storage
                   provider may be temporarily down or rate-limiting requests.
                 </Box>
-                <Box as="li" mb={1}>
+                <Box as="li" mb={2}>
                   <strong>Configuration issue</strong> — There may be a problem
                   with your storage provider settings or authentication token.
                 </Box>
@@ -438,7 +438,7 @@ export default function QueuePanel({ entries, experimentId }) {
                     {statusIndicator(entry.status)}
                     {(entry.status === "pending" || entry.status === "processing") &&
                       entry.nextRetryAt && (
-                        <Text fontSize="xs" color="fg.muted" mt={1}>
+                        <Text fontSize="xs" color="fg.muted" mt={2}>
                           Next retry {nextRetryText(entry.nextRetryAt)}
                         </Text>
                       )}
@@ -496,7 +496,7 @@ export function UploadsResolvedNotice() {
       borderColor="border"
       borderRadius="md"
       px={4}
-      py={3}
+      py={4}
       role="status"
       aria-live="polite"
     >

--- a/components/ui/ConfirmDialog.js
+++ b/components/ui/ConfirmDialog.js
@@ -88,7 +88,7 @@ export default function ConfirmDialog({
             )}
           </Dialog.Body>
 
-          <Dialog.Footer>
+          <Dialog.Footer gap={3}>
             <Button
               variant="outline"
               onClick={() => onOpenChange({ open: false })}
@@ -101,7 +101,6 @@ export default function ConfirmDialog({
               variant="solid"
               loading={isPending}
               onClick={handleConfirm}
-              ml={3}
             >
               {confirmLabel}
             </Button>

--- a/components/ui/EmptyState.js
+++ b/components/ui/EmptyState.js
@@ -55,7 +55,7 @@ export default function EmptyState({ title, body, action, secondary }) {
       borderWidth="1px"
       borderColor="border"
       borderRadius="md"
-      px={[5, 8]}
+      px={[6, 8]}
       py={[6, 8]}
     >
       <Stack gap={4} align="flex-start" maxW="60ch">

--- a/components/ui/PageHeader.js
+++ b/components/ui/PageHeader.js
@@ -72,7 +72,7 @@ export default function PageHeader({
           color="fg.muted"
           display="inline-flex"
           alignItems="center"
-          gap={1.5}
+          gap={2}
           mb={3}
           _hover={{ color: "fg", textDecoration: "underline" }}
         >

--- a/components/ui/SettingsRow.js
+++ b/components/ui/SettingsRow.js
@@ -264,7 +264,7 @@ export default function SettingsRow({
           </Switch.Root>
         </HStack>
 
-        {description && <GuidanceLine mt={1}>{description}</GuidanceLine>}
+        {description && <GuidanceLine mt={2}>{description}</GuidanceLine>}
 
         <SaveStatus saved={saved} error={error} savedLabel={savedLabel} />
 

--- a/components/ui/SettingsSection.js
+++ b/components/ui/SettingsSection.js
@@ -76,7 +76,7 @@ export default function SettingsSection({
         size="md"
         fontWeight="semibold"
         color={isDanger ? "brandRed.fg" : "fg"}
-        mb={description ? 1 : 4}
+        mb={description ? 2 : 4}
       >
         {title}
       </Heading>
@@ -101,7 +101,7 @@ export default function SettingsSection({
       borderWidth="1px"
       borderColor="brandRed.border"
       borderRadius="md"
-      p={4}
+      p={6}
     >
       {content}
     </Box>

--- a/components/ui/StatusIndicator.js
+++ b/components/ui/StatusIndicator.js
@@ -88,7 +88,7 @@ export default function StatusIndicator({ status, label, size = 16 }) {
   const color = STATUS_COLORS[status] || STATUS_COLORS.neutral;
 
   return (
-    <HStack gap={1.5} display="inline-flex" alignItems="center">
+    <HStack gap={2} display="inline-flex" alignItems="center">
       <Icon aria-hidden="true" size={size} color={color} />
       <Text fontSize="sm" color="fg">
         {label}

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -3,7 +3,7 @@ import Navbar from "../components/Navbar";
 import Footer from "../components/Footer";
 import { UserContext } from "../lib/context";
 import { ChakraProvider } from "@chakra-ui/react";
-import { Box, Center } from "@chakra-ui/react";
+import { Box, Flex } from "@chakra-ui/react";
 import { ThemeProvider } from "next-themes";
 
 import { auth } from "../lib/firebase";
@@ -26,14 +26,32 @@ function MyApp({ Component, pageProps }) {
       justifyContent="space-between"
     >
       <Navbar />
-      <Center
+      {/* This was a <Center>, which is `align-items: center` in BOTH axes:
+          the navbar-to-content gap was never specified, it was whatever
+          flexbox had left over -- zero on any page taller than the viewport
+          (the owner's "very tight" report) and a floating, vertically
+          centered column on any page shorter than it. The gap is now
+          declared once, here, for every page that uses the default layout,
+          rather than each page growing its own top margin.
+
+          DESIGN.md §4 ladder: pt 8/12 opens the page under the nav; the
+          larger pb 12/16 makes the hand-off into the footer band deliberate
+          and asymmetric -- more air before a change of surface than after a
+          change of chrome. */}
+      <Flex
+        as="main"
+        direction="column"
+        alignItems="center"
+        w="100%"
         flexGrow={1}
         flexShrink={0}
         flexBasis="auto"
-        justifySelf="flex-start"
+        px={4}
+        pt={{ base: 8, md: 12 }}
+        pb={{ base: 12, md: 16 }}
       >
         {page}
-      </Center>
+      </Flex>
       <Footer />
       {
         /* A `!== ""` guard renders whenever the var is UNDEFINED

--- a/pages/admin/[experiment_id].js
+++ b/pages/admin/[experiment_id].js
@@ -100,7 +100,7 @@ function ExperimentPageDashboard({ experiment_id }) {
 
   if (loading) {
     return (
-      <Center w="100%" py={16}>
+      <Center w="100%" py={8}>
         <Spinner color="brandGreen.solid" size="xl" />
       </Center>
     );
@@ -117,7 +117,7 @@ function ExperimentPageDashboard({ experiment_id }) {
   const notFound = !!snapshot && !snapshot.exists();
   if (error || notFound) {
     return (
-      <VStack w="100%" maxW="1100px" px={4} align="stretch">
+      <VStack w="100%" maxW="1100px" gap={6} align="stretch">
         <PageHeader
           title={notFound ? "Experiment not found" : "Could not load this experiment"}
           backHref="/admin"
@@ -141,7 +141,6 @@ function ExperimentPageDashboard({ experiment_id }) {
       w="100%"
       // 1100px, DESIGN.md §4's dashboard measure. Was an unexplained 1200.
       maxW="1100px"
-      px={4}
       gap={0}
     >
       <PageHeader
@@ -177,12 +176,12 @@ function ExperimentPageDashboard({ experiment_id }) {
       </HStack>
 
       {queueError && (
-        <Box mb={6}>
+        <Box mb={4}>
           <StatusIndicator
             status="warning"
             label="DataPipe could not check for queued uploads."
           />
-          <GuidanceLine mt={1}>
+          <GuidanceLine mt={2}>
             Files may be waiting to reach your storage provider without this
             page being able to show them. Reload to try again.
           </GuidanceLine>
@@ -190,22 +189,25 @@ function ExperimentPageDashboard({ experiment_id }) {
       )}
 
       {showResolved && (
-        <Box w="100%" mb={6}>
+        <Box w="100%" mb={4}>
           <UploadsResolvedNotice />
         </Box>
       )}
       {uploadError && queueEntries.length === 0 && !showResolved && (
-        <Box w="100%" mb={6}>
+        <Box w="100%" mb={4}>
           <ErrorPanel errors={errorLog} />
         </Box>
       )}
       {queueEntries.length > 0 && (
-        <Box w="100%" mb={6}>
+        <Box w="100%" mb={4}>
           <QueuePanel entries={queueEntries} experimentId={experiment_id} />
         </Box>
       )}
 
-      <Flex w="100%" gap={10} wrap="wrap" alignItems="flex-start">
+      {/* The notices above are one group of alerts (mb={4} between them);
+          this mt lifts the body away from that group instead of leaving it
+          the same 24px the notices used between themselves. */}
+      <Flex w="100%" mt={6} gap={10} wrap="wrap" alignItems="flex-start">
         <VStack flex="1" minW="300px" gap={0} align="stretch">
           <ExperimentInfo data={data} />
 

--- a/pages/admin/account.js
+++ b/pages/admin/account.js
@@ -50,7 +50,7 @@ export default function AccountPage() {
 
   if (loading) {
     return (
-      <Center py={16}>
+      <Center w="100%" py={8}>
         <Spinner size="lg" color="brandGreen.solid" />
       </Center>
     );
@@ -93,10 +93,10 @@ export default function AccountPage() {
 
   return (
     <AuthCheck fallbackRoute={deleting ? "/admin/deleted-account" : null}>
-      <VStack gap={0} w="100%" maxW="560px" px={4} align="stretch">
+      <VStack gap={0} w="100%" maxW="560px" align="stretch">
         <Box mb={10}>
           <Heading>Account settings</Heading>
-          <Text fontSize="sm" color="fg.muted" mt={1}>
+          <Text fontSize="sm" color="fg.muted" mt={2}>
             {accountIdentity}
           </Text>
           {/* /admin/new sends researchers here mid-creation with ?next= so

--- a/pages/admin/index.js
+++ b/pages/admin/index.js
@@ -34,7 +34,7 @@ export default function AdminPage({}) {
           settings column, 1100px for dashboard and marketing pages. This was
           960px, one of three different widths across the three dashboard
           routes (960 / 540 / 1200). */}
-      <VStack gap={8} w="100%" maxW="1100px" px={4} align="stretch">
+      <VStack gap={8} w="100%" maxW="1100px" align="stretch">
         <AddSignInMethodBanner />
         <ExperimentList />
       </VStack>
@@ -191,7 +191,7 @@ function ExperimentItem({ exp }) {
           <ChakraLink asChild color="fg" fontSize="lg" fontWeight="semibold">
             <Link href={`/admin/${exp.id}`}>{exp.title}</Link>
           </ChakraLink>
-          <HStack gap={[2, 4]} flexWrap="wrap" rowGap={1}>
+          <HStack gap={[2, 4]} flexWrap="wrap" rowGap={2}>
             {/* One status per row, stated in words. "Data / Base64 /
                 Conditions / Metadata" were feature NAMES, not statuses --
                 whether each was on lived in the dot's hue. */}

--- a/pages/admin/new.js
+++ b/pages/admin/new.js
@@ -282,7 +282,7 @@ function NewExperimentForm() {
           when content arrived (DESIGN.md §7: skeletons for content loading in
           place, spinners for actions). This holds the form's shape. */}
       {loading && (
-        <Stack gap={6} w="100%" maxW="560px" px={4}>
+        <Stack gap={6} w="100%" maxW="560px">
           <Skeleton height="40px" width="60%" />
           <Skeleton height="80px" />
           <Skeleton height="80px" />
@@ -290,7 +290,7 @@ function NewExperimentForm() {
       )}
       {!loading && (
         // 560px, DESIGN.md §4's single-subject column. Was a stray 540px.
-        <Stack gap={6} w="100%" maxW="560px" px={4}>
+        <Stack gap={6} w="100%" maxW="560px">
           <PageHeader
             title="Create an experiment"
             purpose="An experiment gives you an ID to paste into your study, and a folder for its data to land in."
@@ -313,7 +313,12 @@ function NewExperimentForm() {
               retires the hand-written `role="radiogroup"` + `aria-label` the
               old markup carried, which duplicated the visible label for
               screen readers. */}
+          {/* mt={4} on top of the stack's gap={6} = 40px, DESIGN.md §4's
+              routine-section distance. This page was ONE flat gap={6}: the
+              page title, the provider decision, every field and the submit
+              button were all 24px apart, so nothing on it was grouped. */}
           <RadioGroup.Root
+            mt={4}
             name="storage-provider"
             value={provider}
             onValueChange={(e) => handleProviderChange(e.value)}
@@ -346,7 +351,7 @@ function NewExperimentForm() {
           </RadioGroup.Root>
 
           {!providerConnected && (
-            <VStack gap={3} align="flex-start">
+            <VStack gap={3} mt={4} align="flex-start">
               <GuidanceLine>
                 You cannot create an experiment until DataPipe has somewhere to
                 put its data. Connecting your{" "}
@@ -368,7 +373,10 @@ function NewExperimentForm() {
           )}
 
           {providerConnected && (
-            <>
+            // A Stack, not a bare fragment: "describe the experiment" is a
+            // section distinct from "choose where data goes" above it, and
+            // mt={4} over the parent gap gives it the same 40px break.
+            <Stack gap={6} mt={4}>
               {/* Was a bare `<Text color="red.400">` -- no role="alert", no
                   icon, no mapping, a raw adapter string shown verbatim.
                   FormErrorAlert is the app's one error surface (DESIGN.md
@@ -473,14 +481,17 @@ function NewExperimentForm() {
                 </Field.Root>
               )}
 
+              {/* The submit sat exactly as far from the last field as the
+                  fields sat from each other. */}
               <Button
                 onClick={handleProviderSubmit}
                 loading={providerSubmitting}
                 colorPalette="brandGreen"
+                mt={4}
               >
                 Create experiment
               </Button>
-            </>
+            </Stack>
           )}
         </Stack>
       )}

--- a/pages/api-docs.js
+++ b/pages/api-docs.js
@@ -66,7 +66,10 @@ function ErrorRow({ code, status, children }) {
 
 export default function ApiDocs() {
   return (
-    <Stack w={["95%", 960]} gap={12} py={4}>
+    // 960 -> the committed 1100px measure (DESIGN.md §4), which this page
+    // wants anyway: it carries three reference tables, one of them 22 rows.
+    // `py={4}` removed -- _app.js owns the navbar and footer gaps now.
+    <Stack w="100%" maxW="1100px" gap={12}>
 
       <Stack gap={3}>
         <Heading as="h1" size="xl">

--- a/pages/contact.js
+++ b/pages/contact.js
@@ -2,8 +2,14 @@ import { Stack, Heading, Text, Button, Link } from "@chakra-ui/react";
 
 export default function Contact() {
   return (
-    <Stack w="100%" maxW={600} px={4} gap={8}>
-      <Heading as="h1" size="2xl">
+    // maxW 600 -> the committed 560px single-subject column; px={4} removed
+    // (the page gutter is set once in _app.js). gap 8 -> 4 with the heading
+    // carrying its own mb={4}: at a flat gap={8} the h1 sat exactly as far
+    // from the first paragraph as the paragraphs sat from each other, so the
+    // title did not read as a title. Now the body is one tight group and the
+    // heading is separated from it.
+    <Stack w="100%" maxW="560px" gap={4}>
+      <Heading as="h1" size="2xl" mb={4}>
         Contact Us
       </Heading>
       <Text>

--- a/pages/faq.js
+++ b/pages/faq.js
@@ -41,8 +41,13 @@ export default function FAQ() {
   }, []);
 
   return (
-    <Stack maxW={800} w="100%" my={10}>
-      <Heading as="h1" my={4}>
+    // maxW 800 was a fifth measure. This page is pure prose -- no tables, no
+    // code -- so it takes §4's single-subject column (560px) rather than the
+    // 1100px that getting-started and api-docs need for their tables.
+    // `my={10}` removed: _app.js owns the navbar and footer gaps, and the
+    // page-level margin was stacking on top of them.
+    <Stack maxW="560px" w="100%">
+      <Heading as="h1" mb={6}>
         FAQ
       </Heading>
       <Accordion.Root value={openItems} onValueChange={(e) => setOpenItems(e.value)} multiple collapsible>
@@ -214,8 +219,10 @@ export default function FAQ() {
           <Text mb={2}>
             There are a few risks to be aware of:
           </Text>
-          <ol style={{ paddingLeft: "1.5em" }}>
-            <li style={{ marginBottom: "0.5em" }}>
+          {/* Raw em inline styles (1.5em / 0.5em) replaced with the ladder --
+              pl={6} / mb={2} is the same list geometry QueuePanel uses. */}
+          <Box as="ol" pl={6}>
+            <Box as="li" mb={2}>
               <strong>Authorization tokens.</strong> DataPipe needs permission
               to write to your storage account, and all tokens are stored
               encrypted. For Google Drive and Zenodo you authorize DataPipe
@@ -223,14 +230,14 @@ export default function FAQ() {
               Dataverse you supply an API token, so create one specifically for
               DataPipe and revoke it when you are done collecting data. You can
               disconnect any provider from your account settings at any time.
-            </li>
-            <li style={{ marginBottom: "0.5em" }}>
+            </Box>
+            <Box as="li" mb={2}>
               <strong>Fake or spam data.</strong> As with any online experiment,
               a technically savvy user could submit fabricated data or spam
               files to your storage. DataPipe provides validation rules and
               session limits to reduce this risk.
-            </li>
-            <li>
+            </Box>
+            <Box as="li">
               <strong>Support availability.</strong> DataPipe is not a
               commercial product with a dedicated support team. However,
               the{" "}
@@ -239,8 +246,8 @@ export default function FAQ() {
               </Link>{" "}
               and thoroughly tested, and the service runs on Google Cloud
               infrastructure.
-            </li>
-          </ol>
+            </Box>
+          </Box>
         </FAQItem>
         <FAQItem value="item-8" question="How does data validation work?">
           <Text mb={2}>
@@ -406,13 +413,20 @@ function FAQItem({ question, children, value }) {
     <Box id={value}>
       <Accordion.Item value={value}>
         <Accordion.ItemTrigger>
-          <Heading as="h2" size="md" my={2} flex="1" textAlign="left">
+          {/* my={3}: 18 of these triggers stack down the page, and at my={2}
+              each row was ~36px. 12px around a 24px heading line is a 48px
+              target. */}
+          <Heading as="h2" size="md" my={3} flex="1" textAlign="left">
             {question}
           </Heading>
           <Accordion.ItemIndicator />
         </Accordion.ItemTrigger>
         <Accordion.ItemContent>
-          <Box pb={4} style={{ whiteSpace: "pre-line" }}>
+          {/* The answer had no pt at all -- it opened flush against its own
+              trigger -- and the same pb={4} below it, so it sat equidistant
+              from its question and the next one. Closer to the question it
+              answers than to the question after it. */}
+          <Box pt={2} pb={6} style={{ whiteSpace: "pre-line" }}>
             {children}
           </Box>
         </Accordion.ItemContent>

--- a/pages/getting-started.js
+++ b/pages/getting-started.js
@@ -59,7 +59,10 @@ function StepCard({ number, title, children }) {
           {title}
         </Heading>
       </HStack>
-      <Stack gap={4} pl={[0, "48px"]}>
+      {/* 12 == 48px == StepNumber (36px) + the header HStack's gap={3}:
+          the step body hangs off the title, not the number. Was the raw
+          string "48px". */}
+      <Stack gap={4} pl={[0, 12]}>
         {children}
       </Stack>
     </Box>
@@ -78,7 +81,7 @@ function Callout({ children }) {
       borderColor="brandGreen.border"
       borderRadius={8}
       px={4}
-      py={3}
+      py={4}
     >
       <HStack gap={2} alignItems="flex-start">
         <Shield size={18} style={{ flexShrink: 0, marginTop: "3px" }} />
@@ -107,7 +110,7 @@ function CollapsibleSection({ title, children }) {
       <Collapsible.Content>
         {/* Decorative hairline inside an already-grouped (collapsed)
             region, not the section's own boundary -- border.subtle. */}
-        <Stack gap={3} pt={2} pl={4} borderLeft="1px solid" borderColor="border.subtle">
+        <Stack gap={3} pt={2} pb={4} pl={4} borderLeft="1px solid" borderColor="border.subtle">
           {children}
         </Stack>
       </Collapsible.Content>
@@ -138,13 +141,13 @@ function ProviderOption({ name, summary, landsIn, connect, limits }) {
     // uses `border` (gray.500, 4.50 light / 3.43 dark) rather than
     // `border.subtle`, which DESIGN.md bans as a lone grouping device.
     <Box borderWidth="1px" borderColor="border" borderRadius={8} p={4}>
-      <Text fontWeight="semibold" color="brandOrange.fg" mb={1}>
+      <Text fontWeight="semibold" color="brandOrange.fg" mb={2}>
         {name}
       </Text>
       <Text fontSize="sm" mb={3}>
         {summary}
       </Text>
-      <Stack gap={1}>
+      <Stack gap={2}>
         <Text fontSize="sm" color="fg.muted">
           <Text as="span" fontWeight="semibold">Data lands in:</Text> {landsIn}
         </Text>
@@ -172,7 +175,11 @@ export default function GettingStarted() {
     : "Experiments already collecting keep running for now.";
 
   return (
-    <Stack w={["95%", 960]} gap={8} py={4}>
+    // 960 is one of the stray measures DESIGN.md §4 names for consolidation;
+    // this is a public docs page with cards, code blocks and a provider grid,
+    // so it takes the 1100px measure. `py={4}` is gone: the navbar gap and
+    // the footer gap are set once in _app.js for every page.
+    <Stack w="100%" maxW="1100px" gap={8}>
       <VStack gap={2} align="start">
         <Heading as="h1" size="2xl">
           Getting Started
@@ -428,7 +435,13 @@ export default function GettingStarted() {
         </Text>
       </StepCard>
 
-      <StepCard number={8} title="When data collection ends">
+      {/* mt={8} over the stack's gap={8} = 64px. Eight steps at an
+          identical 32px told the reader nothing about which one is
+          different; this last one is the irreversible one (finalizing
+          cannot be undone), so it gets the break DESIGN.md §4 reserves for
+          a consequential section. */}
+      <Box mt={8}>
+        <StepCard number={8} title="When data collection ends">
         <Text>
           When your study is finished, <strong>finalize</strong> the
           experiment from its dashboard. DataPipe merges every remaining data
@@ -442,7 +455,8 @@ export default function GettingStarted() {
           it. Publishing the record, and with it issuing the DOI, stays your
           decision and happens on Zenodo itself.
         </Text>
-      </StepCard>
+        </StepCard>
+      </Box>
     </Stack>
   );
 }

--- a/pages/oauth2/callback.js
+++ b/pages/oauth2/callback.js
@@ -221,8 +221,10 @@ function OAuth2CallbackPage() {
   const renderContent = () => {
     switch (status) {
       case 'processing':
+        // gap={4}: the spinner, its heading and its explanation are one
+        // labelled loader, not three equidistant siblings.
         return (
-          <VStack gap={6}>
+          <VStack gap={4}>
             <Center>
               <Spinner size="xl" color="brandGreen.solid" borderWidth="4px" />
             </Center>
@@ -281,8 +283,10 @@ function OAuth2CallbackPage() {
         );
 
       default:
+        // gap={4}: the spinner, its heading and its explanation are one
+        // labelled loader, not three equidistant siblings.
         return (
-          <VStack gap={6}>
+          <VStack gap={4}>
             <Center>
               <Spinner size="xl" color="brandGreen.solid" borderWidth="4px" />
             </Center>
@@ -299,7 +303,9 @@ function OAuth2CallbackPage() {
       w="100%"
       maxW="560px"
       mx="auto"
-      px={4}
+      // No px here: this Card.Root padding sat INSIDE the card border and
+      // added to Card.Body's p={8}, making the card 48px horizontally and
+      // 32px vertically. The page gutter belongs to _app.js.
       variant="unstyled"
       bg="bg.panel"
       borderWidth="1px"
@@ -307,7 +313,10 @@ function OAuth2CallbackPage() {
       rounded="lg"
     >
       <Card.Body p={8}>
-        <VStack gap={6}>
+        {/* gap={8}, not gap={6}: the page heading and the status block below
+            it used to sit exactly as far apart as the elements INSIDE that
+            block, so the h1 read as one more line of the message. */}
+        <VStack gap={8}>
           <Heading as="h1" fontSize="2xl" fontWeight="700" textAlign="center" color="fg">
             OSF authentication
           </Heading>

--- a/pages/oauth2/connect.js
+++ b/pages/oauth2/connect.js
@@ -225,8 +225,10 @@ function ProviderConnectCallbackPage() {
 
       case "processing":
       default:
+        // gap={4}: the spinner, its heading and its explanation are one
+        // labelled loader, not three equidistant siblings.
         return (
-          <VStack gap={6}>
+          <VStack gap={4}>
             <Center>
               <Spinner size="xl" color="brandGreen.solid" borderWidth="4px" />
             </Center>
@@ -246,7 +248,9 @@ function ProviderConnectCallbackPage() {
       w="100%"
       maxW="560px"
       mx="auto"
-      px={4}
+      // No px here: this Card.Root padding sat INSIDE the card border and
+      // added to Card.Body's p={8}, making the card 48px horizontally and
+      // 32px vertically. The page gutter belongs to _app.js.
       variant="unstyled"
       bg="bg.panel"
       borderWidth="1px"
@@ -254,7 +258,10 @@ function ProviderConnectCallbackPage() {
       rounded="lg"
     >
       <Card.Body p={8}>
-        <VStack gap={6}>
+        {/* gap={8}, not gap={6}: the page heading and the status block below
+            it used to sit exactly as far apart as the elements INSIDE that
+            block, so the h1 read as one more line of the message. */}
+        <VStack gap={8}>
           <Heading as="h1" fontSize="2xl" fontWeight="700" textAlign="center" color="fg">
             Connect a storage provider
           </Heading>

--- a/pages/reset-password.js
+++ b/pages/reset-password.js
@@ -125,7 +125,9 @@ export default function ResetPassword() {
       w="100%"
       maxW="560px"
       mx="auto"
-      px={4}
+      // No px here: this Card.Root padding sat INSIDE the card border and
+      // added to Card.Body's p={8}, making the card 48px horizontally and
+      // 32px vertically. The page gutter belongs to _app.js.
       variant="unstyled"
       bg="bg.panel"
       borderWidth="1px"
@@ -196,11 +198,13 @@ export default function ResetPassword() {
                 <Field.ErrorText>{emailFieldError}</Field.ErrorText>
               </Field.Root>
 
+              {/* mt={2} over gap={4}: submit is the end of the form. */}
               <Button
                 type="submit"
                 colorPalette="brandGreen"
                 loading={isSubmitting}
                 loadingText="Sending link…"
+                mt={2}
               >
                 Send reset link
               </Button>
@@ -249,6 +253,7 @@ export default function ResetPassword() {
                 colorPalette="brandGreen"
                 loading={isSubmitting}
                 loadingText="Setting password…"
+                mt={2}
               >
                 Set new password
               </Button>

--- a/pages/signup.js
+++ b/pages/signup.js
@@ -148,7 +148,9 @@ export default function SignUpPage() {
       w="100%"
       maxW="560px"
       mx="auto"
-      px={4}
+      // No px here: this Card.Root padding sat INSIDE the card border and
+      // added to Card.Body's p={8}, making the card 48px horizontally and
+      // 32px vertically. The page gutter belongs to _app.js.
       variant="unstyled"
       bg="bg.panel"
       borderWidth="1px"
@@ -157,7 +159,7 @@ export default function SignUpPage() {
     >
       <Card.Body p={8}>
         <VStack gap={6} as="form" onSubmit={onSubmit} noValidate>
-          <VStack gap={1} textAlign="center">
+          <VStack gap={2} textAlign="center">
             <Heading as="h1" fontSize="2xl" fontWeight="700" color="fg">
               Create an account
             </Heading>
@@ -234,6 +236,8 @@ export default function SignUpPage() {
               <Field.ErrorText>{fieldErrors.password}</Field.ErrorText>
             </Field.Root>
 
+            {/* mt={2} against the stack's gap={4}: the submit is the end of
+                the form, not another field in it. */}
             <Button
               type="submit"
               colorPalette="brandGreen"
@@ -241,6 +245,7 @@ export default function SignUpPage() {
               loadingText="Creating account…"
               w="full"
               size="lg"
+              mt={2}
             >
               Create account
             </Button>


### PR DESCRIPTION
## What this is

Owner-directed layout pass ("padding and spacing seems very tight in some places, like between the nav bar and the page; there's an odd horizontal line in the footer").

Both named issues turned out structural, not cosmetic:

- **The navbar gap was never a value.** `_app.js` rendered every page into a `Center`, which centers on both axes — the gap under the navbar was flexbox residue (zero on tall pages, floating on short ones), and no page wrapper declared its own. Pages now render into a top-aligned `<main>` that declares the rhythm once (`pt 8/12`, `pb 12/16`, larger toward the footer band); the per-page bandaids it obsoletes are removed. The landing page keeps its own `getLayout` and is untouched.
- **The footer line was never an edge.** The `borderTop` sat on the inner Stack, 40px below the band's actual boundary — a rule floating inside the fill. It now sits on the `<footer>` element itself as `border.subtle`, exactly on the fill transition (which at 1.08:1 is too weak to carry the edge alone, per the DESIGN §1 rule).
- **The sweep**: ~30 files of off-ladder values consolidated onto the DESIGN §4 scale — 44px touch targets in the nav menus, submit buttons spaced as actions rather than form fields, loading spinners normalized so content doesn't jump on load, auth cards un-double-padded, FAQ onto the 560px prose measure, stray 960/800/600 containers onto the committed 1100/560 pair.

## Testing

Full frontend suite 195/195 green; all routes verified 200.

## Merge note

Touches `getting-started`/`faq`/`api-docs` spacing, which #181 (light-mode ship) touches for color — whichever merges second may need a trivial rebase; ping Claude and it's handled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)