### PR TITLE
Required contact email for all users + first-failure upload notifications

### DIFF
--- a/__tests__/contact-email-gate.test.jsx
+++ b/__tests__/contact-email-gate.test.jsx
@@ -1,0 +1,204 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { ChakraProvider } from "@chakra-ui/react";
+import { system } from "../lib/theme";
+import "@testing-library/jest-dom";
+
+// Same mocking shape as __tests__/provider-connections.test.jsx: mock
+// ../lib/firebase, ../lib/context, firebase/firestore, and
+// react-firebase-hooks/firestore, then wrap in ChakraProvider.
+jest.mock("../lib/firebase", () => ({
+  auth: { currentUser: { uid: "user-1" } },
+  db: {},
+}));
+
+const mockUser = { uid: "user-1", email: "researcher@example.edu" };
+jest.mock("../lib/context", () => ({
+  UserContext: require("react").createContext({ user: null, loading: true }),
+}));
+
+const mockSetDoc = jest.fn(() => Promise.resolve());
+jest.mock("firebase/firestore", () => ({
+  doc: jest.fn(() => ({})),
+  setDoc: (...args) => mockSetDoc(...args),
+}));
+
+jest.mock("react-firebase-hooks/firestore", () => ({
+  useDocumentData: jest.fn(),
+}));
+
+// AuthCheck reads useRouter for the pathname passed to SignInForm and an
+// effect that pushes fallbackRoute when signed out -- neither path is
+// exercised by these tests (every case here is signed in), but the module
+// still has to resolve.
+jest.mock("next/router", () => ({
+  __esModule: true,
+  default: { push: jest.fn() },
+  useRouter: () => ({ push: jest.fn(), pathname: "/admin" }),
+}));
+
+import { UserContext } from "../lib/context";
+import { useDocumentData } from "react-firebase-hooks/firestore";
+import AuthCheck from "../components/AuthCheck";
+
+function renderGated(userValue = { user: mockUser, loading: false }) {
+  return render(
+    <ChakraProvider value={system}>
+      <UserContext.Provider value={userValue}>
+        <AuthCheck>
+          <div>Protected dashboard content</div>
+        </AuthCheck>
+      </UserContext.Provider>
+    </ChakraProvider>
+  );
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockSetDoc.mockClear();
+  mockSetDoc.mockResolvedValue();
+});
+
+describe("AuthCheck's contact-email gate", () => {
+  it("users/{uid} doc with no contactEmail: gate copy renders, children absent", () => {
+    useDocumentData.mockReturnValue([{ email: "" }, false, undefined]);
+
+    renderGated();
+
+    expect(screen.getByText("Add an email address")).toBeInTheDocument();
+    expect(
+      screen.getByText(/DataPipe needs a way to reach you/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("Protected dashboard content")
+    ).not.toBeInTheDocument();
+  });
+
+  it("users/{uid} doc with a valid contactEmail: children render, gate absent", () => {
+    useDocumentData.mockReturnValue([
+      { contactEmail: "lab@example.edu", contactEmailVerified: false },
+      false,
+      undefined,
+    ]);
+
+    renderGated();
+
+    expect(screen.getByText("Protected dashboard content")).toBeInTheDocument();
+    expect(screen.queryByText("Add an email address")).not.toBeInTheDocument();
+  });
+
+  it("synthetic OSF fallback address does not satisfy the gate", () => {
+    // The case a naive truthiness check gets wrong -- oauth2-callback.ts
+    // seeds this exact shape as a fallback, and it is undeliverable.
+    useDocumentData.mockReturnValue([
+      { contactEmail: "user-abc12@osf.io", email: "user-abc12@osf.io" },
+      false,
+      undefined,
+    ]);
+
+    renderGated();
+
+    expect(screen.getByText("Add an email address")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Protected dashboard content")
+    ).not.toBeInTheDocument();
+  });
+
+  it("loading users/{uid}: neither the gate nor the children render", () => {
+    useDocumentData.mockReturnValue([undefined, true, undefined]);
+
+    renderGated();
+
+    expect(screen.queryByText("Add an email address")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Protected dashboard content")
+    ).not.toBeInTheDocument();
+  });
+
+  it("a users/{uid} read error fails OPEN: children render, not the gate", () => {
+    useDocumentData.mockReturnValue([
+      undefined,
+      false,
+      new Error("permission-denied"),
+    ]);
+
+    renderGated();
+
+    expect(screen.getByText("Protected dashboard content")).toBeInTheDocument();
+    expect(screen.queryByText("Add an email address")).not.toBeInTheDocument();
+  });
+
+  it("malformed input shows a field error and never calls setDoc", () => {
+    useDocumentData.mockReturnValue([{ email: "" }, false, undefined]);
+
+    renderGated();
+
+    fireEvent.change(screen.getByLabelText(/Email address/i), {
+      target: { value: "not-an-email" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Save and continue/i }));
+
+    expect(screen.getByText(/Enter a valid email address/i)).toBeInTheDocument();
+    expect(mockSetDoc).not.toHaveBeenCalled();
+  });
+
+  it("a valid submit writes exactly the four allowed keys, contactEmailVerified false", async () => {
+    useDocumentData.mockReturnValue([{ email: "" }, false, undefined]);
+
+    renderGated();
+
+    fireEvent.change(screen.getByLabelText(/Email address/i), {
+      target: { value: "researcher@example.edu" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Save and continue/i }));
+
+    await waitFor(() => expect(mockSetDoc).toHaveBeenCalled());
+
+    const [, payload, options] = mockSetDoc.mock.calls[0];
+    expect(Object.keys(payload).sort()).toEqual(
+      [
+        "contactEmail",
+        "contactEmailVerified",
+        "contactEmailUpdatedAt",
+        "contactEmailSource",
+      ].sort()
+    );
+    expect(payload.contactEmail).toBe("researcher@example.edu");
+    expect(payload.contactEmailVerified).toBe(false);
+    expect(options).toEqual({ merge: true });
+  });
+
+  it("has no control labelled Skip or Later -- there is no skip", () => {
+    useDocumentData.mockReturnValue([{ email: "" }, false, undefined]);
+
+    renderGated();
+
+    expect(screen.queryByText(/^Skip$/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/^Later$/i)).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /skip/i })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /later/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("/admin/account's requireContactEmail={false} bypasses the gate entirely", () => {
+    // Doc has no contactEmail at all -- would trip the gate on any other
+    // route -- but requireContactEmail={false} must render children
+    // unconditionally, without even subscribing to useDocumentData.
+    useDocumentData.mockReturnValue([undefined, false, undefined]);
+
+    render(
+      <ChakraProvider value={system}>
+        <UserContext.Provider value={{ user: mockUser, loading: false }}>
+          <AuthCheck requireContactEmail={false}>
+            <div>Account settings content</div>
+          </AuthCheck>
+        </UserContext.Provider>
+      </ChakraProvider>
+    );
+
+    expect(screen.getByText("Account settings content")).toBeInTheDocument();
+    expect(screen.queryByText("Add an email address")).not.toBeInTheDocument();
+  });
+});

--- a/__tests__/contact-email-section.test.jsx
+++ b/__tests__/contact-email-section.test.jsx
@@ -1,0 +1,260 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { ChakraProvider } from "@chakra-ui/react";
+import { system } from "../lib/theme";
+import "@testing-library/jest-dom";
+
+// Same mocking shape as __tests__/provider-connections.test.jsx: mock
+// ../lib/firebase (auth.currentUser.getIdToken, matching DeleteAccount.js /
+// FinalizeControl.js's fetch-with-bearer-token idiom, NOT a Firestore write --
+// this file only calls the two P3 HTTP endpoints), ../lib/context (for
+// user.uid, used only by the P1 edit-form's setDoc call), and firebase/firestore.
+const mockGetIdToken = jest.fn(() => Promise.resolve("id-token-123"));
+jest.mock("../lib/firebase", () => ({
+  auth: { currentUser: { uid: "user-1", getIdToken: () => mockGetIdToken() } },
+  db: {},
+}));
+
+jest.mock("../lib/context", () => ({
+  UserContext: require("react").createContext({ user: { uid: "user-1" }, loading: false }),
+}));
+
+const mockSetDoc = jest.fn(() => Promise.resolve());
+jest.mock("firebase/firestore", () => ({
+  doc: jest.fn(() => ({})),
+  setDoc: (...args) => mockSetDoc(...args),
+}));
+
+import ContactEmail from "../components/account/ContactEmail";
+
+function renderComponent(data) {
+  return render(
+    <ChakraProvider value={system}>
+      <ContactEmail data={data} />
+    </ChakraProvider>
+  );
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetIdToken.mockClear();
+  mockGetIdToken.mockImplementation(() => Promise.resolve("id-token-123"));
+  mockSetDoc.mockClear();
+  mockSetDoc.mockResolvedValue();
+  global.fetch = jest.fn();
+});
+
+describe("ContactEmail — states", () => {
+  it("verified: shows StatusIndicator ok/Confirmed, no Verify or Resend affordance", () => {
+    renderComponent({ contactEmail: "researcher@example.edu", contactEmailVerified: true });
+
+    expect(screen.getByText("Confirmed")).toBeInTheDocument();
+    expect(screen.queryByText("Not confirmed yet")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /^Verify$/i })).not.toBeInTheDocument();
+  });
+
+  it("unverified: shows StatusIndicator neutral/Not confirmed yet plus a Verify action", () => {
+    renderComponent({ contactEmail: "researcher@example.edu", contactEmailVerified: false });
+
+    expect(screen.getByText("Not confirmed yet")).toBeInTheDocument();
+    expect(screen.queryByText("Confirmed")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^Verify$/i })).toBeInTheDocument();
+  });
+
+  it("no address on file: neither Confirmed, Not confirmed yet, nor Verify render", () => {
+    renderComponent({ contactEmail: "" });
+
+    expect(screen.getByText("No address on file")).toBeInTheDocument();
+    expect(screen.queryByText("Not confirmed yet")).not.toBeInTheDocument();
+    expect(screen.queryByText("Confirmed")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /^Verify$/i })).not.toBeInTheDocument();
+  });
+});
+
+describe("ContactEmail — sending a code", () => {
+  it("Verify calls sendcontactemailverification with the bearer token, then opens the code form", async () => {
+    global.fetch.mockResolvedValue({ ok: true, json: () => Promise.resolve({ success: true }) });
+
+    renderComponent({ contactEmail: "researcher@example.edu", contactEmailVerified: false });
+    fireEvent.click(screen.getByRole("button", { name: /^Verify$/i }));
+
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+    const [url, options] = global.fetch.mock.calls[0];
+    expect(url).toBe("/api/sendcontactemailverification");
+    expect(options.method).toBe("POST");
+    expect(options.headers.Authorization).toBe("Bearer id-token-123");
+    expect(mockGetIdToken).toHaveBeenCalled();
+
+    expect(await screen.findByLabelText(/Verification code/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Enter the 6-digit code we sent to researcher@example\.edu/i)
+    ).toBeInTheDocument();
+    // The Verify button that triggered the send is gone once the form is
+    // open -- Resend (inside the form) replaces it.
+    expect(screen.queryByRole("button", { name: /^Verify$/i })).not.toBeInTheDocument();
+  });
+
+  it("a send failure (e.g. no contact email) is shown via FormErrorAlert, in human copy, and does not open the form", async () => {
+    global.fetch.mockResolvedValue({
+      ok: false,
+      json: () =>
+        Promise.resolve({
+          error: "Add a contact email address before requesting a code.",
+          code: "no-contact-email",
+        }),
+    });
+
+    renderComponent({ contactEmail: "researcher@example.edu", contactEmailVerified: false });
+    fireEvent.click(screen.getByRole("button", { name: /^Verify$/i }));
+
+    expect(
+      await screen.findByText(/Add a contact email address before requesting a code/i)
+    ).toBeInTheDocument();
+    // The raw machine code must never reach the page.
+    expect(screen.queryByText(/no-contact-email/i)).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/Verification code/i)).not.toBeInTheDocument();
+  });
+
+  it("a rate-limited resend still opens the code form -- a code is already out there and usable", async () => {
+    global.fetch.mockResolvedValue({
+      ok: false,
+      status: 429,
+      json: () =>
+        Promise.resolve({
+          error: "Please wait a moment before requesting another code.",
+          code: "rate-limited",
+        }),
+    });
+
+    renderComponent({ contactEmail: "researcher@example.edu", contactEmailVerified: false });
+    fireEvent.click(screen.getByRole("button", { name: /^Verify$/i }));
+
+    expect(await screen.findByLabelText(/Verification code/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Please wait a moment before requesting another code/i)
+    ).toBeInTheDocument();
+  });
+});
+
+describe("ContactEmail — entering a code", () => {
+  async function openCodeForm() {
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ success: true }),
+    });
+    renderComponent({ contactEmail: "researcher@example.edu", contactEmailVerified: false });
+    fireEvent.click(screen.getByRole("button", { name: /^Verify$/i }));
+    await screen.findByLabelText(/Verification code/i);
+  }
+
+  it("Confirm calls verifycontactemail with the bearer token and the entered code", async () => {
+    await openCodeForm();
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ success: true }),
+    });
+
+    fireEvent.change(screen.getByLabelText(/Verification code/i), {
+      target: { value: "482913" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^Confirm$/i }));
+
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(2));
+    const [url, options] = global.fetch.mock.calls[1];
+    expect(url).toBe("/api/verifycontactemail");
+    expect(options.method).toBe("POST");
+    expect(options.headers.Authorization).toBe("Bearer id-token-123");
+    expect(JSON.parse(options.body)).toEqual({ code: "482913" });
+
+    // Success closes the form; contactEmailVerified itself flips only via
+    // the parent's live users/{uid} subscription (a prop update this test
+    // does not simulate), so the form closing is the observable effect here.
+    await waitFor(() =>
+      expect(screen.queryByLabelText(/Verification code/i)).not.toBeInTheDocument()
+    );
+  });
+
+  it("non-digit input is stripped and the field is capped at 6 characters", async () => {
+    await openCodeForm();
+
+    const input = screen.getByLabelText(/Verification code/i);
+    fireEvent.change(input, { target: { value: "4a8b2c913x" } });
+
+    expect(input.value).toBe("482913");
+  });
+
+  it("a wrong-code failure surfaces through FormErrorAlert with human copy, never the raw error code", async () => {
+    await openCodeForm();
+    global.fetch.mockResolvedValueOnce({
+      ok: false,
+      json: () => Promise.resolve({ error: "That code is incorrect.", code: "invalid-code" }),
+    });
+
+    fireEvent.change(screen.getByLabelText(/Verification code/i), {
+      target: { value: "000001" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^Confirm$/i }));
+
+    expect(await screen.findByText(/That code is incorrect/i)).toBeInTheDocument();
+    expect(screen.queryByText(/invalid-code/i)).not.toBeInTheDocument();
+    // Stays open so the researcher can retry without re-requesting a code.
+    expect(screen.getByLabelText(/Verification code/i)).toBeInTheDocument();
+  });
+
+  it("an expired-code failure maps to its own human sentence", async () => {
+    await openCodeForm();
+    global.fetch.mockResolvedValueOnce({
+      ok: false,
+      json: () => Promise.resolve({ error: "That code has expired.", code: "expired" }),
+    });
+
+    fireEvent.change(screen.getByLabelText(/Verification code/i), {
+      target: { value: "000001" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^Confirm$/i }));
+
+    expect(await screen.findByText(/expired. Request a new one/i)).toBeInTheDocument();
+  });
+
+  it("submitting fewer than 6 digits is refused client-side, with no request sent", async () => {
+    await openCodeForm();
+    global.fetch.mockClear();
+
+    fireEvent.change(screen.getByLabelText(/Verification code/i), {
+      target: { value: "42" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^Confirm$/i }));
+
+    // Exact string: the helper line says "Enter the 6-digit code we sent
+    // to..." so a loose regex would double-match.
+    expect(await screen.findByText("Enter the 6-digit code.")).toBeInTheDocument();
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("Resend re-calls sendcontactemailverification and clears the entered code", async () => {
+    await openCodeForm();
+    fireEvent.change(screen.getByLabelText(/Verification code/i), {
+      target: { value: "111111" },
+    });
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ success: true }),
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /^Resend$/i }));
+
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(2));
+    expect(global.fetch.mock.calls[1][0]).toBe("/api/sendcontactemailverification");
+    await waitFor(() => expect(screen.getByLabelText(/Verification code/i).value).toBe(""));
+  });
+
+  it("Cancel closes the form without calling verify", async () => {
+    await openCodeForm();
+    global.fetch.mockClear();
+
+    fireEvent.click(screen.getByRole("button", { name: /^Cancel$/i }));
+
+    expect(screen.queryByLabelText(/Verification code/i)).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^Verify$/i })).toBeInTheDocument();
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/firestore-rules.test.js
+++ b/__tests__/firestore-rules.test.js
@@ -480,3 +480,437 @@ describe('/experiments — provider-migration generalization (step 7a)', () => {
     });
   });
 });
+
+// ---------------------------------------------------------------------------
+// P0 of the contact-email + upload-failure-notification work.
+//
+// Two independent rule changes, plus the collections that are protected by
+// having NO rule at all:
+//
+//   users/{uid}   -- the contactEmail group becomes client-writable, but
+//                    contactEmailVerified only ever as false.
+//   experiments/{id} -- uploadFailure joins serverManagedFieldsUntouched().
+//   contactEmailVerifications/{uid}, mail/{id} -- unmatched, default-denied.
+//
+// Every test below uses a uid/docId of its own. Nothing in this suite is
+// cleaned up between tests, so reusing 'user123' would mean asserting against
+// whatever an earlier test left on that document.
+// ---------------------------------------------------------------------------
+describe('contact email (P0)', () => {
+  // The slim shape ensureUserDocument writes, before any contact fields.
+  function slimUser(uid, overrides = {}) {
+    return { uid, email: 'researcher@example.edu', experiments: [], ...overrides };
+  }
+
+  // Seed shape for the UPDATE tests, and the reason it is not slimUser:
+  // isAccountCreation() tests the SHAPE of request.resource.data, not whether
+  // the document already exists. On an update, request.resource.data is the
+  // merged document -- so any update to a document whose whole merged shape
+  // still fits the creation whitelist is permitted by isAccountCreation(),
+  // whatever it touches. (That is pre-existing behaviour, not something this
+  // change introduced.) connectedAccounts is outside the whitelist and sits on
+  // real migrated user documents, so seeding it here forces every assertion
+  // below to be decided by isContactEmailUpdate() -- which is the rule under
+  // test. Without it, several of these would pass or fail for the wrong reason.
+  function existingUser(uid, overrides = {}) {
+    return slimUser(uid, {
+      connectedAccounts: { gdrive: { authMethod: 'oauth2' } },
+      ...overrides,
+    });
+  }
+
+  describe('account creation', () => {
+    it('ALLOWS the seeded shape carrying the contactEmail group', async () => {
+      const uid = 'ce-create-seeded';
+      const ctx = testEnv.authenticatedContext(uid);
+
+      await assertSucceeds(setDoc(doc(ctx.firestore(), `users/${uid}`), slimUser(uid, {
+        contactEmail: 'researcher@example.edu',
+        contactEmailVerified: false,
+        contactEmailUpdatedAt: 1700000000000,
+        contactEmailSource: 'auth',
+      })));
+    });
+
+    it('ALLOWS the slim shape with no contact fields at all (ORCID signup)', async () => {
+      // contactEmail is NOT in hasAll() -- an account with no address to seed
+      // must still be creatable; it meets the gate on its first /admin load.
+      const uid = 'ce-create-slim';
+      const ctx = testEnv.authenticatedContext(uid);
+
+      await assertSucceeds(
+        setDoc(doc(ctx.firestore(), `users/${uid}`), slimUser(uid, { email: '' }))
+      );
+    });
+
+    it('DENIES a creation that self-certifies contactEmailVerified: true', async () => {
+      // The whole point of the field: only the server may ever set it true.
+      const uid = 'ce-create-verified';
+      const ctx = testEnv.authenticatedContext(uid);
+
+      await assertFails(setDoc(doc(ctx.firestore(), `users/${uid}`), slimUser(uid, {
+        contactEmail: 'researcher@example.edu',
+        contactEmailVerified: true,
+      })));
+    });
+
+    it('DENIES a creation carrying an unlisted key alongside the contact group', async () => {
+      // hasOnly() gained four keys, not a general amnesty.
+      const uid = 'ce-create-extra-key';
+      const ctx = testEnv.authenticatedContext(uid);
+
+      await assertFails(setDoc(doc(ctx.firestore(), `users/${uid}`), slimUser(uid, {
+        contactEmail: 'researcher@example.edu',
+        connectedAccounts: { gdrive: { authMethod: 'oauth2' } },
+      })));
+    });
+  });
+
+  describe('contactEmail updates', () => {
+    it('ALLOWS the four-key update the gate writes', async () => {
+      const uid = 'ce-update-ok';
+      await seedDB({ [`users/${uid}`]: existingUser(uid, { contactEmail: '', contactEmailVerified: false }) });
+
+      const ctx = testEnv.authenticatedContext(uid);
+      await assertSucceeds(updateDoc(doc(ctx.firestore(), `users/${uid}`), {
+        contactEmail: 'lab-data@university.edu',
+        contactEmailVerified: false,
+        contactEmailUpdatedAt: 1700000000000,
+        contactEmailSource: 'user',
+      }));
+    });
+
+    it('ALLOWS a first-ever address on a document that has no contactEmailVerified field', async () => {
+      // The `in` guard in contactEmailNotSelfCertified(). Reading a missing
+      // key would otherwise error and deny a perfectly legitimate write --
+      // every pre-feature user document is in exactly this state.
+      const uid = 'ce-update-no-flag-field';
+      await seedDB({ [`users/${uid}`]: existingUser(uid) });
+
+      const ctx = testEnv.authenticatedContext(uid);
+      await assertSucceeds(updateDoc(doc(ctx.firestore(), `users/${uid}`), {
+        contactEmail: 'first@example.edu',
+        contactEmailUpdatedAt: 1700000000000,
+        contactEmailSource: 'user',
+      }));
+    });
+
+    it('ALLOWS changing the address while flipping verified back to false', async () => {
+      // The intended flow off a confirmed address: a new address is by
+      // definition unconfirmed, and the client is the one that says so.
+      const uid = 'ce-update-reverify';
+      await seedDB({
+        [`users/${uid}`]: existingUser(uid, {
+          contactEmail: 'old@example.edu',
+          contactEmailVerified: true,
+        }),
+      });
+
+      const ctx = testEnv.authenticatedContext(uid);
+      await assertSucceeds(updateDoc(doc(ctx.firestore(), `users/${uid}`), {
+        contactEmail: 'new@example.edu',
+        contactEmailVerified: false,
+        contactEmailUpdatedAt: 1700000000001,
+        contactEmailSource: 'user',
+      }));
+    });
+
+    it('DENIES setting contactEmailVerified: true', async () => {
+      const uid = 'ce-update-selfcertify';
+      await seedDB({
+        [`users/${uid}`]: existingUser(uid, {
+          contactEmail: 'researcher@example.edu',
+          contactEmailVerified: false,
+        }),
+      });
+
+      const ctx = testEnv.authenticatedContext(uid);
+      await assertFails(updateDoc(doc(ctx.firestore(), `users/${uid}`), {
+        contactEmailVerified: true,
+      }));
+    });
+
+    it('DENIES changing the address while leaving an existing verified: true standing', async () => {
+      // The post-state test, not the diff test. request.resource.data is the
+      // MERGED document on an update, so a write that touches only
+      // contactEmail on an already-verified account would carry `true`
+      // forward against an address nobody has confirmed.
+      const uid = 'ce-update-carryover';
+      await seedDB({
+        [`users/${uid}`]: existingUser(uid, {
+          contactEmail: 'old@example.edu',
+          contactEmailVerified: true,
+        }),
+      });
+
+      const ctx = testEnv.authenticatedContext(uid);
+      await assertFails(updateDoc(doc(ctx.firestore(), `users/${uid}`), {
+        contactEmail: 'new@example.edu',
+        contactEmailUpdatedAt: 1700000000002,
+      }));
+    });
+
+    it('DENIES touching contactEmail and experiments in one operation', async () => {
+      // One narrow shape per intent: a contact-email save must not be a
+      // vehicle for anything else on the document.
+      const uid = 'ce-update-plus-experiments';
+      await seedDB({ [`users/${uid}`]: existingUser(uid, { experiments: ['exp1'] }) });
+
+      const ctx = testEnv.authenticatedContext(uid);
+      await assertFails(updateDoc(doc(ctx.firestore(), `users/${uid}`), {
+        contactEmail: 'researcher@example.edu',
+        contactEmailVerified: false,
+        experiments: ['exp1', 'exp2'],
+      }));
+    });
+
+    it('DENIES an address longer than 254 characters', async () => {
+      const uid = 'ce-update-too-long';
+      await seedDB({ [`users/${uid}`]: existingUser(uid) });
+
+      const ctx = testEnv.authenticatedContext(uid);
+      await assertFails(updateDoc(doc(ctx.firestore(), `users/${uid}`), {
+        contactEmail: `${'a'.repeat(250)}@example.edu`,
+        contactEmailVerified: false,
+      }));
+    });
+
+    it('DENIES an empty contactEmail', async () => {
+      const uid = 'ce-update-empty';
+      await seedDB({ [`users/${uid}`]: existingUser(uid, { contactEmail: 'researcher@example.edu' }) });
+
+      const ctx = testEnv.authenticatedContext(uid);
+      await assertFails(updateDoc(doc(ctx.firestore(), `users/${uid}`), {
+        contactEmail: '',
+        contactEmailVerified: false,
+      }));
+    });
+
+    it('DENIES a non-string contactEmail', async () => {
+      const uid = 'ce-update-nonstring';
+      await seedDB({ [`users/${uid}`]: existingUser(uid) });
+
+      const ctx = testEnv.authenticatedContext(uid);
+      await assertFails(updateDoc(doc(ctx.firestore(), `users/${uid}`), {
+        contactEmail: 12345,
+        contactEmailVerified: false,
+      }));
+    });
+
+    it('DENIES writing another user\'s contact email', async () => {
+      const uid = 'ce-update-victim';
+      await seedDB({ [`users/${uid}`]: existingUser(uid) });
+
+      const attacker = testEnv.authenticatedContext('ce-update-attacker');
+      await assertFails(updateDoc(doc(attacker.firestore(), `users/${uid}`), {
+        contactEmail: 'attacker@example.com',
+        contactEmailVerified: false,
+      }));
+    });
+  });
+
+  // The three shapes that existed before this change must keep working
+  // exactly as they did. isContactEmailUpdate() is a fourth alternative in the
+  // same disjunction, and a fourth alternative is the easiest place in a rules
+  // file to accidentally narrow the other three.
+  describe('legacy write shapes still work (regression)', () => {
+    it('ALLOWS the OSF-era account-creation shape', async () => {
+      const uid = 'ce-legacy-create';
+      const ctx = testEnv.authenticatedContext(uid);
+
+      await assertSucceeds(setDoc(doc(ctx.firestore(), `users/${uid}`), {
+        uid,
+        email: 'researcher@example.edu',
+        experiments: [],
+        osfToken: '',
+        osfTokenValid: false,
+        usingPersonalToken: false,
+        createdAt: 1700000000000,
+      }));
+    });
+
+    it('ALLOWS a usingPersonalToken-only update', async () => {
+      const uid = 'ce-legacy-token-method';
+      await seedDB({ [`users/${uid}`]: existingUser(uid, { usingPersonalToken: false }) });
+
+      const ctx = testEnv.authenticatedContext(uid);
+      await assertSucceeds(
+        updateDoc(doc(ctx.firestore(), `users/${uid}`), { usingPersonalToken: true })
+      );
+    });
+
+    it('ALLOWS an experiments-only update', async () => {
+      const uid = 'ce-legacy-experiments';
+      await seedDB({ [`users/${uid}`]: existingUser(uid, { experiments: ['exp1'] }) });
+
+      const ctx = testEnv.authenticatedContext(uid);
+      await assertSucceeds(
+        updateDoc(doc(ctx.firestore(), `users/${uid}`), { experiments: ['exp1', 'exp2'] })
+      );
+    });
+  });
+
+  // No rule matches either collection, so Firestore default-denies them. These
+  // tests exist because that protection is invisible in the rules file: the
+  // verification code hash MUST NOT be reachable by the person being verified,
+  // and `allow read` on users/{uid} hands the owner their whole document --
+  // which is precisely why the hash lives in its own collection instead.
+  describe('server-only collections are unreachable from any client', () => {
+    it('DENIES the owner reading their own contactEmailVerifications document', async () => {
+      const uid = 'ce-verif-owner';
+      await seedDB({
+        [`contactEmailVerifications/${uid}`]: {
+          emailHash: 'deadbeef',
+          codeHash: 'cafebabe',
+          expiresAt: 1700000000000,
+          attempts: 0,
+          sentAt: 1699999999999,
+        },
+      });
+
+      const ctx = testEnv.authenticatedContext(uid);
+      await assertFails(getDoc(doc(ctx.firestore(), `contactEmailVerifications/${uid}`)));
+    });
+
+    it('DENIES the owner writing their own contactEmailVerifications document', async () => {
+      // Writable would be as bad as readable: a client could install a code
+      // hash it knows and then "verify" any address it likes.
+      const uid = 'ce-verif-owner-write';
+      const ctx = testEnv.authenticatedContext(uid);
+
+      await assertFails(setDoc(doc(ctx.firestore(), `contactEmailVerifications/${uid}`), {
+        codeHash: 'known-to-the-client',
+        attempts: 0,
+      }));
+    });
+
+    it('DENIES reading another user\'s contactEmailVerifications document', async () => {
+      await seedDB({
+        'contactEmailVerifications/ce-verif-victim': { codeHash: 'cafebabe', attempts: 0 },
+      });
+
+      const ctx = testEnv.authenticatedContext('ce-verif-snooper');
+      await assertFails(
+        getDoc(doc(ctx.firestore(), 'contactEmailVerifications/ce-verif-victim'))
+      );
+    });
+
+    it('DENIES clients reading or writing the mail collection', async () => {
+      // mail documents hold researchers' addresses and the message bodies the
+      // Trigger Email extension will send.
+      await seedDB({
+        'mail/ce-mail-doc': {
+          to: ['researcher@example.edu'],
+          message: { subject: 'x', text: 'y' },
+          datapipe: { kind: 'upload-failure', owner: 'ce-mail-owner' },
+        },
+      });
+
+      const ctx = testEnv.authenticatedContext('ce-mail-owner');
+      await assertFails(getDoc(doc(ctx.firestore(), 'mail/ce-mail-doc')));
+      await assertFails(getDocs(collection(ctx.firestore(), 'mail')));
+      await assertFails(setDoc(doc(ctx.firestore(), 'mail/ce-mail-forged'), {
+        to: ['someone-else@example.com'],
+        message: { subject: 'x', text: 'y' },
+      }));
+    });
+  });
+});
+
+// experiments/{id}.uploadFailure -- the notifier's armed flag. Written only by
+// the Admin SDK (functions/src/upload-failure-notify.ts), which bypasses these
+// rules; what is being tested here is that the CLIENT SDK path cannot touch
+// it. A researcher able to clear notifiedAt would re-arm the notifier and get
+// mailed once per failed FILE -- twenty mails from one participant
+// submission -- which is the exact failure mode the feature exists to prevent.
+describe('/experiments — uploadFailure is server-managed (P0)', () => {
+  function experimentFields(overrides = {}) {
+    return {
+      active: true,
+      activeBase64: false,
+      activeConditionAssignment: false,
+      id: overrides.id,
+      owner: overrides.owner,
+      title: 'Test experiment',
+      sessions: 0,
+      nConditions: 1,
+      currentCondition: 0,
+      useValidation: true,
+      allowJSON: true,
+      allowCSV: true,
+      requiredFields: [],
+      maxSessions: 1,
+      limitSessions: false,
+      storageProvider: 'gdrive',
+      providerContainer: { provider: 'gdrive', folderId: 'folder-abc' },
+      ...overrides,
+    };
+  }
+
+  it('DENIES a client update that writes uploadFailure', async () => {
+    const docId = 'exp-uploadfailure-forge';
+    await seedDB({
+      [`experiments/${docId}`]: experimentFields({ id: docId, owner: 'uf-user' }),
+    });
+
+    const ctx = testEnv.authenticatedContext('uf-user');
+    await assertFails(
+      updateDoc(doc(ctx.firestore(), `experiments/${docId}`), {
+        uploadFailure: { notifiedAt: null, failureCount: 0 },
+      })
+    );
+  });
+
+  it('DENIES a client update that clears uploadFailure.notifiedAt', async () => {
+    // The re-arm attack, written the way a client actually would: a dotted
+    // field path. affectedKeys() reports the TOP-LEVEL key, so this is caught
+    // by the same list entry.
+    const docId = 'exp-uploadfailure-rearm';
+    await seedDB({
+      [`experiments/${docId}`]: experimentFields({
+        id: docId,
+        owner: 'uf-user',
+        uploadFailure: { notifiedAt: new Date(), failureCount: 3 },
+      }),
+    });
+
+    const ctx = testEnv.authenticatedContext('uf-user');
+    await assertFails(
+      updateDoc(doc(ctx.firestore(), `experiments/${docId}`), {
+        'uploadFailure.notifiedAt': null,
+      })
+    );
+  });
+
+  it('DENIES a create that arrives already carrying uploadFailure', async () => {
+    const docId = 'exp-uploadfailure-create';
+    const ctx = testEnv.authenticatedContext('uf-user');
+
+    await assertFails(
+      setDoc(doc(ctx.firestore(), `experiments/${docId}`), experimentFields({
+        id: docId,
+        owner: 'uf-user',
+        uploadFailure: { notifiedAt: null },
+      }))
+    );
+  });
+
+  it('ALLOWS ordinary edits on an experiment that HAS uploadFailure', async () => {
+    // Regression guard for the rule change itself: the dashboard's writers
+    // (ExperimentActive.js, ExperimentValidation.js) are narrow merge writes,
+    // so the presence of a protected field must not make them fail.
+    const docId = 'exp-uploadfailure-ordinary-edit';
+    await seedDB({
+      [`experiments/${docId}`]: experimentFields({
+        id: docId,
+        owner: 'uf-user',
+        uploadFailure: { notifiedAt: new Date(), failureCount: 3 },
+      }),
+    });
+
+    const ctx = testEnv.authenticatedContext('uf-user');
+    await assertSucceeds(
+      updateDoc(doc(ctx.firestore(), `experiments/${docId}`), { active: false })
+    );
+  });
+});

--- a/__tests__/new-experiment-page.test.jsx
+++ b/__tests__/new-experiment-page.test.jsx
@@ -120,7 +120,7 @@ beforeEach(() => {
 describe("NewExperimentPage — OSF is closed to new experiments", () => {
   it("2. offers no OSF option and no OSF form, even for a researcher with a live OSF connection", () => {
     useDocumentData.mockReturnValue([
-      { refreshToken: "osf-refresh-token", usingPersonalToken: false },
+      { contactEmail: "researcher@example.edu", refreshToken: "osf-refresh-token", usingPersonalToken: false },
       false,
       undefined,
     ]);
@@ -139,7 +139,7 @@ describe("NewExperimentPage — OSF is closed to new experiments", () => {
 
   it("2b. defaults to the first registered storage provider instead of OSF", () => {
     useDocumentData.mockReturnValue([
-      { connectedAccounts: { gdrive: true } },
+      { contactEmail: "researcher@example.edu", connectedAccounts: { gdrive: true } },
       false,
       undefined,
     ]);
@@ -165,6 +165,7 @@ describe("NewExperimentPage — Google Drive provider selector", () => {
   it("3. selecting Google Drive with no connection shows a connect CTA, no title-only submit", async () => {
     useDocumentData.mockReturnValue([
       {
+        contactEmail: "researcher@example.edu",
         refreshToken: "osf-refresh-token",
         connectedAccounts: {},
       },
@@ -190,6 +191,7 @@ describe("NewExperimentPage — Google Drive provider selector", () => {
   it("4. selecting Google Drive while connected shows only the title field + create button", async () => {
     useDocumentData.mockReturnValue([
       {
+        contactEmail: "researcher@example.edu",
         refreshToken: "osf-refresh-token",
         connectedAccounts: { gdrive: true },
       },
@@ -213,6 +215,7 @@ describe("NewExperimentPage — Google Drive provider selector", () => {
   it("5. gdrive submit calls /api/createexperiment and navigates to /admin/<id> on success", async () => {
     useDocumentData.mockReturnValue([
       {
+        contactEmail: "researcher@example.edu",
         refreshToken: "osf-refresh-token",
         connectedAccounts: { gdrive: true },
       },
@@ -261,6 +264,7 @@ describe("NewExperimentPage — Google Drive provider selector", () => {
   it("6. gdrive submit failure renders an error message and does not navigate", async () => {
     useDocumentData.mockReturnValue([
       {
+        contactEmail: "researcher@example.edu",
         refreshToken: "osf-refresh-token",
         connectedAccounts: { gdrive: true },
       },
@@ -317,7 +321,7 @@ describe("NewExperimentPage — Dataverse provider (provider-generic rendering)"
 
   it("the provider selector offers Dataverse", () => {
     useDocumentData.mockReturnValue([
-      { refreshToken: "osf-refresh-token", connectedAccounts: {} },
+      { contactEmail: "researcher@example.edu", refreshToken: "osf-refresh-token", connectedAccounts: {} },
       false,
       undefined,
     ]);
@@ -329,7 +333,7 @@ describe("NewExperimentPage — Dataverse provider (provider-generic rendering)"
 
   it("selecting Dataverse with no connection shows the connect CTA and no create form", async () => {
     useDocumentData.mockReturnValue([
-      { refreshToken: "osf-refresh-token", connectedAccounts: {} },
+      { contactEmail: "researcher@example.edu", refreshToken: "osf-refresh-token", connectedAccounts: {} },
       false,
       undefined,
     ]);
@@ -352,6 +356,7 @@ describe("NewExperimentPage — Dataverse provider (provider-generic rendering)"
   it("selecting a CONNECTED Dataverse renders the declared fields alongside Title", async () => {
     useDocumentData.mockReturnValue([
       {
+        contactEmail: "researcher@example.edu",
         refreshToken: "osf-refresh-token",
         connectedAccounts: { dataverse: true },
       },
@@ -374,6 +379,7 @@ describe("NewExperimentPage — Dataverse provider (provider-generic rendering)"
   it("submitting with a required field blank does NOT call the API", async () => {
     useDocumentData.mockReturnValue([
       {
+        contactEmail: "researcher@example.edu",
         refreshToken: "osf-refresh-token",
         connectedAccounts: { dataverse: true },
       },
@@ -412,6 +418,7 @@ describe("NewExperimentPage — Dataverse provider (provider-generic rendering)"
   it("a full submit calls /api/createexperiment with researcherInput carrying exactly the five declared fields, and navigates on success", async () => {
     useDocumentData.mockReturnValue([
       {
+        contactEmail: "researcher@example.edu",
         refreshToken: "osf-refresh-token",
         connectedAccounts: { dataverse: true },
       },
@@ -469,6 +476,7 @@ describe("NewExperimentPage — Dataverse provider (provider-generic rendering)"
     // otherwise a Drive folder id rides along on a Dataverse request.
     useDocumentData.mockReturnValue([
       {
+        contactEmail: "researcher@example.edu",
         refreshToken: "osf-refresh-token",
         connectedAccounts: { dataverse: true, gdrive: true },
       },
@@ -521,6 +529,7 @@ describe("NewExperimentPage — Dataverse provider (provider-generic rendering)"
   it("switching provider away and back clears the entered values (no stale carry-over)", async () => {
     useDocumentData.mockReturnValue([
       {
+        contactEmail: "researcher@example.edu",
         refreshToken: "osf-refresh-token",
         connectedAccounts: { dataverse: true, gdrive: true },
       },
@@ -548,7 +557,7 @@ describe("NewExperimentPage — Dataverse provider (provider-generic rendering)"
 describe("NewExperimentPage — provider setup warnings (Dataverse)", () => {
   it("selecting a connected Dataverse shows a warning returned by /api/providersetupwarnings", async () => {
     useDocumentData.mockReturnValue([
-      { refreshToken: "osf-refresh-token", connectedAccounts: { dataverse: true } },
+      { contactEmail: "researcher@example.edu", refreshToken: "osf-refresh-token", connectedAccounts: { dataverse: true } },
       false,
       undefined,
     ]);
@@ -580,7 +589,7 @@ describe("NewExperimentPage — provider setup warnings (Dataverse)", () => {
 
   it("an empty warnings array shows nothing", async () => {
     useDocumentData.mockReturnValue([
-      { refreshToken: "osf-refresh-token", connectedAccounts: { dataverse: true } },
+      { contactEmail: "researcher@example.edu", refreshToken: "osf-refresh-token", connectedAccounts: { dataverse: true } },
       false,
       undefined,
     ]);
@@ -607,7 +616,7 @@ describe("NewExperimentPage — provider setup warnings (Dataverse)", () => {
 
   it("a failed warnings fetch is silent -- the form still renders and submission is not blocked", async () => {
     useDocumentData.mockReturnValue([
-      { refreshToken: "osf-refresh-token", connectedAccounts: { dataverse: true } },
+      { contactEmail: "researcher@example.edu", refreshToken: "osf-refresh-token", connectedAccounts: { dataverse: true } },
       false,
       undefined,
     ]);

--- a/components/AuthCheck.js
+++ b/components/AuthCheck.js
@@ -1,10 +1,25 @@
 import { useContext, useEffect } from "react";
 import { Spinner, Center } from "@chakra-ui/react";
+import { doc } from "firebase/firestore";
+import { useDocumentData } from "react-firebase-hooks/firestore";
 import { UserContext } from "../lib/context";
+import { db } from "../lib/firebase";
+import { hasContactEmail } from "../lib/contact-email";
+import ContactEmailGate from "./ContactEmailGate";
 import SignInForm from "./SignInForm";
 import { useRouter } from "next/router";
 
-export default function AuthCheck({ children, fallback, fallbackRoute }) {
+// requireContactEmail defaults to true: every admin route is walled off
+// until the signed-in researcher has a usable contactEmail EXCEPT
+// /admin/account, which passes requireContactEmail={false} so the account
+// deletion control is never itself stuck behind the gate it exists to let a
+// researcher get past (see components/ContactEmailGate.js).
+export default function AuthCheck({
+  children,
+  fallback,
+  fallbackRoute,
+  requireContactEmail = true,
+}) {
   const router = useRouter();
   const { user, loading } = useContext(UserContext);
 
@@ -14,11 +29,38 @@ export default function AuthCheck({ children, fallback, fallbackRoute }) {
     }
   }, [user, router, fallbackRoute]);
 
+  // Only subscribed when there is a signed-in uid and the route actually
+  // requires the gate -- `doc()` is passed `null` otherwise, which is
+  // react-firebase-hooks' own "don't subscribe" signal, same pattern as
+  // pages/admin/account.js and pages/admin/new.js.
+  const shouldWatchContactEmail = requireContactEmail && !!user?.uid;
+  const [userDoc, userDocLoading, userDocError] = useDocumentData(
+    shouldWatchContactEmail ? doc(db, "users", user.uid) : null
+  );
+
   if (loading || (user && !user.uid)) {
     return <Center py={8}><Spinner size="lg" color="brandGreen.solid" /></Center>;
   }
 
-  return (user && user.uid)
-    ? children
-    : fallback || <SignInForm routeAfterSignIn={router.pathname} />;
+  if (!(user && user.uid)) {
+    return fallback || <SignInForm routeAfterSignIn={router.pathname} />;
+  }
+
+  if (shouldWatchContactEmail) {
+    // Loading -> the existing spinner treatment, never children. A flash of
+    // the dashboard immediately followed by a wall is worse than a beat of
+    // spinner.
+    if (userDocLoading) {
+      return <Center py={8}><Spinner size="lg" color="brandGreen.solid" /></Center>;
+    }
+
+    // Read error -> fail open. The gate is a data-quality nudge, not a
+    // security boundary; a Firestore blip must not lock a researcher out of
+    // a running study.
+    if (!userDocError && !hasContactEmail(userDoc)) {
+      return <ContactEmailGate userDoc={userDoc} />;
+    }
+  }
+
+  return children;
 }

--- a/components/ContactEmailGate.js
+++ b/components/ContactEmailGate.js
@@ -1,0 +1,176 @@
+import { useContext, useState } from "react";
+import { Box, VStack, Heading, Text, Field, Input, Button, Center } from "@chakra-ui/react";
+import { doc, setDoc } from "firebase/firestore";
+import { UserContext } from "../lib/context";
+import { db } from "../lib/firebase";
+import FormErrorAlert from "./ui/FormErrorAlert";
+import {
+  isValidEmailFormat,
+  isSyntheticOsfEmail,
+  buildContactEmailUpdate,
+} from "../lib/contact-email";
+
+// The wall §2.3 of the plan decided on: rendered IN PLACE by AuthCheck when
+// a signed-in researcher's users/{uid} doc has no usable contactEmail, on
+// every admin route except /admin/account (AuthCheck's
+// requireContactEmail={false} there -- see pages/admin/account.js). Never a
+// modal, never a redirect: a redirect-based gate on four routes means four
+// redirect effects, a loop risk against AuthCheck's own fallbackRoute push,
+// and a URL the researcher can bookmark into. This renders in the layout,
+// with the navbar above it.
+//
+// No skip control. Sign-out stays reachable because the Navbar is mounted
+// OUTSIDE AuthCheck (pages/_app.js) -- this component must not render a
+// sign-out control of its own, and must not be a full-screen overlay that
+// hides that chrome.
+//
+// On a successful save this component does NOT navigate or force a
+// re-render itself: AuthCheck owns the users/{uid} subscription that
+// decided to render this gate in the first place, so the next snapshot
+// after the write re-evaluates hasContactEmail() and simply stops
+// rendering this component in favor of the page it was blocking.
+export default function ContactEmailGate({ userDoc }) {
+  const { user } = useContext(UserContext);
+
+  // Prefill computed ONCE, via a lazy initializer, so a later Firestore
+  // snapshot of userDoc (e.g. some unrelated field changing while this
+  // panel is open) never clobbers what the researcher has already typed.
+  const [email, setEmail] = useState(() => initialEmailFor(user, userDoc));
+  const [touched, setTouched] = useState(false);
+  const [formError, setFormError] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const trimmed = email.trim();
+  const formatValid = isValidEmailFormat(trimmed);
+
+  // The OSF-prefill hint only makes sense when the value on screen actually
+  // came from OSF -- i.e. there was no usable Auth email, and users/{uid}.email
+  // is a real, non-synthetic address. Recomputed from the same inputs as
+  // initialEmailFor rather than stored, so editing the field never leaves a
+  // stale hint pointing at a value that is no longer showing.
+  const showOsfHint =
+    !isValidEmailFormat((user?.email || "").trim()) &&
+    isValidEmailFormat((userDoc?.email || "").trim()) &&
+    !isSyntheticOsfEmail(userDoc?.email);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setTouched(true);
+    setFormError("");
+
+    if (!formatValid) return;
+
+    setIsSubmitting(true);
+    try {
+      // buildContactEmailUpdate() is the ONLY place this object is
+      // assembled -- it emits exactly the four keys
+      // firestore.rules' isContactEmailUpdate() allows
+      // (contactEmail, contactEmailVerified, contactEmailUpdatedAt,
+      // contactEmailSource), with contactEmailVerified always false so a
+      // client write can never self-certify an address.
+      await setDoc(
+        doc(db, "users", user.uid),
+        buildContactEmailUpdate(trimmed),
+        { merge: true }
+      );
+    } catch (err) {
+      setFormError(
+        "Could not save your email address. Check your connection and try again."
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Center py={8} px={4}>
+      <Box
+        as="form"
+        onSubmit={handleSubmit}
+        noValidate
+        w="100%"
+        maxW="560px"
+        bg="bg.panel"
+        borderWidth="1px"
+        borderColor="border"
+        borderRadius="lg"
+        p={8}
+      >
+        <VStack gap={4} align="stretch">
+          {/* Copy is verbatim from plan §2.3 -- consequence before
+              mechanism (PRODUCT.md principle 2). Do not paraphrase. */}
+          <Heading as="h1" size="lg" color="fg">
+            Add an email address
+          </Heading>
+
+          <Text color="fg.muted">
+            DataPipe needs a way to reach you if your data stops arriving.
+          </Text>
+
+          <Text color="fg.muted">
+            We email you when a data file fails to upload to your storage
+            provider, and if the service is disrupted. That is the only
+            thing this address is used for — no announcements, no mailing
+            list, and it is never shown to participants.
+          </Text>
+
+          <Field.Root invalid={touched && !formatValid}>
+            <Field.Label>Email address</Field.Label>
+            <Input
+              type="email"
+              autoComplete="email"
+              value={email}
+              onChange={(e) => {
+                setEmail(e.target.value);
+                setFormError("");
+              }}
+              onBlur={() => setTouched(true)}
+            />
+            <Field.ErrorText>Enter a valid email address.</Field.ErrorText>
+          </Field.Root>
+
+          {showOsfHint && (
+            <Text fontSize="sm" color="fg.muted">
+              This is the address we have from OSF — change it if it is
+              wrong.
+            </Text>
+          )}
+
+          <FormErrorAlert>{formError}</FormErrorAlert>
+
+          <Button
+            type="submit"
+            colorPalette="brandGreen"
+            loading={isSubmitting}
+            loadingText="Saving…"
+            w="full"
+            size="lg"
+          >
+            Save and continue
+          </Button>
+        </VStack>
+      </Box>
+    </Center>
+  );
+}
+
+// Prefill rules (plan §2.3): auth.currentUser.email wins when present
+// (email/password, Google, GitHub with a disclosed address). Otherwise
+// users/{uid}.email if it is a real, non-synthetic address -- the
+// OSF-API-supplied one the migration population already has on file. An
+// ORCID-only signup with no OSF history gets neither and sees an empty
+// field: the intended path, not a failure (see the SEEDING RULE in
+// lib/contact-email.js -- this prefill only ever reads from Auth or the
+// legacy OSF `email` field, and NEVER writes without the researcher
+// submitting the form).
+function initialEmailFor(user, userDoc) {
+  const authEmail = (user?.email || "").trim();
+  if (isValidEmailFormat(authEmail)) return authEmail;
+
+  const osfEmail = (userDoc?.email || "").trim();
+  if (isValidEmailFormat(osfEmail) && !isSyntheticOsfEmail(osfEmail)) {
+    return osfEmail;
+  }
+
+  return "";
+}

--- a/components/account/ContactEmail.js
+++ b/components/account/ContactEmail.js
@@ -1,0 +1,154 @@
+import { useContext, useState } from "react";
+import { Button, Field, HStack, Input, Text, VStack } from "@chakra-ui/react";
+import { doc, setDoc } from "firebase/firestore";
+import { UserContext } from "../../lib/context";
+import { db } from "../../lib/firebase";
+import FormErrorAlert from "../ui/FormErrorAlert";
+import StatusIndicator from "../ui/StatusIndicator";
+import { isValidEmailFormat, buildContactEmailUpdate } from "../../lib/contact-email";
+
+// Display + edit ONLY. The verification round trip (send/resend a code,
+// confirm it) is P3's -- see the SEAM comment below the StatusIndicator.
+// This is the same section AuthCheck's gate exists to get a researcher
+// PAST (components/ContactEmailGate.js); here it renders on a settled
+// page, in place, whether the address is set or not -- /admin/account is
+// exempt from the gate specifically so this control is never itself stuck
+// behind it.
+//
+// `data` is the users/{uid} doc, passed down from pages/admin/account.js's
+// single subscription -- same convention as ProviderConnections,
+// OAuthTokenStatus, and SelectAuth on this page. No subscription of its
+// own.
+export default function ContactEmail({ data }) {
+  const { user } = useContext(UserContext);
+  const [isEditing, setIsEditing] = useState(false);
+  const [email, setEmail] = useState("");
+  const [touched, setTouched] = useState(false);
+  const [formError, setFormError] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const currentEmail = (data?.contactEmail || "").trim();
+  const hasEmail = currentEmail.length > 0;
+  // contactEmailVerified is server-only in the TRUE direction (see
+  // firestore.rules / lib/contact-email.js), so this is trustworthy: a
+  // client can never have written `true` itself.
+  const isVerified = !!data?.contactEmailVerified;
+
+  const trimmed = email.trim();
+  const formatValid = isValidEmailFormat(trimmed);
+
+  const startEditing = () => {
+    setEmail(currentEmail);
+    setTouched(false);
+    setFormError("");
+    setIsEditing(true);
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setTouched(true);
+    setFormError("");
+    if (!formatValid) return;
+
+    setIsSubmitting(true);
+    try {
+      // buildContactEmailUpdate() is the ONLY place this object is
+      // assembled -- exactly the four keys firestore.rules'
+      // isContactEmailUpdate() allows, with contactEmailVerified always
+      // false so changing the address always resets confirmation rather
+      // than leaving `true` standing against a new, unconfirmed value.
+      await setDoc(
+        doc(db, "users", user.uid),
+        buildContactEmailUpdate(trimmed),
+        { merge: true }
+      );
+      setIsEditing(false);
+    } catch (err) {
+      setFormError(
+        "Could not save your email address. Check your connection and try again."
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  if (isEditing) {
+    return (
+      <VStack as="form" onSubmit={handleSubmit} gap={3} align="stretch" noValidate>
+        <Field.Root invalid={touched && !formatValid}>
+          <Field.Label>Email address</Field.Label>
+          <Input
+            type="email"
+            autoComplete="email"
+            value={email}
+            onChange={(e) => {
+              setEmail(e.target.value);
+              setFormError("");
+            }}
+            onBlur={() => setTouched(true)}
+          />
+          <Field.ErrorText>Enter a valid email address.</Field.ErrorText>
+        </Field.Root>
+
+        <FormErrorAlert>{formError}</FormErrorAlert>
+
+        <HStack>
+          <Button
+            type="submit"
+            colorPalette="brandGreen"
+            size="sm"
+            loading={isSubmitting}
+          >
+            Save
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setIsEditing(false)}
+            disabled={isSubmitting}
+          >
+            Cancel
+          </Button>
+        </HStack>
+      </VStack>
+    );
+  }
+
+  return (
+    <VStack gap={3} align="stretch">
+      <HStack justifyContent="space-between" w="100%" flexWrap="wrap" gap={3}>
+        <VStack align="start" gap={1}>
+          <Text fontSize="lg">
+            {hasEmail ? currentEmail : "No address on file"}
+          </Text>
+          {hasEmail &&
+            (isVerified ? (
+              <StatusIndicator status="ok" label="Confirmed" />
+            ) : (
+              // Unverified is a NEUTRAL state, not an error or a warning:
+              // an unconfirmed address still receives notifications (plan
+              // §2.2 -- DataPipe never gates on verification), so nothing
+              // is actually broken here. The Resend action that would
+              // make this actionable is P3's -- see the seam below.
+              <StatusIndicator status="neutral" label="Not confirmed yet" />
+            ))}
+        </VStack>
+        <Button colorPalette="brandGreen" size="sm" onClick={startEditing}>
+          {hasEmail ? "Change" : "Add email address"}
+        </Button>
+      </HStack>
+
+      {/* ---------------------------------------------------------------
+          SEAM FOR P3 -- do not build here.
+
+          The verification round trip renders in this spot, alongside the
+          StatusIndicator above: a "Resend" action next to "Not confirmed
+          yet", and the 6-digit code entry form it opens. P3 owns
+          functions/src/send-contact-email-verification.ts,
+          functions/src/verify-contact-email.ts, and
+          __tests__/contact-email-section.test.jsx. P1 (this file) is
+          display + edit only.
+         --------------------------------------------------------------- */}
+    </VStack>
+  );
+}

--- a/components/account/ContactEmail.js
+++ b/components/account/ContactEmail.js
@@ -2,23 +2,54 @@ import { useContext, useState } from "react";
 import { Button, Field, HStack, Input, Text, VStack } from "@chakra-ui/react";
 import { doc, setDoc } from "firebase/firestore";
 import { UserContext } from "../../lib/context";
-import { db } from "../../lib/firebase";
+import { auth, db } from "../../lib/firebase";
 import FormErrorAlert from "../ui/FormErrorAlert";
 import StatusIndicator from "../ui/StatusIndicator";
 import { isValidEmailFormat, buildContactEmailUpdate } from "../../lib/contact-email";
 
-// Display + edit ONLY. The verification round trip (send/resend a code,
-// confirm it) is P3's -- see the SEAM comment below the StatusIndicator.
-// This is the same section AuthCheck's gate exists to get a researcher
-// PAST (components/ContactEmailGate.js); here it renders on a settled
-// page, in place, whether the address is set or not -- /admin/account is
-// exempt from the gate specifically so this control is never itself stuck
+// Human copy for the verification endpoints' `code` field. Never rendered
+// verbatim -- functions/src/verify-contact-email.ts and
+// send-contact-email-verification.ts return a short machine code
+// ("invalid-code", "rate-limited", ...) specifically so this file can map it
+// to a sentence instead of parroting server jargon through FormErrorAlert.
+// `body.error` (the server's own human sentence) is the fallback for a code
+// not listed here, and a generic message is the fallback below that.
+const SEND_ERROR_COPY = {
+  "no-contact-email": "Add a contact email address before requesting a code.",
+  "rate-limited": "Please wait a moment before requesting another code.",
+};
+const VERIFY_ERROR_COPY = {
+  "invalid-code": "That code is incorrect. Check it and try again.",
+  expired: "That code has expired. Request a new one.",
+  "no-code-requested": "Request a new code before entering one.",
+  "too-many-attempts": "Too many incorrect attempts. Request a new code.",
+  "stale-address":
+    "This code was sent to a different address. Request a new code.",
+  "no-contact-email": "Add a contact email address before verifying.",
+};
+const GENERIC_ERROR = "Something went wrong. Please try again.";
+
+function humanError(body, copyMap) {
+  return (body && copyMap[body.code]) || (body && body.error) || GENERIC_ERROR;
+}
+
+// Display + edit + verify. The verification round trip (send/resend a code,
+// confirm it) is P3's -- this is the same section AuthCheck's gate exists to
+// get a researcher PAST (components/ContactEmailGate.js); here it renders on
+// a settled page, in place, whether the address is set or not -- /admin/account
+// is exempt from the gate specifically so this control is never itself stuck
 // behind it.
 //
 // `data` is the users/{uid} doc, passed down from pages/admin/account.js's
 // single subscription -- same convention as ProviderConnections,
 // OAuthTokenStatus, and SelectAuth on this page. No subscription of its
 // own.
+//
+// Verification NEVER gates on anything (plan §2.2): the moment
+// contactEmailVerified flips to true is decided entirely server-side, by
+// functions/src/verify-contact-email.ts checking a code hash this component
+// never sees. This component only ever reflects that flag back -- it cannot
+// set it, and does not try to.
 export default function ContactEmail({ data }) {
   const { user } = useContext(UserContext);
   const [isEditing, setIsEditing] = useState(false);
@@ -26,6 +57,16 @@ export default function ContactEmail({ data }) {
   const [touched, setTouched] = useState(false);
   const [formError, setFormError] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
+
+  // Verification round trip. Independent of the edit-form state above --
+  // switching into edit mode does not need to reset this, and code entry
+  // does not need to reset that.
+  const [showCodeForm, setShowCodeForm] = useState(false);
+  const [code, setCode] = useState("");
+  const [isSending, setIsSending] = useState(false);
+  const [isVerifying, setIsVerifying] = useState(false);
+  const [sendError, setSendError] = useState("");
+  const [verifyError, setVerifyError] = useState("");
 
   const currentEmail = (data?.contactEmail || "").trim();
   const hasEmail = currentEmail.length > 0;
@@ -63,6 +104,17 @@ export default function ContactEmail({ data }) {
         { merge: true }
       );
       setIsEditing(false);
+      // A saved address is always unverified (buildContactEmailUpdate always
+      // writes contactEmailVerified: false) and may not even be the same
+      // address a code was just sent to -- any in-flight code entry now
+      // refers to a stale address, so close it rather than let a correct
+      // code for the OLD address appear to still apply here. The server
+      // would refuse it anyway (verify-contact-email.ts's stale-address
+      // guard); this just avoids showing a form that can only fail.
+      setShowCodeForm(false);
+      setCode("");
+      setSendError("");
+      setVerifyError("");
     } catch (err) {
       setFormError(
         "Could not save your email address. Check your connection and try again."
@@ -70,6 +122,105 @@ export default function ContactEmail({ data }) {
     } finally {
       setIsSubmitting(false);
     }
+  };
+
+  // Shared by the initial "Verify" click and "Resend": ask the server to
+  // (re)send a code to whatever address it currently has on file for this
+  // account. Never sends the address itself -- the endpoint reads
+  // users/{uid}.contactEmail server-side, so there is nothing here for a
+  // compromised client to redirect.
+  const requestCode = async () => {
+    const idToken = await auth.currentUser.getIdToken();
+    const response = await fetch("/api/sendcontactemailverification", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${idToken}` },
+    });
+    const body = await response.json().catch(() => ({}));
+    if (!response.ok) {
+      // A rate-limited resend still means a code is already out there and
+      // usable -- keep (or open) the entry form so the researcher can use
+      // it, just with the cooldown message alongside it, rather than
+      // treating "you already have a valid code" as a dead end.
+      if (body.code === "rate-limited") {
+        setSendError(humanError(body, SEND_ERROR_COPY));
+        setShowCodeForm(true);
+        return;
+      }
+      throw new Error(humanError(body, SEND_ERROR_COPY));
+    }
+    setSendError("");
+    setShowCodeForm(true);
+  };
+
+  const handleSendClick = async () => {
+    setIsSending(true);
+    setSendError("");
+    try {
+      await requestCode();
+    } catch (err) {
+      setSendError(err.message || GENERIC_ERROR);
+    } finally {
+      setIsSending(false);
+    }
+  };
+
+  const handleResend = async () => {
+    setIsSending(true);
+    setSendError("");
+    setVerifyError("");
+    try {
+      await requestCode();
+      setCode("");
+    } catch (err) {
+      setSendError(err.message || GENERIC_ERROR);
+    } finally {
+      setIsSending(false);
+    }
+  };
+
+  const handleVerifySubmit = async (e) => {
+    e.preventDefault();
+    const trimmedCode = code.trim();
+    setVerifyError("");
+    if (!/^\d{6}$/.test(trimmedCode)) {
+      setVerifyError("Enter the 6-digit code.");
+      return;
+    }
+
+    setIsVerifying(true);
+    try {
+      const idToken = await auth.currentUser.getIdToken();
+      const response = await fetch("/api/verifycontactemail", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${idToken}`,
+        },
+        body: JSON.stringify({ code: trimmedCode }),
+      });
+      const body = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        throw new Error(humanError(body, VERIFY_ERROR_COPY));
+      }
+      // Success. contactEmailVerified flips to true server-side
+      // (verify-contact-email.ts); the account page's users/{uid}
+      // subscription picks that up on its own and this component
+      // re-renders into the "Confirmed" state -- nothing to set locally
+      // beyond closing the code form.
+      setShowCodeForm(false);
+      setCode("");
+    } catch (err) {
+      setVerifyError(err.message || GENERIC_ERROR);
+    } finally {
+      setIsVerifying(false);
+    }
+  };
+
+  const handleCancelCode = () => {
+    setShowCodeForm(false);
+    setCode("");
+    setSendError("");
+    setVerifyError("");
   };
 
   if (isEditing) {
@@ -128,9 +279,21 @@ export default function ContactEmail({ data }) {
               // Unverified is a NEUTRAL state, not an error or a warning:
               // an unconfirmed address still receives notifications (plan
               // §2.2 -- DataPipe never gates on verification), so nothing
-              // is actually broken here. The Resend action that would
-              // make this actionable is P3's -- see the seam below.
-              <StatusIndicator status="neutral" label="Not confirmed yet" />
+              // is actually broken here. The action beside it is "Verify",
+              // not framed as fixing a problem.
+              <HStack gap={2}>
+                <StatusIndicator status="neutral" label="Not confirmed yet" />
+                {!showCodeForm && (
+                  <Button
+                    variant="outline"
+                    size="xs"
+                    onClick={handleSendClick}
+                    loading={isSending}
+                  >
+                    Verify
+                  </Button>
+                )}
+              </HStack>
             ))}
         </VStack>
         <Button colorPalette="brandGreen" size="sm" onClick={startEditing}>
@@ -138,17 +301,73 @@ export default function ContactEmail({ data }) {
         </Button>
       </HStack>
 
-      {/* ---------------------------------------------------------------
-          SEAM FOR P3 -- do not build here.
+      {/* A send failure that never got as far as opening the code form --
+          e.g. no address on file at all (a stale render mid-save), or a
+          500. Once showCodeForm is true, the form's own FormErrorAlert
+          below takes over so there is only ever one error surface visible
+          at a time. */}
+      {hasEmail && !isVerified && !showCodeForm && sendError && (
+        <FormErrorAlert>{sendError}</FormErrorAlert>
+      )}
 
-          The verification round trip renders in this spot, alongside the
-          StatusIndicator above: a "Resend" action next to "Not confirmed
-          yet", and the 6-digit code entry form it opens. P3 owns
-          functions/src/send-contact-email-verification.ts,
-          functions/src/verify-contact-email.ts, and
-          __tests__/contact-email-section.test.jsx. P1 (this file) is
-          display + edit only.
-         --------------------------------------------------------------- */}
+      {hasEmail && !isVerified && showCodeForm && (
+        <VStack
+          as="form"
+          onSubmit={handleVerifySubmit}
+          align="stretch"
+          gap={2}
+          maxW="sm"
+          borderWidth="1px"
+          borderColor="border"
+          borderRadius="md"
+          p={3}
+        >
+          <Text fontSize="sm" color="fg.muted">
+            Enter the 6-digit code we sent to {currentEmail}.
+          </Text>
+          <HStack>
+            <Input
+              value={code}
+              onChange={(e) => {
+                setCode(e.target.value.replace(/\D/g, "").slice(0, 6));
+                setVerifyError("");
+              }}
+              placeholder="000000"
+              inputMode="numeric"
+              autoComplete="one-time-code"
+              aria-label="Verification code"
+              maxW="8em"
+              letterSpacing="0.2em"
+              textAlign="center"
+            />
+            <Button
+              type="submit"
+              colorPalette="brandGreen"
+              size="sm"
+              loading={isVerifying}
+            >
+              Confirm
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={handleResend}
+              disabled={isSending || isVerifying}
+            >
+              Resend
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={handleCancelCode}
+              disabled={isVerifying}
+            >
+              Cancel
+            </Button>
+          </HStack>
+          <FormErrorAlert>{verifyError || sendError}</FormErrorAlert>
+        </VStack>
+      )}
     </VStack>
   );
 }

--- a/docs/deploy-contact-email.md
+++ b/docs/deploy-contact-email.md
@@ -1,0 +1,150 @@
+# Deploying the contact-email feature
+
+Operational notes for rolling out required contact emails + first-failure
+upload notifications. See the design doc for the full architecture; this file
+covers only what changes at deploy time, in the order it needs to happen.
+
+## 1. Deploy order: rules before functions, and it is not optional
+
+```
+firebase deploy --only firestore:rules
+firebase deploy --only functions
+firebase deploy --only hosting
+```
+
+`firestore.rules` must go out **before** the functions and the frontend that
+depend on it, for two independent reasons:
+
+- **The contact-email gate's `setDoc` needs `isContactEmailUpdate()` to
+  exist.** Deploy the frontend first and a researcher who fills in the gate
+  gets a write rejected by the old rules — a silent-looking failure from
+  their side, since the client only sees "permission denied."
+- **`uploadFailure` needs to be in `serverManagedFieldsUntouched()`.** The
+  notification trigger writes `experiments/{id}.uploadFailure` with the Admin
+  SDK, which bypasses rules entirely — so the trigger itself is not blocked
+  by deploy order. What *is* blocked: the moment `uploadFailure` appears on
+  an experiment doc under the *old* rules, any client-side update to that
+  experiment (`ExperimentActive.js`, `ExperimentValidation.js`) that the old
+  rules validate with a stale field allowlist starts failing, because the
+  document now carries a key the old rules don't know to ignore.
+
+Both failure modes are silent-to-the-researcher permission errors, not
+crashes, which is exactly the kind of bug that sits undetected until a
+support email arrives. Deploy rules first.
+
+## 2. Trigger Email extension install
+
+DataPipe sends no mail directly — every notification is a document written to
+the `mail` collection (`functions/src/mail.ts`), and the Firebase "Trigger
+Email" extension (`firebase/firestore-send-email`) is the only thing that
+turns those documents into delivered mail.
+
+```
+firebase ext:install firebase/firestore-send-email --project=<prod>
+```
+
+Configuration:
+
+| Setting | Value |
+|---|---|
+| `MAIL_COLLECTION` | `mail` |
+| `SMTP_CONNECTION_URI` | Secret Manager — **never a config literal**. SMTP provider is chosen at install time (Owner question 1 in the design doc: Amazon SES or Brevo were the candidates); whichever is picked, the connection string goes in Secret Manager, not `extensions/*.env`. |
+| `DEFAULT_FROM` | `DataPipe <notifications@pipe.jspsych.org>` (or whatever sending address was decided) |
+| `DEFAULT_REPLY_TO` | The contact address already used by `pages/contact.js` |
+| Location | Match the existing functions region (`us-central1`) |
+
+**SPF/DKIM warning.** The sending domain needs SPF and DKIM records before
+this extension goes live in production. Without them, a meaningful share of
+these notifications will land in spam or be silently dropped — and because
+this feature exists specifically to reach a researcher whose data has stopped
+arriving, a notification nobody sees is functionally the same as no
+notification at all. This needs DNS access to `jspsych.org`; confirm the
+records are in place (or in progress) before flipping this on in prod. Do not
+install the production SMTP config until DNS is ready — install with a
+placeholder or leave the extension config unset in the interim rather than
+sending unauthenticated mail from a new address.
+
+**Install in `datapipe-test` too**, or accept that staging queues `mail`
+documents that are never delivered. Un-delivered mail in the emulator/staging
+project is not a bug — the extension does not run against the emulator at
+all, which is why the test suites assert on the `mail` collection directly
+rather than mocking a transport.
+
+## 3. Backfill run procedure
+
+`migrations/2026-08-contact-email-backfill.cjs` seeds `contactEmail` for
+existing accounts that already have a usable address sitting in **Firebase
+Auth** (`admin.auth().listUsers()`), never from `users/{uid}.email` — see the
+file's header comment for why the OSF-era `email` field is never a legitimate
+source (it is either an OSF-API address DataPipe never confirmed, or the
+synthetic `user-{id}@osf.io` fallback).
+
+Run order:
+
+1. **Dry run first, always:**
+   ```
+   node migrations/2026-08-contact-email-backfill.cjs
+   ```
+   No `--apply` flag means no writes. It walks every Auth user (paginated,
+   1000 at a time), logs per-page running totals, and prints a final report:
+   auth users seen, how many would be seeded, how many were skipped because
+   `users/{uid}.contactEmail` is already set, how many Auth users have no
+   corresponding `users/{uid}` document, and how many have no usable Auth
+   email at all (ORCID-only, OSF-era with nothing linked). Read the report
+   before doing anything else — the "seeded" count is the population that is
+   about to change, and it should roughly match expectations for this project
+   (email/password + Google + linked-provider accounts).
+
+2. **Apply:**
+   ```
+   node migrations/2026-08-contact-email-backfill.cjs --apply
+   ```
+   Same traversal, same report, but batches (500/commit) are actually
+   committed. The script is idempotent — it never overwrites a non-empty
+   `contactEmail`, so it is safe to re-run (e.g. against users created after
+   the first pass, or after fixing a config issue) without risk of clobbering
+   an address a researcher has since set themselves.
+
+3. **Target project:** the script uses the same three-way init as the other
+   `migrations/*.cjs` scripts — `NODE_ENV=production` or `CI` for a service
+   account from `GOOGLE_CREDENTIALS`/application-default credentials against
+   `FIREBASE_PROJECT_ID` (default `datapipe-prod`); `USE_LOCAL_SERVICE_ACCOUNT`
+   for a local service-account file against `datapipe-test`; otherwise it
+   points at the Firestore *and* Auth emulators (`localhost:8080` /
+   `localhost:9099`) against `datapipe-test`. Double-check
+   `FIREBASE_PROJECT_ID` before running with `--apply` against a real project.
+
+4. **Rollout sequencing.** Per the design doc: ship the schema + notification
+   pipeline + this backfill *before* shipping the account-page gate. That way
+   notifications already work for everyone who has a usable address, and the
+   backfill has already cleared most of the population that would otherwise
+   hit the gate on their very next visit.
+
+## 4. Extension TTL / mail retention
+
+`mail` documents hold a researcher's address (in `to`) and, after delivery,
+the extension's own audit trail (`delivery.state`, `delivery.attempts`,
+`delivery.error`). They should not accumulate indefinitely:
+
+- Configure the extension's Firestore TTL policy: **TTL field
+  `delivery.endTime`, TTL value 30 days.** Processed mail documents
+  self-delete a month after the extension finishes with them; this is a
+  Firestore TTL policy on the `mail` collection, set once at extension
+  install/config time, not something DataPipe's own code manages.
+- This TTL is a backstop, not the only cleanup path. Account deletion
+  (`functions/src/purge-user-data.ts`) also deletes a purged user's `mail`
+  documents directly (queried on `datapipe.owner == uid`) and their
+  `contactEmailVerifications/{uid}` doc, so a deleted account's mail does not
+  wait out the 30-day TTL — it is gone as part of the same purge pass that
+  removes their experiments and queue entries.
+- If the TTL policy is ever missed at install time, `mail` will grow
+  unbounded — it is not covered by any other retention mechanism.
+
+## Not covered here
+
+Firestore index changes (none expected — see the design doc §3.4/§7 on why
+the existing `uploadQueue` composite index already serves the drain query;
+confirm with `firebase firestore:indexes` before deploy anyway) and function
+secrets (none new — verification codes are SHA-256 hashed, not encrypted, and
+`TOKEN_ENCRYPTION_KEY` is untouched) are addressed in the main design doc, not
+here.

--- a/firebase.json
+++ b/firebase.json
@@ -85,6 +85,14 @@
       {
         "source": "/api/finalize",
         "function": "apifinalize"
+      },
+      {
+        "source": "/api/sendcontactemailverification",
+        "function": "sendcontactemailverification"
+      },
+      {
+        "source": "/api/verifycontactemail",
+        "function": "verifycontactemail"
       }
     ]
   },

--- a/firestore.rules
+++ b/firestore.rules
@@ -2,16 +2,44 @@ rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
     match /users/{userId} {
+      // contactEmailVerified is server-only in the TRUE direction. The client
+      // may write it -- it has to, so that saving a new address resets the
+      // flag -- but only ever as false. No client can self-certify an address.
+      //
+      // The test is on the POST-STATE (request.resource.data), not on the
+      // diff, and that is the point: on an update, request.resource.data is
+      // the merged document, so changing the address on an already-verified
+      // account WITHOUT resetting the flag leaves `true` standing against a
+      // new, unconfirmed address -- and is denied here. lib/contact-email.js's
+      // buildContactEmailUpdate() always emits contactEmailVerified: false for
+      // exactly this reason.
+      //
+      // The `in` guard tolerates the case where the field is absent from the
+      // post-state entirely (a first-ever address on a document that has never
+      // carried the flag). Absent is not verified, so there is nothing to
+      // refuse; reading a missing key would instead error and deny a
+      // legitimate write.
+      function contactEmailNotSelfCertified() {
+        return !('contactEmailVerified' in request.resource.data)
+          || request.resource.data.contactEmailVerified == false;
+      }
       // New accounts (federated or email/password) write only the slim
-      // { uid, email, experiments } shape -- see ensureUserDocument in
+      // { uid, email, experiments } shape plus, since the contact-email
+      // feature, the contactEmail* group -- see ensureUserDocument in
       // lib/user-bootstrap.js. The OSF-era keys stay on the whitelist so
       // existing documents remain writable, but they are no longer required:
       // the osfToken == '' assertion below only applies when the field is
       // actually present, because a new account never has one.
+      //
+      // Adding the four contactEmail* keys to hasOnly() is what makes the
+      // seeded shape writable at all; hasAll() is unchanged, so contactEmail
+      // remains optional -- an ORCID signup has no address to seed and meets
+      // the gate on its first /admin load instead.
       function isAccountCreation() {
-        return request.resource.data.keys().hasOnly(['email', 'experiments', 'osfToken', 'osfTokenValid', 'uid', 'usingPersonalToken', 'refreshToken', 'refreshTokenExpires', 'authToken', 'authTokenExpires', 'osfUserId', 'displayName', 'authMethod', 'createdAt'])
+        return request.resource.data.keys().hasOnly(['email', 'experiments', 'osfToken', 'osfTokenValid', 'uid', 'usingPersonalToken', 'refreshToken', 'refreshTokenExpires', 'authToken', 'authTokenExpires', 'osfUserId', 'displayName', 'authMethod', 'createdAt', 'contactEmail', 'contactEmailVerified', 'contactEmailUpdatedAt', 'contactEmailSource'])
           && request.resource.data.keys().hasAll(['uid', 'email', 'experiments'])
-          && (!('osfToken' in request.resource.data) || request.resource.data.osfToken == '');
+          && (!('osfToken' in request.resource.data) || request.resource.data.osfToken == '')
+          && contactEmailNotSelfCertified();
       }
       function isTokenMethodUpdate() {
         return request.resource.data.diff(resource.data).affectedKeys().hasOnly(['usingPersonalToken']);
@@ -19,10 +47,43 @@ service cloud.firestore {
       function isExperimentsUpdate() {
         return request.resource.data.diff(resource.data).affectedKeys().hasOnly(['experiments']);
       }
+      // A researcher may set their own notification address, and nothing else
+      // in the same write: a single operation touching contactEmail AND
+      // experiments matches no shape here and fails whole. That is the
+      // established posture of this rule -- one narrow shape per intent --
+      // and it is what stops a contact-email save from being a vehicle for
+      // anything else on the document.
+      //
+      // The 254-character cap mirrors MAX_CONTACT_EMAIL_LENGTH in
+      // lib/contact-email.js (the longest addr-spec SMTP must accept).
+      // Deliverability is not decided here; format is checked client-side and
+      // confirmed by the verification code. This rule only has to stop a
+      // client from parking arbitrary bulk on the document.
+      function isContactEmailUpdate() {
+        return request.resource.data.diff(resource.data).affectedKeys()
+            .hasOnly(['contactEmail', 'contactEmailVerified', 'contactEmailUpdatedAt', 'contactEmailSource'])
+          && request.resource.data.contactEmail is string
+          && request.resource.data.contactEmail.size() > 0
+          && request.resource.data.contactEmail.size() <= 254
+          && contactEmailNotSelfCertified();
+      }
       allow read: if(request.auth.uid == userId);
       allow write: if(request.auth.uid == userId) &&
-        (isAccountCreation() || isTokenMethodUpdate() || isExperimentsUpdate());
+        (isAccountCreation() || isTokenMethodUpdate() || isExperimentsUpdate()
+          || isContactEmailUpdate());
     }
+    // NO match block for contactEmailVerifications/{uid}, and that is
+    // deliberate. It holds the SHA-256 of the verification code alongside the
+    // hash of the address it was sent to, and `allow read` above hands the
+    // owner their entire user document -- so the hash cannot live there, where
+    // the person being verified could read it. Firestore default-denies every
+    // unmatched path, which makes this collection invisible and unwritable to
+    // every client and reachable only by the Admin SDK. Adding a rule here
+    // could only weaken that.
+    //
+    // Same for the `mail` collection (functions/src/mail.ts): unmatched,
+    // therefore already closed. Written down so nobody "fixes" the absence
+    // later by granting access.
     match /experiments/{experimentId} {
       function baseFields() {
         return request.resource.data.keys().hasAll(['active', 'activeBase64', 'activeConditionAssignment', 'id', 'owner', 'title', 'sessions', 'nConditions', 'currentCondition', 'useValidation', 'allowJSON', 'allowCSV', 'requiredFields', 'maxSessions', 'limitSessions'])
@@ -46,9 +107,24 @@ service cloud.firestore {
       // defensive about that too, but the field has no business being
       // client-writable in the first place. Verified no client code writes
       // either map.
+      //
+      // `uploadFailure` (functions/src/upload-failure-notify.ts) joins them for
+      // exactly the same two reasons: it holds server-written Timestamps that
+      // the notifier calls .toMillis() on, and a client that could clear
+      // uploadFailure.notifiedAt could make DataPipe mail them once per failed
+      // FILE instead of once per episode -- one participant submission can
+      // produce twenty queue entries.
+      //
+      // DEPLOY ORDER: this file ships BEFORE the functions, and it is not
+      // optional. The notifier writes uploadFailure with the Admin SDK, which
+      // these rules never see -- so if the functions land first, every
+      // experiment starts carrying a field that the deployed rules still do
+      // not protect, and any client merge-write can clear notifiedAt for the
+      // duration of the gap. Nothing breaks loudly; the notifier just quietly
+      // re-arms on demand. Rules first closes the window before it opens.
       function serverManagedFieldsUntouched() {
         return !request.resource.data.diff(resource.data).affectedKeys()
-          .hasAny(['finalized', 'finalizedAt', 'finalization', 'compaction', 'collisionCache']);
+          .hasAny(['finalized', 'finalizedAt', 'finalization', 'compaction', 'collisionCache', 'uploadFailure']);
       }
       // UPDATE shape: legacy-tolerant. An experiment created before the
       // provider-migration schema carries the OSF triple and no
@@ -72,12 +148,15 @@ service cloud.firestore {
       // No new experiment is ever born finalized -- a create that already
       // carries finalized/finalizedAt/finalization is exactly as forged as an
       // update that adds them (see serverManagedFieldsUntouched() above), just
-      // with no prior document for diff() to compare against.
+      // with no prior document for diff() to compare against. `uploadFailure`
+      // is on this list for the same reason: serverManagedFieldsUntouched()
+      // governs updates only, so without it here a client could simply be born
+      // holding an armed notifiedAt and never be mailed about a failure.
       function isCreatableProvider() {
         return ('storageProvider' in request.resource.data) &&
           request.resource.data.storageProvider != 'osf' &&
           request.resource.data.keys().hasAll(['storageProvider', 'providerContainer']) &&
-          !request.resource.data.keys().hasAny(['finalized', 'finalizedAt', 'finalization']);
+          !request.resource.data.keys().hasAny(['finalized', 'finalizedAt', 'finalization', 'uploadFailure']);
       }
       allow read: if(request.auth.uid != null) &&
         resource.data.owner == request.auth.uid;

--- a/functions/src/__tests__/contact-email-verify-emulator.test.js
+++ b/functions/src/__tests__/contact-email-verify-emulator.test.js
@@ -1,0 +1,420 @@
+/**
+ * @jest-environment node
+ */
+
+// End-to-end coverage for the verification round trip (plan §2.2, package
+// P3): send-contact-email-verification.ts (POST /api/sendcontactemailverification)
+// and verify-contact-email.ts (POST /api/verifycontactemail).
+//
+// Both are bearer-token onRequest endpoints -- the same shape as
+// delete-account.ts and api-finalize.ts -- not Firestore triggers, so unlike
+// upload-failure-notify-emulator.test.js's handleQueueWrite seam there is no
+// plain in-process function to import and call: an onRequest export is a
+// CloudFunction object, not a callable (req, res) function. This suite
+// therefore follows api-finalize-emulator.test.js's pattern instead -- real
+// HTTP calls against the running Functions emulator, with real Auth-emulator
+// idTokens from accounts:signUp -- while keeping the env-var and admin-app
+// conventions upload-failure-notify-emulator.test.js established:
+// FIRESTORE_EMULATOR_HOST set at module scope before any import that reaches
+// app.js, a NAMED admin app so the compiled modules' bare initializeApp()
+// does not collide with it, and a dynamic import of the COMPILED module from
+// functions/lib/ (so `npm --prefix functions run build` must run first).
+//
+// The dynamic import is for hashVerificationCode / hashContactEmail /
+// EXPIRY_MS / VERIFICATIONS_COLLECTION only -- reading the real hashing logic
+// and the real 24-hour constant rather than restating them, so a fixture
+// this suite seeds directly (for the expired-code, attempt-exhaustion and
+// stale-address cases, which bypass the send endpoint on purpose to control
+// expiresAt/attempts/the address a code was bound to) stays byte-identical
+// to what the endpoint itself would have written.
+//
+// The happy path deliberately never reads a code out of a fixture it wrote
+// itself: it goes through the real send endpoint and recovers the actual
+// mailed code from the `mail` collection -- the same "assert on the mail
+// collection" contract mail.ts's header describes -- so it is the real
+// generate/hash/store/mail pipeline being proven, not just the verify half.
+
+import { initializeApp, getApp } from "firebase-admin/app";
+import { getFirestore } from "firebase-admin/firestore";
+import { randomUUID } from "crypto";
+
+process.env.FIRESTORE_EMULATOR_HOST = "localhost:8080";
+process.env.GCLOUD_PROJECT = "datapipe-test";
+process.env.FIREBASE_CONFIG = JSON.stringify({
+  projectId: "datapipe-test",
+  storageBucket: "datapipe-test.appspot.com",
+});
+
+jest.setTimeout(30000);
+
+const config = { projectId: "datapipe-test" };
+const FUNCTIONS_BASE = "http://localhost:5001/datapipe-test/us-central1";
+const SEND_URL = `${FUNCTIONS_BASE}/sendcontactemailverification`;
+const VERIFY_URL = `${FUNCTIONS_BASE}/verifycontactemail`;
+const AUTH_EMULATOR_SIGNUP_URL =
+  "http://localhost:9099/identitytoolkit.googleapis.com/v1/accounts:signUp?key=fake";
+
+let db;
+let hashVerificationCode;
+let hashContactEmail;
+let EXPIRY_MS;
+let VERIFICATIONS_COLLECTION;
+
+beforeAll(async () => {
+  let app;
+  try {
+    app = getApp("contact-email-verify-test");
+  } catch {
+    app = initializeApp(config, "contact-email-verify-test");
+  }
+  db = getFirestore(app);
+
+  ({ hashVerificationCode, hashContactEmail, EXPIRY_MS, VERIFICATIONS_COLLECTION } =
+    await import("../../lib/send-contact-email-verification.js"));
+});
+
+// ---------------------------------------------------------------------------
+// Fixtures, HTTP helpers, and scoped cleanup
+// ---------------------------------------------------------------------------
+
+const created = { uids: [] };
+
+async function signUpEmulatorUser() {
+  const email = `contact-verify-${randomUUID()}@example.test`;
+  const res = await fetch(AUTH_EMULATOR_SIGNUP_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email, password: "Password123!", returnSecureToken: true }),
+  });
+  const body = await res.json();
+  if (!res.ok) {
+    throw new Error(`Auth emulator signUp failed (${res.status}): ${JSON.stringify(body)}`);
+  }
+  created.uids.push(body.localId);
+  return { uid: body.localId, idToken: body.idToken };
+}
+
+async function seedUserDoc(uid, contactEmail, overrides = {}) {
+  await db.doc(`users/${uid}`).set({
+    uid,
+    email: "",
+    experiments: [],
+    contactEmail,
+    contactEmailVerified: false,
+    ...overrides,
+  });
+}
+
+async function callSend(idToken) {
+  const res = await fetch(SEND_URL, {
+    method: "POST",
+    headers: idToken ? { Authorization: `Bearer ${idToken}` } : {},
+  });
+  const body = await res.json().catch(() => ({}));
+  return { status: res.status, body };
+}
+
+async function callVerify(idToken, code, { method = "POST" } = {}) {
+  const headers = { "Content-Type": "application/json" };
+  if (idToken) headers.Authorization = `Bearer ${idToken}`;
+  const res = await fetch(VERIFY_URL, {
+    method,
+    headers,
+    body: method === "POST" ? JSON.stringify({ code }) : undefined,
+  });
+  const body = await res.json().catch(() => ({}));
+  return { status: res.status, body };
+}
+
+// Recovers the code from the `mail` collection rather than from a
+// server-returned field -- the endpoint must never put the code in an API
+// response, only in the mailed body. Sorted newest-first so a resend test
+// (which produces two documents when the first send is not itself
+// rate-limited) reads the current one.
+async function mailedCodeFor(uid) {
+  const snap = await db
+    .collection("mail")
+    .where("datapipe.owner", "==", uid)
+    .where("datapipe.kind", "==", "contact-email-verification")
+    .get();
+  expect(snap.size).toBeGreaterThan(0);
+  const docs = snap.docs.sort(
+    (a, b) =>
+      (b.data().datapipe.queuedAt?.toMillis?.() ?? 0) -
+      (a.data().datapipe.queuedAt?.toMillis?.() ?? 0)
+  );
+  const match = /code is (\d{6})/.exec(docs[0].data().message.text);
+  expect(match).not.toBeNull();
+  return { code: match[1], mailCount: docs.length };
+}
+
+async function verificationDoc(uid) {
+  const snap = await db.doc(`${VERIFICATIONS_COLLECTION}/${uid}`).get();
+  return snap.exists ? snap.data() : undefined;
+}
+
+afterEach(async () => {
+  const batch = db.batch();
+  for (const uid of created.uids) {
+    const mail = await db.collection("mail").where("datapipe.owner", "==", uid).get();
+    mail.docs.forEach((d) => batch.delete(d.ref));
+    batch.delete(db.doc(`users/${uid}`));
+    batch.delete(db.doc(`${VERIFICATIONS_COLLECTION}/${uid}`));
+  }
+  await batch.commit();
+  created.uids.length = 0;
+});
+
+// ---------------------------------------------------------------------------
+// Auth and request shape -- both endpoints, same shape as delete-account.ts
+// ---------------------------------------------------------------------------
+
+describe("auth and request shape", () => {
+  it("send: rejects non-POST methods", async () => {
+    const res = await fetch(SEND_URL, { method: "GET" });
+    expect(res.status).toBe(405);
+  });
+
+  it("send: 401 with no Authorization header", async () => {
+    const { status } = await callSend(undefined);
+    expect(status).toBe(401);
+  });
+
+  it("send: 401 for a garbage bearer token", async () => {
+    const { status } = await callSend("not-a-real-token");
+    expect(status).toBe(401);
+  });
+
+  it("verify: rejects non-POST methods", async () => {
+    const { status } = await callVerify("irrelevant", "123456", { method: "GET" });
+    expect(status).toBe(405);
+  });
+
+  it("verify: 401 with no Authorization header", async () => {
+    const { status } = await callVerify(undefined, "123456");
+    expect(status).toBe(401);
+  });
+
+  it("verify: 401 for a garbage bearer token", async () => {
+    const { status } = await callVerify("not-a-real-token", "123456");
+    expect(status).toBe(401);
+  });
+
+  it("verify: 400 for a malformed code, before touching Firestore at all", async () => {
+    const { uid, idToken } = await signUpEmulatorUser();
+    // No user doc seeded -- if this reached the "no contact email" branch
+    // instead of failing on shape, that would also be a 400, so the
+    // assertion is on the specific code to prove which check fired.
+    const { status, body } = await callVerify(idToken, "12ab56");
+    expect(status).toBe(400);
+    expect(body.code).toBe("invalid-code");
+    void uid;
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Happy path: the real generate -> hash -> mail -> verify round trip
+// ---------------------------------------------------------------------------
+
+describe("happy path", () => {
+  it("a correct code verifies the address, deletes the record, and is never echoed in a response", async () => {
+    const { uid, idToken } = await signUpEmulatorUser();
+    await seedUserDoc(uid, "researcher@example.edu");
+
+    const sent = await callSend(idToken);
+    expect(sent.status).toBe(200);
+    // The 6-digit secret must never appear in an API response -- only in the
+    // mailed body, recovered below via mailedCodeFor.
+    expect(JSON.stringify(sent.body)).not.toMatch(/codeHash|emailHash/);
+
+    const { code } = await mailedCodeFor(uid);
+
+    const verified = await callVerify(idToken, code);
+    expect(verified.status).toBe(200);
+    expect(verified.body).toEqual({ success: true });
+    expect(JSON.stringify(verified.body)).not.toMatch(/codeHash|emailHash/);
+
+    const userSnap = await db.doc(`users/${uid}`).get();
+    expect(userSnap.data().contactEmailVerified).toBe(true);
+
+    // The record is consumed on success -- nothing left for a second guess
+    // to be checked against, and nothing left holding the hash.
+    expect(await verificationDoc(uid)).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Wrong code
+// ---------------------------------------------------------------------------
+
+describe("wrong code", () => {
+  it("is refused, counts against the attempt budget, and does not verify", async () => {
+    const { uid, idToken } = await signUpEmulatorUser();
+    await seedUserDoc(uid, "researcher@example.edu");
+
+    await callSend(idToken);
+    const { code } = await mailedCodeFor(uid);
+    const wrongCode = code === "000001" ? "000002" : "000001";
+
+    const result = await callVerify(idToken, wrongCode);
+    expect(result.status).toBe(400);
+    expect(result.body.code).toBe("invalid-code");
+
+    expect((await verificationDoc(uid)).attempts).toBe(1);
+    const userSnap = await db.doc(`users/${uid}`).get();
+    expect(userSnap.data().contactEmailVerified).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Expired code
+// ---------------------------------------------------------------------------
+
+describe("expired code", () => {
+  it("is refused even though it is otherwise correct", async () => {
+    const { uid, idToken } = await signUpEmulatorUser();
+    const email = "researcher@example.edu";
+    await seedUserDoc(uid, email);
+
+    const knownCode = "482913";
+    await db.doc(`${VERIFICATIONS_COLLECTION}/${uid}`).set({
+      emailHash: hashContactEmail(email),
+      codeHash: hashVerificationCode(knownCode, uid),
+      expiresAt: Date.now() - 1000,
+      attempts: 0,
+      sentAt: Date.now() - EXPIRY_MS - 1000,
+    });
+
+    const result = await callVerify(idToken, knownCode);
+    expect(result.status).toBe(400);
+    expect(result.body.code).toBe("expired");
+
+    const userSnap = await db.doc(`users/${uid}`).get();
+    expect(userSnap.data().contactEmailVerified).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Attempt exhaustion
+// ---------------------------------------------------------------------------
+
+describe("attempt exhaustion", () => {
+  it("the sixth attempt is refused regardless of correctness", async () => {
+    const { uid, idToken } = await signUpEmulatorUser();
+    const email = "researcher@example.edu";
+    await seedUserDoc(uid, email);
+
+    const knownCode = "731044";
+    await db.doc(`${VERIFICATIONS_COLLECTION}/${uid}`).set({
+      emailHash: hashContactEmail(email),
+      codeHash: hashVerificationCode(knownCode, uid),
+      expiresAt: Date.now() + EXPIRY_MS,
+      attempts: 5, // plan §2.2's cap, already reached by five prior guesses
+      sentAt: Date.now(),
+    });
+
+    // The CORRECT code -- proving the cap wins even over a right answer, not
+    // merely that a sixth wrong guess is refused.
+    const result = await callVerify(idToken, knownCode);
+    expect(result.status).toBe(429);
+    expect(result.body.code).toBe("too-many-attempts");
+
+    const userSnap = await db.doc(`users/${uid}`).get();
+    expect(userSnap.data().contactEmailVerified).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Stale-address guard -- the bug class this endpoint exists to close
+// ---------------------------------------------------------------------------
+
+describe("stale address", () => {
+  it("a code minted for a previous address does not verify a newer one", async () => {
+    const { uid, idToken } = await signUpEmulatorUser();
+    await seedUserDoc(uid, "old@example.edu");
+
+    await callSend(idToken);
+    const { code } = await mailedCodeFor(uid);
+
+    // The researcher changes their address before entering the code --
+    // exactly what components/account/ContactEmail.js's edit form allows at
+    // any time, and exactly what buildContactEmailUpdate() does: reset
+    // contactEmailVerified to false on the new, unconfirmed value.
+    await db.doc(`users/${uid}`).update({
+      contactEmail: "new@example.edu",
+      contactEmailVerified: false,
+    });
+
+    const result = await callVerify(idToken, code);
+    expect(result.status).toBe(400);
+    expect(result.body.code).toBe("stale-address");
+
+    const userSnap = await db.doc(`users/${uid}`).get();
+    expect(userSnap.data().contactEmailVerified).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Rate limit on resend
+// ---------------------------------------------------------------------------
+
+describe("rate limit", () => {
+  it("a resend within the cooldown is refused, and the original code stays usable", async () => {
+    const { uid, idToken } = await signUpEmulatorUser();
+    await seedUserDoc(uid, "researcher@example.edu");
+
+    const first = await callSend(idToken);
+    expect(first.status).toBe(200);
+
+    const second = await callSend(idToken);
+    expect(second.status).toBe(429);
+    expect(second.body.code).toBe("rate-limited");
+
+    // The blocked resend must not have queued a second mail, and must not
+    // have overwritten the first record with a fresh (unusable) one.
+    const { code, mailCount } = await mailedCodeFor(uid);
+    expect(mailCount).toBe(1);
+
+    const verified = await callVerify(idToken, code);
+    expect(verified.status).toBe(200);
+    expect(verified.body.success).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// No contact email on file
+// ---------------------------------------------------------------------------
+
+describe("no contact email", () => {
+  it("send is refused when there is nothing to mail", async () => {
+    const { uid, idToken } = await signUpEmulatorUser();
+    await seedUserDoc(uid, "");
+
+    const result = await callSend(idToken);
+    expect(result.status).toBe(400);
+    expect(result.body.code).toBe("no-contact-email");
+    expect(await verificationDoc(uid)).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Already verified -- both endpoints are idempotent no-ops
+// ---------------------------------------------------------------------------
+
+describe("already verified", () => {
+  it("send and verify both report alreadyVerified without sending mail or requiring a code", async () => {
+    const { uid, idToken } = await signUpEmulatorUser();
+    await seedUserDoc(uid, "researcher@example.edu", { contactEmailVerified: true });
+
+    const sent = await callSend(idToken);
+    expect(sent.status).toBe(200);
+    expect(sent.body.alreadyVerified).toBe(true);
+
+    const mail = await db.collection("mail").where("datapipe.owner", "==", uid).get();
+    expect(mail.size).toBe(0);
+
+    const verified = await callVerify(idToken, "000000");
+    expect(verified.status).toBe(200);
+    expect(verified.body.alreadyVerified).toBe(true);
+  });
+});

--- a/functions/src/__tests__/purge-user-data-emulator.test.js
+++ b/functions/src/__tests__/purge-user-data-emulator.test.js
@@ -80,6 +80,16 @@ describe("purgeUserData", () => {
       .collection("uploadQueue")
       .doc(queueDocId)
       .set({ owner: uid, experimentID, status: "pending" });
+    const mailRef = db.collection("mail").doc();
+    await mailRef.set({
+      to: ["purge@example.com"],
+      message: { subject: "s", text: "t" },
+      datapipe: { kind: "upload-failure", owner: uid, experimentID },
+    });
+    await db
+      .collection("contactEmailVerifications")
+      .doc(uid)
+      .set({ emailHash: "h", codeHash: "h", expiresAt: Date.now(), attempts: 0, sentAt: Date.now() });
 
     const counts = await purgeUserData(uid);
 
@@ -91,6 +101,8 @@ describe("purgeUserData", () => {
       queueEntries: 1,
       pendingFiles: 1,
       userDocument: 1,
+      mailDocuments: 1,
+      contactEmailVerification: 1,
     });
 
     expect(await exists(db.collection("users").doc(uid))).toBe(false);
@@ -104,11 +116,34 @@ describe("purgeUserData", () => {
     expect(await exists(db.collection("uploadQueue").doc(queueDocId))).toBe(
       false
     );
+    expect(await exists(mailRef)).toBe(false);
+    expect(
+      await exists(db.collection("contactEmailVerifications").doc(uid))
+    ).toBe(false);
 
     const [pending] = await bucket.getFiles({
       prefix: `pending-data/${experimentID}/`,
     });
     expect(pending).toHaveLength(0);
+  });
+
+  // A user who never set a contact email, or never had a verification
+  // in flight, has neither document -- purging must not error or find
+  // phantom counts.
+  it("purges clean when there are no mail docs or verification doc", async () => {
+    const uid = makeUid();
+    const experimentID = `exp-${randomUUID()}`;
+    await seedExperiment(uid, experimentID);
+    await db
+      .collection("users")
+      .doc(uid)
+      .set({ uid, email: "no-mail@example.com", experiments: [experimentID] });
+
+    const counts = await purgeUserData(uid);
+
+    expect(counts.mailDocuments).toBe(0);
+    expect(counts.contactEmailVerification).toBe(0);
+    expect(counts.userDocument).toBe(1);
   });
 
   // The regression that left a live experiment behind in datapipe-test: the
@@ -171,6 +206,18 @@ describe("purgeUserData", () => {
       .collection("users")
       .doc(uid)
       .set({ uid, email: "twice@example.com", experiments: [experimentID] });
+    await db
+      .collection("mail")
+      .doc()
+      .set({
+        to: ["twice@example.com"],
+        message: { subject: "s", text: "t" },
+        datapipe: { kind: "upload-failure", owner: uid },
+      });
+    await db
+      .collection("contactEmailVerifications")
+      .doc(uid)
+      .set({ emailHash: "h", codeHash: "h", expiresAt: Date.now(), attempts: 0, sentAt: Date.now() });
 
     await purgeUserData(uid);
     const second = await purgeUserData(uid);
@@ -183,6 +230,8 @@ describe("purgeUserData", () => {
       queueEntries: 0,
       pendingFiles: 0,
       userDocument: 0,
+      mailDocuments: 0,
+      contactEmailVerification: 0,
     });
   });
 
@@ -203,6 +252,24 @@ describe("purgeUserData", () => {
     strays.push(db.collection("experiments").doc(bystanderExp));
     strays.push(db.collection("metadata").doc(bystanderExp));
     strays.push(db.collection("logs").doc(bystanderExp));
+    const bystanderMailRef = db.collection("mail").doc();
+    await bystanderMailRef.set({
+      to: ["bystander@example.com"],
+      message: { subject: "s", text: "t" },
+      datapipe: { kind: "upload-failure", owner: bystander },
+    });
+    strays.push(bystanderMailRef);
+    const bystanderVerificationRef = db
+      .collection("contactEmailVerifications")
+      .doc(bystander);
+    await bystanderVerificationRef.set({
+      emailHash: "h",
+      codeHash: "h",
+      expiresAt: Date.now(),
+      attempts: 0,
+      sentAt: Date.now(),
+    });
+    strays.push(bystanderVerificationRef);
 
     await purgeUserData(victim);
 
@@ -210,6 +277,8 @@ describe("purgeUserData", () => {
       true
     );
     expect(await exists(bystanderUserRef)).toBe(true);
+    expect(await exists(bystanderMailRef)).toBe(true);
+    expect(await exists(bystanderVerificationRef)).toBe(true);
     const [pending] = await bucket.getFiles({
       prefix: `pending-data/${bystanderExp}/`,
     });

--- a/functions/src/__tests__/upload-failure-copy.test.js
+++ b/functions/src/__tests__/upload-failure-copy.test.js
@@ -1,0 +1,221 @@
+// Pure copy tests for the first-failure notification.
+//
+// No emulator, no admin app, no network: functions/src/email/upload-failure-copy.ts
+// has only `import type` dependencies, so the compiled module it imports below
+// has no runtime imports at all and never reaches app.js. That is the whole
+// reason the wording lives in its own module -- these are the assertions that
+// would otherwise need a Firestore transaction to reach.
+//
+// Imports the COMPILED module (functions/lib/), so `npm --prefix functions run
+// build` must run first. Same convention as metadata-derived-files.test.js.
+
+import {
+  buildUploadFailureEmail,
+  actionLine,
+  reasonLine,
+  providerDisplayName,
+  experimentUrl,
+  ACCOUNT_URL,
+  FAQ_URL,
+  APP_BASE_URL,
+} from "../../lib/email/upload-failure-copy.js";
+
+const base = {
+  experimentID: "abc123",
+  title: "Working Memory Span",
+  storageProvider: "gdrive",
+  providerErrorCode: "UNAVAILABLE",
+  failureCount: 1,
+};
+
+describe("subject line", () => {
+  test("names the experiment", () => {
+    const { subject } = buildUploadFailureEmail(base);
+    expect(subject).toContain("Working Memory Span");
+    expect(subject).toContain("couldn't upload");
+  });
+
+  test("falls back to a generic subject when the experiment has no title", () => {
+    // Nothing guarantees a `title` on an older experiment document, and a
+    // subject reading `for ""` would be worse than one that says nothing.
+    for (const title of [undefined, null, "", "   "]) {
+      const { subject } = buildUploadFailureEmail({ ...base, title });
+      expect(subject).toBe(
+        "DataPipe couldn't upload a data file for your experiment"
+      );
+      expect(subject).not.toContain('""');
+    }
+  });
+});
+
+describe("body essentials", () => {
+  test("carries the study, the provider, the reassurance and both links", () => {
+    const { text } = buildUploadFailureEmail(base);
+
+    expect(text).toContain("Working Memory Span");
+    expect(text).toContain("Google Drive");
+    // The single most important sentence in the mail.
+    expect(text).toContain("The file is not lost.");
+    // The retry horizon is owner-confirmed: five attempts, ~31 hours.
+    expect(text).toContain("five attempts over about 31 hours");
+    expect(text).toContain(`${APP_BASE_URL}/admin/abc123`);
+    expect(text).toContain(ACCOUNT_URL);
+    // Service-critical transactional mail: the only control offered is
+    // changing the address, and there is deliberately no unsubscribe link.
+    expect(text).not.toMatch(/unsubscribe/i);
+  });
+
+  test("says the researcher will only be mailed once per episode", () => {
+    const { text } = buildUploadFailureEmail(base);
+    expect(text).toContain("only email you once about this");
+    expect(text).toContain("not once per file");
+  });
+
+  test("html body carries the same links and is valid-ish markup", () => {
+    const { html } = buildUploadFailureEmail(base);
+    expect(html).toContain(`href="${experimentUrl("abc123")}"`);
+    expect(html).toContain("<strong>The file is not lost.</strong>");
+    expect(html).toContain(ACCOUNT_URL);
+  });
+
+  test("escapes a researcher-supplied title in the html body", () => {
+    // `title` is typed by the researcher and reaches the mail unfiltered.
+    const { html, subject } = buildUploadFailureEmail({
+      ...base,
+      title: '<script>alert("x")</script> & co',
+    });
+    expect(html).not.toContain("<script>");
+    expect(html).toContain("&lt;script&gt;");
+    expect(html).toContain("&amp; co");
+    // The plaintext subject is not markup and is left alone.
+    expect(subject).toContain("<script>");
+  });
+});
+
+describe("failure count", () => {
+  test("omits the burst line for a single file", () => {
+    // The mail is only composed on the FIRST failure of an episode, so the
+    // count is normally 1 -- "1 file is waiting so far" would be noise.
+    const { text } = buildUploadFailureEmail({ ...base, failureCount: 1 });
+    expect(text).not.toMatch(/files from this experiment are waiting/);
+  });
+
+  test("includes the burst line when more than one file has failed", () => {
+    const { text } = buildUploadFailureEmail({ ...base, failureCount: 4 });
+    expect(text).toContain("4 files from this experiment are waiting so far");
+  });
+
+  test("tolerates an absent count", () => {
+    const { text } = buildUploadFailureEmail({ ...base, failureCount: undefined });
+    expect(text).not.toMatch(/undefined/);
+    expect(text).not.toMatch(/NaN/);
+  });
+});
+
+describe("provider display names", () => {
+  test.each([
+    ["osf", "OSF"],
+    ["gdrive", "Google Drive"],
+    ["figshare", "Figshare"],
+    ["dataverse", "Dataverse"],
+    ["zenodo", "Zenodo"],
+  ])("%s renders as %s", (id, expected) => {
+    expect(providerDisplayName(id)).toBe(expected);
+    expect(buildUploadFailureEmail({ ...base, storageProvider: id }).text).toContain(expected);
+  });
+
+  test("an absent or unknown provider gets a generic phrase, never a raw id", () => {
+    // Legacy OSF experiments have no storageProvider field at all
+    // (interfaces.ts: the field is additive).
+    expect(providerDisplayName(undefined)).toBe("your storage provider");
+    expect(providerDisplayName(null)).toBe("your storage provider");
+    expect(providerDisplayName("wat")).toBe("your storage provider");
+    expect(buildUploadFailureEmail({ ...base, storageProvider: "wat" }).text).not.toContain(
+      "wat"
+    );
+  });
+});
+
+describe("reason mapping", () => {
+  // Every member of ProviderErrorCode (functions/src/providers/types.ts) maps
+  // to a researcher-facing clause. A code added there without a line here
+  // would silently fall back to the generic wording.
+  test.each([
+    ["AUTH_EXPIRED", "your storage connection needs to be reconnected"],
+    ["QUOTA_EXCEEDED", "your storage account is out of room"],
+    ["RATE_LIMITED", "the provider is asking us to slow down"],
+    ["UNAVAILABLE", "the provider was unreachable"],
+    ["CONTENTION", "another write to the same folder was in progress"],
+    ["NAME_CONFLICT", "a file with that name already exists"],
+  ])("%s maps to its own line", (code, line) => {
+    expect(reasonLine(code)).toBe(line);
+    expect(buildUploadFailureEmail({ ...base, providerErrorCode: code }).text).toContain(
+      `What went wrong: ${line}.`
+    );
+  });
+
+  test("an absent or unrecognized code falls back", () => {
+    // The larger population, not an edge case: only a provider WriteResult
+    // carries a code, so every failure that never reached the provider
+    // (token resolution, cache trouble, an unreadable payload) lands here.
+    const fallback = "the upload did not complete";
+    expect(reasonLine(undefined)).toBe(fallback);
+    expect(reasonLine(null)).toBe(fallback);
+    expect(reasonLine("SOMETHING_NEW")).toBe(fallback);
+
+    const { text } = buildUploadFailureEmail({ ...base, providerErrorCode: null });
+    expect(text).toContain(fallback);
+    // With no code to explain, the mail must still leave them somewhere
+    // useful: the queue panel has the per-file detail.
+    expect(text).toContain("queue panel");
+  });
+});
+
+describe("what to check", () => {
+  test("AUTH_EXPIRED on a live provider says reconnect, and where", () => {
+    const line = actionLine("AUTH_EXPIRED", "zenodo");
+    expect(line).toContain("Reconnect Zenodo");
+    expect(line).toContain(ACCOUNT_URL);
+    expect(line).not.toContain(FAQ_URL);
+  });
+
+  test.each([["osf"], [undefined], [null]])(
+    "AUTH_EXPIRED on a legacy OSF experiment (storageProvider=%s) points at the FAQ, not at reconnecting",
+    (provider) => {
+      // OSF is retiring the projects feature DataPipe writes into, so
+      // "reconnect your provider" would send the researcher to repair
+      // something that is going away. An absent storageProvider IS the legacy
+      // OSF shape.
+      const line = actionLine("AUTH_EXPIRED", provider);
+      expect(line).toContain("OSF");
+      expect(line).toContain(FAQ_URL);
+      expect(line).not.toMatch(/^Reconnect/);
+
+      const { text } = buildUploadFailureEmail({
+        ...base,
+        storageProvider: provider,
+        providerErrorCode: "AUTH_EXPIRED",
+      });
+      expect(text).toContain(FAQ_URL);
+    }
+  );
+
+  test("the self-healing codes say there is nothing to do", () => {
+    for (const code of ["CONTENTION", "UNAVAILABLE", "RATE_LIMITED"]) {
+      expect(actionLine(code, "dataverse")).toContain("Nothing to do right now");
+    }
+  });
+
+  test("QUOTA_EXCEEDED and NAME_CONFLICT ask for something specific", () => {
+    expect(actionLine("QUOTA_EXCEEDED", "zenodo")).toContain("Free up room in Zenodo");
+    expect(actionLine("NAME_CONFLICT", "gdrive")).toContain("Check Google Drive");
+  });
+});
+
+describe("urls", () => {
+  test("experiment link points at the admin page for the id", () => {
+    expect(experimentUrl("xy-9")).toBe("https://pipe.jspsych.org/admin/xy-9");
+    expect(ACCOUNT_URL).toBe("https://pipe.jspsych.org/admin/account");
+    expect(FAQ_URL).toBe("https://pipe.jspsych.org/faq");
+  });
+});

--- a/functions/src/__tests__/upload-failure-notify-emulator.test.js
+++ b/functions/src/__tests__/upload-failure-notify-emulator.test.js
@@ -1,0 +1,566 @@
+/**
+ * @jest-environment node
+ */
+
+// The first-failure notification state machine, against the Firestore
+// emulator.
+//
+// Harness conventions are the established ones (upload-queue.test.js:1-90,
+// pending-recovery-provider-regression.test.js:1-81): emulator env vars set at
+// module scope BEFORE any import that reaches app.js, a NAMED admin app so the
+// compiled module's bare initializeApp() does not collide with it, a dynamic
+// import of the COMPILED module from functions/lib/ (so
+// `npm --prefix functions run build` must run first), and scoped cleanup via a
+// registrar of created ids rather than a collection-wide wipe -- the shared
+// emulator is used by suites running in parallel.
+//
+// No node-fetch stub is needed here, unlike the provider suites:
+// upload-failure-notify.js imports app.js, mail.js and the pure copy module,
+// and reaches no adapter and therefore no ESM-only dependency.
+//
+// Everything drives the exported handleQueueWrite(before, after, docId) seam
+// directly, in-process -- the same seam retryPendingUploads(ownerScope) and
+// recoverPendingUploads(prefix) exist for. Provoking real trigger deliveries
+// out of the emulator would make every assertion a poll with a timeout, and
+// would make the concurrency test below impossible to write at all.
+
+import { initializeApp, getApp } from "firebase-admin/app";
+import { getFirestore, Timestamp } from "firebase-admin/firestore";
+import { randomUUID } from "crypto";
+
+process.env.FIRESTORE_EMULATOR_HOST = "localhost:8080";
+process.env.FIREBASE_STORAGE_EMULATOR_HOST = "localhost:9199";
+process.env.GCLOUD_PROJECT = "datapipe-test";
+process.env.FIREBASE_CONFIG = JSON.stringify({
+  projectId: "datapipe-test",
+  storageBucket: "datapipe-test.appspot.com",
+});
+
+jest.setTimeout(30000);
+
+let db;
+let handleQueueWrite;
+// Both read from the production modules rather than restated as literals here:
+// a test that keeps its own copy of a constant stops testing anything the day
+// the constant changes.
+let RATE_LIMIT_MS;
+let COMPACTION_HOLD_REASON;
+
+beforeAll(async () => {
+  let app;
+  try {
+    app = getApp("upload-failure-notify-test");
+  } catch {
+    app = initializeApp({ projectId: "datapipe-test" }, "upload-failure-notify-test");
+  }
+  db = getFirestore(app);
+
+  ({ handleQueueWrite, RATE_LIMIT_MS } = await import("../../lib/upload-failure-notify.js"));
+  ({ COMPACTION_HOLD_REASON } = await import("../../lib/compaction-gate.js"));
+});
+
+// ---------------------------------------------------------------------------
+// Fixtures + scoped cleanup
+// ---------------------------------------------------------------------------
+
+const created = { experiments: [], users: [], queueDocs: [] };
+
+async function seedExperiment(overrides = {}) {
+  const experimentID = `ufn-exp-${randomUUID()}`;
+  created.experiments.push(experimentID);
+  await db.doc(`experiments/${experimentID}`).set({
+    title: "Working Memory Span",
+    active: true,
+    sessions: 3,
+    storageProvider: "gdrive",
+    providerContainer: { provider: "gdrive", folderId: "folder-1" },
+    ...overrides,
+  });
+  return experimentID;
+}
+
+async function seedOwner(fields = { contactEmail: "researcher@example.edu" }) {
+  const uid = `ufn-user-${randomUUID()}`;
+  created.users.push(uid);
+  await db.doc(`users/${uid}`).set({ uid, email: "", experiments: [], ...fields });
+  return uid;
+}
+
+// A queue entry as the retry worker would leave it. Written to Firestore
+// because the DRAIN predicate queries the collection; the FAILURE path reads
+// no queue documents at all, so tests that only fail entries may skip this.
+async function seedQueueDoc(experimentID, owner, overrides = {}) {
+  const filename = `${randomUUID()}.csv`;
+  // Same id scheme queue-upload.ts uses, so the fixtures look like production.
+  const docId = `${experimentID}:${filename}`.replace(/[/\\]/g, "_");
+  created.queueDocs.push(docId);
+  const data = {
+    experimentID,
+    owner,
+    filename,
+    storagePath: `upload-queue/${docId}`,
+    dataType: "data",
+    status: "pending",
+    errorCode: 0,
+    retryCount: 0,
+    maxRetries: 5,
+    createdAt: Timestamp.now(),
+    lastAttemptAt: null,
+    nextRetryAt: Timestamp.now(),
+    completedAt: null,
+    failureReason: null,
+    deduplicationKey: docId,
+    sessionIncremented: true,
+    storageProvider: "gdrive",
+    ...overrides,
+  };
+  await db.doc(`uploadQueue/${docId}`).set(data);
+  return { docId, data };
+}
+
+// An in-memory payload only -- the shape the trigger hands handleQueueWrite.
+function queuePayload(experimentID, owner, overrides = {}) {
+  return {
+    experimentID,
+    owner,
+    status: "pending",
+    retryCount: 0,
+    storageProvider: "gdrive",
+    ...overrides,
+  };
+}
+
+async function uploadFailureState(experimentID) {
+  const snap = await db.doc(`experiments/${experimentID}`).get();
+  return snap.exists ? snap.data().uploadFailure : undefined;
+}
+
+async function mailFor(experimentID) {
+  const snap = await db
+    .collection("mail")
+    .where("datapipe.experimentID", "==", experimentID)
+    .get();
+  return snap.docs.map((d) => d.data());
+}
+
+afterEach(async () => {
+  const batch = db.batch();
+  for (const experimentID of created.experiments) {
+    // Mail documents get server-generated ids, so they are found by the
+    // audit field mail.ts writes for exactly this purpose (and that
+    // purge-user-data.ts will query on).
+    const mail = await db
+      .collection("mail")
+      .where("datapipe.experimentID", "==", experimentID)
+      .get();
+    mail.docs.forEach((d) => batch.delete(d.ref));
+    batch.delete(db.doc(`experiments/${experimentID}`));
+  }
+  for (const uid of created.users) batch.delete(db.doc(`users/${uid}`));
+  for (const docId of created.queueDocs) batch.delete(db.doc(`uploadQueue/${docId}`));
+  await batch.commit();
+  created.experiments.length = 0;
+  created.users.length = 0;
+  created.queueDocs.length = 0;
+});
+
+// ---------------------------------------------------------------------------
+// 1-3. The send predicate fires on failures DataPipe has already tried to fix
+// ---------------------------------------------------------------------------
+
+describe("first failure", () => {
+  test("a first retry failure mails the owner exactly once and arms the flag", async () => {
+    const owner = await seedOwner();
+    const experimentID = await seedExperiment({ owner });
+
+    const before = queuePayload(experimentID, owner, { retryCount: 0 });
+    const after = queuePayload(experimentID, owner, {
+      retryCount: 1,
+      providerErrorCode: "UNAVAILABLE",
+    });
+
+    const outcome = await handleQueueWrite(before, after, "doc-1");
+    expect(outcome).toBe("mailed");
+
+    const mail = await mailFor(experimentID);
+    expect(mail).toHaveLength(1);
+    expect(mail[0].to).toEqual(["researcher@example.edu"]);
+    expect(mail[0].message.subject).toContain("Working Memory Span");
+    expect(mail[0].message.text).toContain("The file is not lost.");
+    expect(mail[0].message.text).toContain(`/admin/${experimentID}`);
+    expect(mail[0].datapipe.kind).toBe("upload-failure");
+    expect(mail[0].datapipe.owner).toBe(owner);
+
+    const state = await uploadFailureState(experimentID);
+    expect(state.notifiedAt).not.toBeNull();
+    expect(state.lastNotifiedAt).toBeDefined();
+    expect(state.firstFailureAt).not.toBeNull();
+    expect(state.failureCount).toBe(1);
+    expect(state.suppressedReason).toBeNull();
+  });
+
+  test("a second file failing in the same episode is counted, not mailed", async () => {
+    const owner = await seedOwner();
+    const experimentID = await seedExperiment({ owner });
+
+    await handleQueueWrite(
+      queuePayload(experimentID, owner, { retryCount: 0 }),
+      queuePayload(experimentID, owner, { retryCount: 1 }),
+      "doc-a"
+    );
+    const outcome = await handleQueueWrite(
+      queuePayload(experimentID, owner, { retryCount: 0 }),
+      queuePayload(experimentID, owner, { retryCount: 1 }),
+      "doc-b"
+    );
+
+    expect(outcome).toBe("counted");
+    expect(await mailFor(experimentID)).toHaveLength(1);
+    expect((await uploadFailureState(experimentID)).failureCount).toBe(2);
+  });
+
+  test("an immediate terminal failure mails even though retryCount never moved", async () => {
+    // The finalized-while-queued path (scheduled-upload-retry.ts:162-171) and
+    // its three siblings write `failed` directly, consuming no attempt. If the
+    // predicate keyed only on retryCount these would never notify anyone.
+    const owner = await seedOwner();
+    const experimentID = await seedExperiment({ owner });
+
+    const outcome = await handleQueueWrite(
+      queuePayload(experimentID, owner, { status: "processing", retryCount: 0 }),
+      queuePayload(experimentID, owner, {
+        status: "failed",
+        retryCount: 0,
+        failureReason: "This experiment was finalized while the upload was queued.",
+      }),
+      "doc-terminal"
+    );
+
+    expect(outcome).toBe("mailed");
+    expect(await mailFor(experimentID)).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. The regression that justifies the whole predicate
+// ---------------------------------------------------------------------------
+
+describe("non-failures stay silent", () => {
+  test("a compaction hold is not a failure: no mail, and no uploadFailure written at all", async () => {
+    // compaction-gate.ts diverts writes into the queue on purpose, and the
+    // retry worker reschedules those entries WITHOUT incrementing retryCount.
+    // Firing here would false-alarm on every compaction pass.
+    const owner = await seedOwner();
+    const experimentID = await seedExperiment({ owner });
+
+    const outcome = await handleQueueWrite(
+      queuePayload(experimentID, owner, { status: "processing", retryCount: 2 }),
+      queuePayload(experimentID, owner, {
+        status: "pending",
+        retryCount: 2,
+        failureReason: COMPACTION_HOLD_REASON,
+      }),
+      "doc-hold"
+    );
+
+    expect(outcome).toBe("noop");
+    expect(await mailFor(experimentID)).toHaveLength(0);
+    // Not merely "no mail" -- the experiment document must be untouched, so a
+    // compaction pass leaves no trace on the notification state.
+    expect(await uploadFailureState(experimentID)).toBeUndefined();
+  });
+
+  test("queueing a brand-new entry is not a failure", async () => {
+    // Queue-time is when the self-healing codes (CONTENTION, AUTH_EXPIRED) are
+    // at their most likely to clear on their own within the minute.
+    const owner = await seedOwner();
+    const experimentID = await seedExperiment({ owner });
+
+    const outcome = await handleQueueWrite(
+      undefined,
+      queuePayload(experimentID, owner, {
+        status: "pending",
+        retryCount: 0,
+        providerErrorCode: "CONTENTION",
+      }),
+      "doc-new"
+    );
+
+    expect(outcome).toBe("noop");
+    expect(await mailFor(experimentID)).toHaveLength(0);
+    expect(await uploadFailureState(experimentID)).toBeUndefined();
+  });
+
+  test("a failure on a deleted experiment writes nothing and creates no ghost document", async () => {
+    // "Experiment not found" is itself one of the terminal failure paths, so
+    // this event really does arrive. tx.set here would CREATE an experiment
+    // document carrying nothing but uploadFailure.
+    const owner = await seedOwner();
+    const experimentID = `ufn-exp-missing-${randomUUID()}`;
+    // Registered for cleanup even though it is never created: if the code
+    // under test regresses and DOES create it, the residue must not outlive
+    // this test in the shared emulator.
+    created.experiments.push(experimentID);
+
+    const outcome = await handleQueueWrite(
+      queuePayload(experimentID, owner, { status: "processing", retryCount: 0 }),
+      queuePayload(experimentID, owner, { status: "failed", retryCount: 0 }),
+      "doc-orphan"
+    );
+
+    expect(outcome).toBe("noop");
+    expect((await db.doc(`experiments/${experimentID}`).get()).exists).toBe(false);
+    expect(await mailFor(experimentID)).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5-7. Draining re-arms the episode
+// ---------------------------------------------------------------------------
+
+describe("drain", () => {
+  async function armEpisode(experimentID, owner) {
+    await handleQueueWrite(
+      queuePayload(experimentID, owner, { retryCount: 0 }),
+      queuePayload(experimentID, owner, { retryCount: 1 }),
+      "doc-arm"
+    );
+  }
+
+  test("the last entry completing clears the flag but keeps lastNotifiedAt", async () => {
+    const owner = await seedOwner();
+    const experimentID = await seedExperiment({ owner });
+    await armEpisode(experimentID, owner);
+    const armed = await uploadFailureState(experimentID);
+
+    // The entry that just landed, already `completed`, so the drain query
+    // (pending/processing/failed) does not see it.
+    await seedQueueDoc(experimentID, owner, { status: "completed" });
+
+    const outcome = await handleQueueWrite(
+      queuePayload(experimentID, owner, { status: "processing" }),
+      queuePayload(experimentID, owner, { status: "completed" }),
+      "doc-done"
+    );
+
+    expect(outcome).toBe("cleared");
+    const state = await uploadFailureState(experimentID);
+    expect(state.notifiedAt).toBeNull();
+    expect(state.firstFailureAt).toBeNull();
+    expect(state.failureCount).toBe(0);
+    expect(state.suppressedReason).toBeNull();
+    // The flap backstop. Cleared here, a queue that broke every hour would
+    // mail every hour.
+    expect(state.lastNotifiedAt.toMillis()).toBe(armed.lastNotifiedAt.toMillis());
+  });
+
+  test("a delete can be the drain -- the cleanupOldEntries case", async () => {
+    // cleanupOldEntries DELETES queue documents at seven days, any status, so
+    // `after` is undefined. compaction-triggers.ts's sibling trigger returns
+    // early on exactly that condition; this one must not, because the last
+    // `failed` entry ageing out is the normal way a dead episode ends.
+    const owner = await seedOwner();
+    const experimentID = await seedExperiment({ owner });
+    await armEpisode(experimentID, owner);
+
+    const { docId } = await seedQueueDoc(experimentID, owner, { status: "failed" });
+    const before = (await db.doc(`uploadQueue/${docId}`).get()).data();
+    await db.doc(`uploadQueue/${docId}`).delete();
+
+    const outcome = await handleQueueWrite(before, undefined, docId);
+
+    expect(outcome).toBe("cleared");
+    expect((await uploadFailureState(experimentID)).notifiedAt).toBeNull();
+  });
+
+  test("a lingering failed entry keeps the queue non-empty", async () => {
+    // `failed` is in the unresolved set on purpose: a permanently dead file is
+    // a problem the researcher has not dealt with, and re-arming would mail
+    // them again about a queue that never actually got better.
+    const owner = await seedOwner();
+    const experimentID = await seedExperiment({ owner });
+    await armEpisode(experimentID, owner);
+
+    await seedQueueDoc(experimentID, owner, { status: "completed" });
+    await seedQueueDoc(experimentID, owner, { status: "failed" });
+
+    const outcome = await handleQueueWrite(
+      queuePayload(experimentID, owner, { status: "processing" }),
+      queuePayload(experimentID, owner, { status: "completed" }),
+      "doc-done"
+    );
+
+    expect(outcome).toBe("noop");
+    expect((await uploadFailureState(experimentID)).notifiedAt).not.toBeNull();
+  });
+
+  test("a completion on an experiment with no episode costs no write", async () => {
+    const owner = await seedOwner();
+    const experimentID = await seedExperiment({ owner });
+
+    const outcome = await handleQueueWrite(
+      queuePayload(experimentID, owner, { status: "processing" }),
+      queuePayload(experimentID, owner, { status: "completed" }),
+      "doc-happy"
+    );
+
+    expect(outcome).toBe("noop");
+    expect(await uploadFailureState(experimentID)).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 8. The race. This is the package's whole reason for being Opus-built.
+// ---------------------------------------------------------------------------
+
+describe("concurrency", () => {
+  test("twenty simultaneous failures produce exactly one mail", async () => {
+    // The routine case, not an exotic one: a metadataActive submission writes
+    // a raw file, a main CSV and one sidecar per extracted column, and the
+    // retry worker can fail all of them in a single run -- firing that many
+    // trigger invocations at once against the same experiment document.
+    //
+    // No uploadQueue documents are seeded: the FAILURE path reads the
+    // experiment and the owner and nothing else, so writing twenty queue docs
+    // would slow the test without changing what it exercises.
+    const owner = await seedOwner();
+    const experimentID = await seedExperiment({ owner });
+
+    const outcomes = await Promise.all(
+      Array.from({ length: 20 }, (_, i) =>
+        handleQueueWrite(
+          queuePayload(experimentID, owner, { retryCount: 0 }),
+          queuePayload(experimentID, owner, { retryCount: 1 }),
+          `doc-race-${i}`
+        )
+      )
+    );
+
+    expect(await mailFor(experimentID)).toHaveLength(1);
+    expect(outcomes.filter((o) => o === "mailed")).toHaveLength(1);
+    expect(outcomes.filter((o) => o === "counted")).toHaveLength(19);
+    // Every one of them landed: the mail and the flag are one commit, and the
+    // count is a field transform, so nothing is lost to the retries.
+    expect((await uploadFailureState(experimentID)).failureCount).toBe(20);
+    // Longer than the suite default: nineteen of these transactions lose the
+    // race and re-run, and the emulator backs off between attempts.
+  }, 60000);
+});
+
+// ---------------------------------------------------------------------------
+// 9. The flap backstop
+// ---------------------------------------------------------------------------
+
+describe("rate limit", () => {
+  async function failOnce(experimentID, owner, docId) {
+    return handleQueueWrite(
+      queuePayload(experimentID, owner, { retryCount: 0 }),
+      queuePayload(experimentID, owner, { retryCount: 1 }),
+      docId
+    );
+  }
+
+  async function drain(experimentID, owner, docId) {
+    return handleQueueWrite(
+      queuePayload(experimentID, owner, { status: "processing" }),
+      queuePayload(experimentID, owner, { status: "completed" }),
+      docId
+    );
+  }
+
+  test("a queue that flaps clear->fail is silent until 24 hours have passed", async () => {
+    const owner = await seedOwner();
+    const experimentID = await seedExperiment({ owner });
+
+    expect(await failOnce(experimentID, owner, "flap-1")).toBe("mailed");
+    expect(await drain(experimentID, owner, "flap-1")).toBe("cleared");
+
+    // Re-armed, so the predicate fires again -- and the 24-hour floor, read
+    // from the lastNotifiedAt the drain deliberately left behind, is the only
+    // thing standing between this study and 168 emails a week.
+    expect(await failOnce(experimentID, owner, "flap-2")).toBe("rate-limited");
+    expect(await mailFor(experimentID)).toHaveLength(1);
+
+    const suppressed = await uploadFailureState(experimentID);
+    expect(suppressed.suppressedReason).toBe("rate-limited");
+    // Still armed, so the rest of the burst is quiet too.
+    expect(suppressed.notifiedAt).not.toBeNull();
+
+    // Advance past the floor. Timestamp.now() reads Date.now(), so this is the
+    // same seam pending-recovery-provider-regression.test.js:112 uses to move
+    // a cutoff without waiting for real time to pass.
+    const realNow = Date.now();
+    const nowSpy = jest
+      .spyOn(Date, "now")
+      .mockReturnValue(realNow + RATE_LIMIT_MS + 60 * 60 * 1000);
+    try {
+      expect(await drain(experimentID, owner, "flap-2")).toBe("cleared");
+      expect(await failOnce(experimentID, owner, "flap-3")).toBe("mailed");
+    } finally {
+      nowSpy.mockRestore();
+    }
+
+    expect(await mailFor(experimentID)).toHaveLength(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 10. Nobody to write to
+// ---------------------------------------------------------------------------
+
+describe("no contact email", () => {
+  test("arms the episode and records why, without sending anything", async () => {
+    // The ORCID and OSF-era populations, until Feature 1's gate closes them
+    // out. Arming still matters: without the flag, twenty derived-file
+    // failures would each open a transaction and each re-decide.
+    const owner = await seedOwner({});
+    const experimentID = await seedExperiment({ owner });
+
+    const outcome = await handleQueueWrite(
+      queuePayload(experimentID, owner, { retryCount: 0 }),
+      queuePayload(experimentID, owner, { retryCount: 1 }),
+      "doc-nomail"
+    );
+
+    expect(outcome).toBe("no-contact-email");
+    expect(await mailFor(experimentID)).toHaveLength(0);
+
+    const state = await uploadFailureState(experimentID);
+    expect(state.notifiedAt).not.toBeNull();
+    expect(state.suppressedReason).toBe("no-contact-email");
+    expect(state.failureCount).toBe(1);
+    // Never sent, so the 24-hour floor was never started -- the moment an
+    // address is added, the next episode can mail immediately.
+    expect(state.lastNotifiedAt).toBeUndefined();
+  });
+
+  test("the synthetic OSF address is not a contact address", async () => {
+    // oauth2-callback.ts seeds `user-{id}@osf.io` as a fallback and it is
+    // undeliverable. contactEmailRecipient rejects it; a naive truthiness
+    // check would mail it forever.
+    const owner = await seedOwner({ contactEmail: "user-abc123@osf.io" });
+    const experimentID = await seedExperiment({ owner });
+
+    const outcome = await handleQueueWrite(
+      queuePayload(experimentID, owner, { retryCount: 0 }),
+      queuePayload(experimentID, owner, { retryCount: 1 }),
+      "doc-synthetic"
+    );
+
+    expect(outcome).toBe("no-contact-email");
+    expect(await mailFor(experimentID)).toHaveLength(0);
+  });
+
+  test("a missing owner document suppresses rather than throws", async () => {
+    const experimentID = await seedExperiment({ owner: "ufn-ghost-owner" });
+
+    const outcome = await handleQueueWrite(
+      queuePayload(experimentID, "ufn-ghost-owner", { retryCount: 0 }),
+      queuePayload(experimentID, "ufn-ghost-owner", { retryCount: 1 }),
+      "doc-noowner"
+    );
+
+    expect(outcome).toBe("no-contact-email");
+    expect(await mailFor(experimentID)).toHaveLength(0);
+  });
+});

--- a/functions/src/email/upload-failure-copy.ts
+++ b/functions/src/email/upload-failure-copy.ts
@@ -1,0 +1,255 @@
+// The first-failure notification, as words.
+//
+// PURE ON PURPOSE. This module reads no Firestore, imports no app.js, and has
+// no runtime imports at all (the two imports below are `import type` and are
+// erased at compile time). That is what lets the copy be unit-tested with no
+// emulator and no network -- see __tests__/upload-failure-copy.test.js -- and
+// it is the reason the wording lives here instead of inline in
+// upload-failure-notify.ts, where every assertion about a sentence would need
+// a transaction to reach it.
+//
+// The mail this builds is the ONE message DataPipe gets to send about a broken
+// upload (upload-failure-notify.ts sends at most one per episode, and at most
+// one per experiment per 24 hours). Everything below is shaped by that: a
+// researcher who skims it must come away knowing their data is not lost,
+// whether they have to do anything, and where to look. Crying wolf, or being
+// vague, spends the only signal we have.
+
+import type { StorageProviderId, ProviderErrorCode } from "../providers/types.js";
+
+// Hardcoded rather than read from an env var, matching pages/api-docs.js:14,
+// which does the same for the same reason: this is the production hostname and
+// there is no server-side base-URL variable in functions/ to read. A staging
+// deploy therefore mails production links -- acceptable, because staging mail
+// is not delivered at all (the Trigger Email extension is not installed there;
+// see functions/src/mail.ts).
+export const APP_BASE_URL = "https://pipe.jspsych.org";
+
+export function experimentUrl(experimentID: string): string {
+  return `${APP_BASE_URL}/admin/${experimentID}`;
+}
+
+export const ACCOUNT_URL = `${APP_BASE_URL}/admin/account`;
+export const FAQ_URL = `${APP_BASE_URL}/faq`;
+
+// Five attempts over roughly 31 hours: the slow tier's backoff chain in
+// scheduled-upload-retry.ts is 2 + 4 + 8 + 16 h before the fifth attempt is
+// abandoned at maxRetries (queue-upload.ts's MAX_RETRIES = 5), plus the ~1 h
+// first delay -- ~31 hours end to end. Stated in the mail because "we are
+// retrying" without a horizon leaves the researcher unable to judge when
+// silence has become a problem.
+export const RETRY_WINDOW_DESCRIPTION = "five attempts over about 31 hours";
+
+// Human names for the taxonomy in providers/types.ts. Falls back to a generic
+// phrase rather than printing the raw id: "we could not write to gdrive" reads
+// like a bug report, not a sentence.
+const PROVIDER_NAMES: Record<string, string> = {
+  osf: "OSF",
+  gdrive: "Google Drive",
+  figshare: "Figshare",
+  dataverse: "Dataverse",
+  zenodo: "Zenodo",
+};
+
+// Own-property lookup, not `map[key]`. Both maps below are indexed by values
+// that arrive from Firestore documents, and a document field reading
+// "constructor" or "toString" would otherwise resolve up the prototype chain
+// and interpolate a function into an email. Cheap to prevent, ugly to discover.
+function lookup(map: Record<string, string>, key: unknown): string | undefined {
+  return typeof key === "string" && Object.prototype.hasOwnProperty.call(map, key)
+    ? map[key]
+    : undefined;
+}
+
+export function providerDisplayName(
+  provider?: StorageProviderId | string | null
+): string {
+  return lookup(PROVIDER_NAMES, provider) || "your storage provider";
+}
+
+// One clause per ProviderErrorCode, saying what happened in the researcher's
+// terms. Deliberately consistent with what the dashboard already tells them
+// (components/dashboard/QueuePanel.js's PROVIDER_ERROR_COPY): the mail and the
+// queue panel are describing the same queue entry, and a researcher who reads
+// one and then the other must not have to reconcile two accounts of it.
+const REASON_LINES: Record<string, string> = {
+  AUTH_EXPIRED: "your storage connection needs to be reconnected",
+  QUOTA_EXCEEDED: "your storage account is out of room",
+  RATE_LIMITED: "the provider is asking us to slow down",
+  UNAVAILABLE: "the provider was unreachable",
+  CONTENTION: "another write to the same folder was in progress",
+  NAME_CONFLICT: "a file with that name already exists",
+};
+
+// The fallback covers two real populations, not just malformed data: queue
+// entries written before providerErrorCode existed, and -- the larger group --
+// every failure that never reached the provider at all (token resolution,
+// collision-cache trouble, an unreadable payload), since only a provider
+// WriteResult carries a code. Saying "the upload did not complete" is honest
+// about that and sends them to the queue panel, which does have the detail.
+const FALLBACK_REASON = "the upload did not complete";
+
+export function reasonLine(code?: ProviderErrorCode | string | null): string {
+  return lookup(REASON_LINES, code) || FALLBACK_REASON;
+}
+
+/**
+ * What the researcher should actually do, which is usually "nothing".
+ *
+ * Saying so explicitly matters more than it looks: an alert that never
+ * distinguishes "we have got this" from "only you can fix this" trains people
+ * to ignore all of them, and the codes in the first group (CONTENTION,
+ * UNAVAILABLE, RATE_LIMITED) are the common ones.
+ */
+export function actionLine(
+  code: ProviderErrorCode | string | null | undefined,
+  provider: StorageProviderId | string | null | undefined
+): string {
+  const name = providerDisplayName(provider);
+  // Absent storageProvider means a legacy OSF experiment -- the field is
+  // additive and pre-migration documents have none (see interfaces.ts's
+  // ExperimentData) -- so both shapes are the same case here.
+  const legacyOsf = !provider || provider === "osf";
+
+  switch (code) {
+    case "AUTH_EXPIRED":
+      // Reconnecting is the standard fix and the wrong advice for OSF: OSF is
+      // retiring the projects feature DataPipe writes into, so a researcher
+      // sent to reconnect would be trying to repair something that is going
+      // away. The FAQ is where that story is told (pages/faq.js).
+      return legacyOsf
+        ? `OSF is winding down the projects feature DataPipe writes into, so reconnecting may not fix this. ${FAQ_URL} explains the options for an OSF experiment.`
+        : `Reconnect ${name} from your account settings: ${ACCOUNT_URL}`;
+    case "QUOTA_EXCEEDED":
+      return `Free up room in ${name}, or move this study to a provider with more space. Until there is room, further uploads will keep failing.`;
+    case "RATE_LIMITED":
+      return `Nothing to do right now -- ${name} has asked us to slow down and DataPipe is waiting it out. Check the experiment page if the queue is still backed up tomorrow.`;
+    case "UNAVAILABLE":
+      return `Nothing to do right now -- this usually means ${name} had an outage, and DataPipe keeps retrying until it is back.`;
+    case "CONTENTION":
+      return "Nothing to do right now -- this is normal when several participants finish at once, and it usually clears within minutes.";
+    case "NAME_CONFLICT":
+      return `Check ${name} for a file with the same name. The data may already be there under a name DataPipe did not expect.`;
+    default:
+      return (
+        "Open the experiment page below. The queue panel lists every waiting file, " +
+        "explains each one, and lets you download it directly."
+      );
+  }
+}
+
+export interface UploadFailureCopyInput {
+  experimentID: string;
+  // The experiment doc's `title`. Optional because nothing guarantees one on
+  // an old document, and a mail with a blank name in the subject would be
+  // worse than a mail that names the id.
+  title?: string | null;
+  storageProvider?: StorageProviderId | string | null;
+  providerErrorCode?: ProviderErrorCode | string | null;
+  // uploadFailure.failureCount AFTER this failure is counted. Normally 1: this
+  // mail is only composed on the first failure of an episode, so the count has
+  // just been incremented from 0. It can be higher only when a caller composes
+  // for an already-open episode, so the extra line below is conditional rather
+  // than always rendered -- "1 file is waiting so far" is noise.
+  failureCount?: number;
+}
+
+export interface UploadFailureEmail {
+  subject: string;
+  text: string;
+  html: string;
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+/**
+ * Builds the subject and both bodies for a first-failure notification.
+ *
+ * Order is consequence, then reassurance, then mechanism, then action
+ * (PRODUCT.md principle 2). The first sentence has to survive being the only
+ * one read -- in a notification list it may be all that is shown -- so it
+ * carries the whole event: whose study, what did not happen, and where.
+ */
+export function buildUploadFailureEmail(
+  input: UploadFailureCopyInput
+): UploadFailureEmail {
+  const { experimentID, title, storageProvider, providerErrorCode } = input;
+  const name = (title || "").trim();
+  const provider = providerDisplayName(storageProvider);
+  const link = experimentUrl(experimentID);
+  const reason = reasonLine(providerErrorCode);
+  const action = actionLine(providerErrorCode, storageProvider);
+  const failureCount = input.failureCount ?? 0;
+
+  const subject = name
+    ? `DataPipe couldn't upload a data file for "${name}"`
+    : "DataPipe couldn't upload a data file for your experiment";
+
+  const study = name ? `"${name}"` : `your experiment (${experimentID})`;
+
+  const opening =
+    `A participant finished ${study} and DataPipe could not write their data file to ${provider}.`;
+
+  // The single most important sentence in the mail, kept separate so the HTML
+  // body can bold it without pulling it back out of a longer string. A
+  // researcher who reads "upload failed" and stops reading assumes lost data
+  // and starts a support thread, or worse, re-runs participants.
+  const NOT_LOST = "The file is not lost.";
+  const retryExplanation =
+    "DataPipe saved a copy before the upload was attempted and is " +
+    `retrying automatically, with increasing delays, across ${RETRY_WINDOW_DESCRIPTION}. ` +
+    "Most upload failures clear on their own. Any file that never lands can be downloaded " +
+    "from the experiment page.";
+  const reassurance = `${NOT_LOST} ${retryExplanation}`;
+
+  const reasonSentence = `What went wrong: ${reason}.`;
+  const actionSentence = `What to check: ${action}`;
+
+  // Only when a burst was already in progress. See failureCount above.
+  const burstSentence =
+    failureCount > 1
+      ? `${failureCount} files from this experiment are waiting so far. `
+      : "";
+
+  const cadence =
+    `${burstSentence}We will only email you once about this -- not once per file. ` +
+    "If more files fail after this experiment's queue clears, you'll hear from us again.";
+
+  const footer =
+    "You are getting this because DataPipe needs to be able to tell you when your data stops " +
+    "arriving. It is the only kind of message sent to this address -- no announcements, no " +
+    `mailing list -- and it is never shown to participants. Change the address: ${ACCOUNT_URL}`;
+
+  const text = [
+    opening,
+    reassurance,
+    reasonSentence,
+    actionSentence,
+    cadence,
+    `See the queue and download any waiting file: ${link}`,
+    "--",
+    footer,
+  ].join("\n\n");
+
+  // `title` is researcher-supplied and reaches this string unfiltered, so it
+  // is escaped -- along with everything else, so no future edit has to
+  // remember which values were trusted.
+  const html = [
+    `<p>${escapeHtml(opening)}</p>`,
+    `<p><strong>${escapeHtml(NOT_LOST)}</strong> ${escapeHtml(retryExplanation)}</p>`,
+    `<p>${escapeHtml(reasonSentence)}</p>`,
+    `<p>${escapeHtml(actionSentence)}</p>`,
+    `<p>${escapeHtml(cadence)}</p>`,
+    `<p><a href="${escapeHtml(link)}">See the queue and download any waiting file</a><br>${escapeHtml(link)}</p>`,
+    "<hr>",
+    `<p style="font-size:0.9em;color:#555">${escapeHtml(footer)}</p>`,
+  ].join("\n");
+
+  return { subject, text, html };
+}

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -13,6 +13,11 @@ import { onExperimentGrew, onUploadQueueChanged } from "./compaction-triggers.js
 // A SECOND trigger on uploadQueue/{docId}, deliberately not folded into
 // onUploadQueueChanged above -- see the header of upload-failure-notify.ts.
 import { onUploadFailure } from "./upload-failure-notify.js";
+// The verification round trip (plan §2.2, §5 package P3): a resend-capable
+// send + a hash-checked verify, both bearer-token onRequest endpoints in the
+// same shape as deleteAccount / apiQueueStatus below.
+import { sendContactEmailVerification } from "./send-contact-email-verification.js";
+import { verifyContactEmail } from "./verify-contact-email.js";
 import { apiQueueStatus } from "./api-queue-status.js";
 import { generateOAuthState } from "./generate-oauth-state.js";
 import { connectProvider, connectStaticTokenProvider, disconnectProvider } from "./connect-provider.js";
@@ -42,6 +47,8 @@ export {
   onExperimentGrew as onexperimentgrew,
   onUploadQueueChanged as onuploadqueuechanged,
   onUploadFailure as onuploadfailure,
+  sendContactEmailVerification as sendcontactemailverification,
+  verifyContactEmail as verifycontactemail,
   apiQueueStatus as apiqueuestatus,
   generateOAuthState as generateoauthstate,
   connectProvider as connectprovider,

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -10,6 +10,9 @@ import { scheduledTokenRefresh } from "./scheduled-token-refresh.js";
 import { scheduledUploadRetry } from "./scheduled-upload-retry.js";
 import { scheduledPendingRecovery } from "./scheduled-pending-recovery.js";
 import { onExperimentGrew, onUploadQueueChanged } from "./compaction-triggers.js";
+// A SECOND trigger on uploadQueue/{docId}, deliberately not folded into
+// onUploadQueueChanged above -- see the header of upload-failure-notify.ts.
+import { onUploadFailure } from "./upload-failure-notify.js";
 import { apiQueueStatus } from "./api-queue-status.js";
 import { generateOAuthState } from "./generate-oauth-state.js";
 import { connectProvider, connectStaticTokenProvider, disconnectProvider } from "./connect-provider.js";
@@ -38,6 +41,7 @@ export {
   scheduledPendingRecovery as scheduledpendingrecovery,
   onExperimentGrew as onexperimentgrew,
   onUploadQueueChanged as onuploadqueuechanged,
+  onUploadFailure as onuploadfailure,
   apiQueueStatus as apiqueuestatus,
   generateOAuthState as generateoauthstate,
   connectProvider as connectprovider,

--- a/functions/src/interfaces.ts
+++ b/functions/src/interfaces.ts
@@ -44,6 +44,44 @@ export interface ExperimentData {
     // reason: a researcher forging "finalized" progress here would be
     // indistinguishable, to the dashboard poller, from a real pass.
     finalization?: FinalizationState;
+    // First-failure notification state (functions/src/upload-failure-notify.ts).
+    // Server-managed: firestore.rules lists `uploadFailure` in
+    // serverManagedFieldsUntouched() for the same reason it lists `compaction`
+    // and `collisionCache` -- it holds Timestamps that server code calls
+    // .toMillis() on, and a client able to clear notifiedAt could make
+    // DataPipe mail them once per failed file instead of once per episode.
+    uploadFailure?: UploadFailureState;
+  }
+
+  // experiments/{id}.uploadFailure. One episode at a time: an episode opens at
+  // the first failure DataPipe has actually retried, and closes when the
+  // experiment's queue drains (nothing left in pending/processing/failed).
+  //
+  // Every field is optional because the map is created lazily by the first
+  // failure and because a document written before this feature has none of
+  // them -- readers must treat "absent" as "disarmed, never notified".
+  export interface UploadFailureState {
+    // ARMED flag, and the whole point of the feature. Non-null means the
+    // researcher has already been told about the CURRENT episode, so further
+    // failures only increment the count. Cleared (to null) when the queue
+    // drains, which re-arms the next episode.
+    //
+    // It is also set when no mail was sent -- see suppressedReason -- because
+    // suppressing the burst matters as much as suppressing the duplicate mail:
+    // one submission can produce twenty queue entries.
+    notifiedAt?: FirebaseFirestore.Timestamp | null;
+    // Rate-limit floor: the last time mail was ACTUALLY sent. NEVER cleared,
+    // including on drain, because it is the backstop against a queue that
+    // flaps clear->fail every hour for a week. One mail per experiment per 24
+    // hours, maximum.
+    lastNotifiedAt?: FirebaseFirestore.Timestamp;
+    // Start of the current episode; cleared on drain alongside notifiedAt.
+    firstFailureAt?: FirebaseFirestore.Timestamp | null;
+    // Files that have failed in the current episode. Reset to 0 on drain.
+    failureCount?: number;
+    // Why the episode was armed without sending anything. Owner-visible in
+    // Firestore, never shown to the researcher.
+    suppressedReason?: "no-contact-email" | "rate-limited" | null;
   }
 
   // experiments/{id}.finalization. `status` starts at "queued" the moment
@@ -111,6 +149,35 @@ export interface ExperimentData {
     authTokenExpires: number;
     // Provider-migration field (additive; legacy OSF fields above stay as-is).
     connectedAccounts?: ConnectedAccounts;
+    // Where DataPipe writes to when a researcher's data stops arriving.
+    //
+    // Deliberately NOT the same thing as `email` above. `email` is an identity
+    // key -- check-email-conflict.ts and oauth2-callback.ts query it for
+    // account collisions -- and it is provenance-mixed: "" for ORCID, an
+    // OSF-API address or the synthetic `user-{id}@osf.io` fallback for the
+    // OSF-era population. Repurposing it would put a researcher-editable value
+    // into a collision query. `contactEmail` sits beside it and is the only
+    // field the notification path reads.
+    //
+    // Validation predicates live in functions/src/mail.ts
+    // (contactEmailRecipient), mirrored in lib/contact-email.js for the
+    // frontend. Both are additive: absent means "no address yet", which is the
+    // normal state for an ORCID or OSF-era account until the gate is met.
+    contactEmail?: string;
+    // Written by the server only. firestore.rules permits a CLIENT write of
+    // this field solely in the `false` direction, so saving a new address can
+    // reset the flag but no client can self-certify one. Nothing gates on it:
+    // notifications go to an unverified address too, because an unverified
+    // typo bounces while a withheld address delivers nothing at all.
+    contactEmailVerified?: boolean;
+    // Epoch ms, written by the client alongside contactEmail.
+    contactEmailUpdatedAt?: number;
+    // Provenance, diagnostic only. "auth" = copied from the Firebase Auth
+    // record's user.email; "user" = typed by the researcher. There is no
+    // OSF-derived source: OSF sign-in mints a custom token and never produced
+    // an Auth email, so no OSF-supplied address is ever seeded (see the
+    // SEEDING RULE in lib/contact-email.js).
+    contactEmailSource?: "auth" | "user";
   }
   
   export interface RequestBody {

--- a/functions/src/mail.ts
+++ b/functions/src/mail.ts
@@ -1,0 +1,140 @@
+import { FieldValue } from "firebase-admin/firestore";
+import { db } from "./app.js";
+
+// The one and only place DataPipe writes outbound mail.
+//
+// Delivery is the Firebase "Trigger Email" extension
+// (firebase/firestore-send-email), which watches the `mail` collection and
+// sends what it finds. Nothing in this codebase knows an SMTP host, a
+// provider, or a credential: the connection URI is extension configuration in
+// Secret Manager and is chosen at DEPLOY time, not here. Switching providers
+// is a config change, not a redeploy of these functions.
+//
+// Why an extension rather than nodemailer inside the functions: it keeps a
+// mail transport out of the same process that writes research data, it gets
+// retries and a `delivery.{state,attempts,error}` audit trail for free, and it
+// makes every test that touches this path assertable with no network and no
+// mock -- the emulator has no extension, so tests read the `mail` collection
+// and check that the right document appeared. That document IS the contract
+// DataPipe owns; delivery is the extension's.
+//
+// `mail` needs no entry in firestore.rules. Firestore default-denies every
+// unmatched path, so the collection is already invisible and unwritable from
+// any client. Stated here, and in firestore.rules, so nobody "fixes" it later
+// by adding a permissive rule.
+
+export const MAIL_COLLECTION = "mail";
+
+export interface MailMessage {
+  // Single recipient. The extension accepts a string or an array; we always
+  // write an array, so the shape is uniform for tests and for purge queries.
+  to: string;
+  subject: string;
+  text: string;
+  html?: string;
+}
+
+// Written under a `datapipe` key that the extension ignores (it only reads
+// `to`/`cc`/`bcc`/`message`/`template`). Two jobs: telling one kind of mail
+// from another when debugging, and giving purge-user-data.ts something to
+// query on -- `datapipe.owner == uid` is served by an automatic single-field
+// index, so account deletion can find and delete a researcher's queued mail
+// without leaving their address behind.
+export interface MailMeta {
+  // Discriminator, e.g. "upload-failure" or "contact-email-verification".
+  kind: string;
+  // Owning user's uid. Always set it: this is the purge handle.
+  owner?: string;
+  experimentID?: string;
+  [key: string]: unknown;
+}
+
+interface MailInput extends MailMessage {
+  meta: MailMeta;
+}
+
+function mailDocument({ to, subject, text, html, meta }: MailInput) {
+  return {
+    to: [to],
+    message: html === undefined ? { subject, text } : { subject, text, html },
+    datapipe: { ...meta, queuedAt: FieldValue.serverTimestamp() },
+  };
+}
+
+// A fresh, unwritten document reference in the mail collection. Callers that
+// enqueue inside a transaction need the ref BEFORE the transaction body runs
+// (a transaction may not allocate ids mid-flight), so this is separate from
+// enqueueMail.
+export function newMailRef(): FirebaseFirestore.DocumentReference {
+  return db.collection(MAIL_COLLECTION).doc();
+}
+
+// Transactional enqueue. The mail document is created as part of the caller's
+// commit, so the mail and whatever flag records that it was sent land together
+// or not at all -- there is no window in which a researcher is mailed but the
+// "already told them" flag is lost, which would mail them again on the next
+// failure.
+//
+// tx.create (not set) is deliberate: the ref comes from newMailRef() and is
+// therefore new, so a create is a cheap assertion that we are not overwriting
+// an unsent message.
+export function enqueueMail(
+  tx: FirebaseFirestore.Transaction,
+  ref: FirebaseFirestore.DocumentReference,
+  input: MailInput
+): void {
+  tx.create(ref, mailDocument(input));
+}
+
+// Non-transactional enqueue, for senders with nothing to keep consistent with
+// the send (the contact-email verification code, which is a direct response to
+// a request the researcher just made). Returns the ref so the caller can log
+// or assert on it.
+export async function sendMail(
+  input: MailInput
+): Promise<FirebaseFirestore.DocumentReference> {
+  const ref = newMailRef();
+  await ref.create(mailDocument(input));
+  return ref;
+}
+
+// ---------------------------------------------------------------------------
+// Recipient resolution.
+//
+// MIRROR of lib/contact-email.js -- keep the two in sync. They cannot be one
+// file: functions/ is a separate package whose tsconfig rootDir is ./src, and
+// its deploy bundle contains only functions/, so a root-level lib/ import
+// would neither compile nor deploy. The same two constraints (the synthetic
+// OSF pattern and the 254-character cap) are also restated in firestore.rules.
+// ---------------------------------------------------------------------------
+
+export const MAX_CONTACT_EMAIL_LENGTH = 254;
+
+// oauth2-callback.ts's `user-${osfUserId}@osf.io` fallback, which is sitting
+// in real user documents' `email` field today and is undeliverable.
+const OSF_SYNTHETIC_EMAIL_PATTERN = /^user-[a-z0-9]+@osf\.io$/i;
+const EMAIL_FORMAT = /^[^\s@]+@[^\s@.]+(\.[^\s@.]+)+$/;
+
+function normalize(value: unknown): string {
+  return typeof value === "string" ? value.trim().toLowerCase() : "";
+}
+
+// The address to mail, or null when this user has none we can reach. Callers
+// must treat null as "suppress and record why", never as "skip silently":
+// twenty derived files failing at once would otherwise open twenty
+// transactions and decide nothing.
+export function contactEmailRecipient(
+  userData: FirebaseFirestore.DocumentData | undefined
+): string | null {
+  const v = normalize(userData?.contactEmail);
+  if (v.length === 0 || v.length > MAX_CONTACT_EMAIL_LENGTH) return null;
+  if (!EMAIL_FORMAT.test(v)) return null;
+  if (OSF_SYNTHETIC_EMAIL_PATTERN.test(v)) return null;
+  return v;
+}
+
+export function hasContactEmail(
+  userData: FirebaseFirestore.DocumentData | undefined
+): boolean {
+  return contactEmailRecipient(userData) !== null;
+}

--- a/functions/src/purge-user-data.ts
+++ b/functions/src/purge-user-data.ts
@@ -1,4 +1,5 @@
 import { db, storage } from "./app.js";
+import { MAIL_COLLECTION } from "./mail.js";
 
 // Everything that belongs to one researcher, removed in one pass.
 //
@@ -33,6 +34,9 @@ export interface PurgeCounts {
   queueEntries: number;
   pendingFiles: number;
   userDocument: number;
+  // Contact-email additions (functions/src/mail.ts, lib/contact-email.js).
+  mailDocuments: number;
+  contactEmailVerification: number;
 }
 
 async function deleteInBatches(
@@ -66,6 +70,8 @@ export async function purgeUserData(uid: string): Promise<PurgeCounts> {
     queueEntries: 0,
     pendingFiles: 0,
     userDocument: 0,
+    mailDocuments: 0,
+    contactEmailVerification: 0,
   };
 
   const ownedExperiments = await db
@@ -119,6 +125,30 @@ export async function purgeUserData(uid: string): Promise<PurgeCounts> {
     .where("owner", "==", uid)
     .get();
   counts.queueEntries = await deleteInBatches(queued.docs.map((doc) => doc.ref));
+
+  // mail/ docs carry the researcher's contactEmail in their `to` field and are
+  // otherwise keyed by an autoId, so datapipe.owner == uid (an automatic
+  // single-field index -- see mail.ts's MailMeta) is the only way to find
+  // them. Deleting these is why account deletion must not leave an address
+  // behind: an undelivered or already-processed mail document is still a
+  // record of where DataPipe last tried to reach this person.
+  const queuedMail = await db
+    .collection(MAIL_COLLECTION)
+    .where("datapipe.owner", "==", uid)
+    .get();
+  counts.mailDocuments = await deleteInBatches(
+    queuedMail.docs.map((doc) => doc.ref)
+  );
+
+  // contactEmailVerifications/{uid} holds a hash of the researcher's
+  // in-flight verification code (functions/src/mail.ts's sibling, the
+  // server-only collection the plan describes at §2.2). Doc id is the uid
+  // itself, so this is a direct lookup, not a query.
+  const verificationRef = db.collection("contactEmailVerifications").doc(uid);
+  if ((await verificationRef.get()).exists) {
+    await verificationRef.delete();
+    counts.contactEmailVerification = 1;
+  }
 
   // Last: the user document holds connectedAccounts, i.e. the storage
   // provider credentials. If an earlier step throws, the researcher still

--- a/functions/src/send-contact-email-verification.ts
+++ b/functions/src/send-contact-email-verification.ts
@@ -1,0 +1,197 @@
+import { onRequest } from "firebase-functions/v2/https";
+import { randomInt, createHash } from "crypto";
+import { db, auth } from "./app.js";
+import { contactEmailRecipient, sendMail } from "./mail.js";
+import { ACCOUNT_URL } from "./email/upload-failure-copy.js";
+
+// Send (or resend) a 6-digit code that confirms users/{uid}.contactEmail.
+//
+// Verification is confirmatory, never a gate (plan §2.2): a researcher has
+// already satisfied the contact-email requirement the moment the address is
+// a syntactically valid, non-synthetic string (lib/contact-email.js's
+// hasContactEmail / this file's sibling mail.ts:contactEmailRecipient), and
+// the upload-failure notifier mails that address regardless of verified
+// state. This endpoint exists only so the account page can show "Confirmed"
+// instead of "Not confirmed yet" -- nothing downstream reads the flag to
+// decide whether to do anything.
+//
+// Auth shape copied from delete-account.ts / api-queue-status.ts exactly:
+// method check, then `Authorization: Bearer <idToken>`, then
+// auth.verifyIdToken. Unlike delete-account.ts this does not also need
+// checkRevoked or a recent-login window -- mailing a code to an address the
+// signed-in account already owns is not the kind of irreversible action that
+// justifies the extra friction.
+//
+// The address that gets a code is always users/{uid}.contactEmail AS
+// CURRENTLY STORED -- never a value the client could pass in the request
+// body. Trusting a client-supplied address would let a signed-in researcher
+// mint a "confirmed" flag for an address DataPipe doesn't actually have on
+// file.
+
+const CODE_DIGITS = 6;
+const CODE_SPACE = 10 ** CODE_DIGITS; // 1_000_000 possible codes
+
+// plan §2.2: "24-hour expiry, 5 attempts."
+export const EXPIRY_MS = 24 * 60 * 60 * 1000;
+
+// Floor between two sends to the same account. The plan does not pin a
+// number beyond "rate-limited" and putting `sentAt` in the
+// contactEmailVerifications schema for exactly this purpose; one minute is
+// enough to stop a resend-mail-bomb loop (an impatient double-click, or
+// someone hammering the endpoint) without making a researcher who mistyped
+// and wants a fresh code wait anywhere near as long as the 24-hour code
+// expiry itself.
+export const RESEND_COOLDOWN_MS = 60 * 1000;
+
+export const VERIFICATIONS_COLLECTION = "contactEmailVerifications";
+
+export function verificationRef(uid: string): FirebaseFirestore.DocumentReference {
+  return db.collection(VERIFICATIONS_COLLECTION).doc(uid);
+}
+
+// sha256 hex digest. Plain hashing, not crypto-utils.ts's AES encryption --
+// the code is a one-time, short-lived, 6-digit secret that only ever needs
+// to be COMPARED, never recovered, which is what a hash is for. Same
+// primitive collision-cache.ts already uses for its salted filename hashes.
+function sha256(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+// Crypto-random, uniform over [0, 10^6) -- Math.random() has no place
+// minting a secret. randomInt's upper bound is exclusive, matching
+// CODE_SPACE exactly: "000000".."999999", all equally likely.
+function generateCode(): string {
+  return randomInt(0, CODE_SPACE).toString().padStart(CODE_DIGITS, "0");
+}
+
+// Binds the code to the uid that requested it, the same shape plan §2.2
+// specifies (`codeHash: sha256(code + uid)`), so a hash leaked from one
+// account's document cannot be replayed as a guess against another.
+export function hashVerificationCode(code: string, uid: string): string {
+  return sha256(`${code}${uid}`);
+}
+
+// Binds the code to the ADDRESS it was sent to, independent of the uid hash
+// above -- this is the half of the record verify-contact-email.ts uses to
+// refuse a stale code after the researcher has changed their address.
+// `email` must already be normalized (contactEmailRecipient does this), so
+// the same string hashed here is byte-identical to the one re-derived at
+// verify time.
+export function hashContactEmail(email: string): string {
+  return sha256(email);
+}
+
+function buildVerificationEmail(code: string) {
+  const subject = "Your DataPipe verification code";
+  const text = [
+    `Your DataPipe verification code is ${code}.`,
+    "Enter it on your account page to confirm this address. The code expires in 24 hours.",
+    "",
+    `If you did not request this, you can ignore it -- nothing changes until the code is entered. Manage your address: ${ACCOUNT_URL}`,
+  ].join("\n\n");
+  const html = [
+    `<p>Your DataPipe verification code is <strong style="font-size:1.2em;letter-spacing:0.1em">${code}</strong>.</p>`,
+    "<p>Enter it on your account page to confirm this address. The code expires in 24 hours.</p>",
+    `<p style="font-size:0.9em;color:#555">If you did not request this, you can ignore it -- nothing changes until the code is entered. <a href="${ACCOUNT_URL}">Manage your address</a>.</p>`,
+  ].join("\n");
+  return { subject, text, html };
+}
+
+export const sendContactEmailVerification = onRequest(
+  { cors: true },
+  async (req, res) => {
+    if (req.method !== "POST") {
+      res.status(405).json({ error: "Method not allowed" });
+      return;
+    }
+
+    const authHeader = req.headers.authorization;
+    if (!authHeader || !authHeader.startsWith("Bearer ")) {
+      res.status(401).json({ error: "Authentication required" });
+      return;
+    }
+
+    let uid: string;
+    try {
+      const idToken = authHeader.split("Bearer ")[1];
+      const decodedToken = await auth.verifyIdToken(idToken);
+      uid = decodedToken.uid;
+    } catch {
+      res.status(401).json({ error: "Invalid authentication token" });
+      return;
+    }
+
+    try {
+      const userSnap = await db.doc(`users/${uid}`).get();
+      const userData = userSnap.exists ? userSnap.data() : undefined;
+
+      if (userData?.contactEmailVerified === true) {
+        // Nothing to resend. The account page should not be offering a
+        // Resend control in this state at all, but a stale client (a second
+        // open tab, a race with the researcher's own last click) is not an
+        // error -- just say so.
+        res.status(200).json({ success: true, alreadyVerified: true });
+        return;
+      }
+
+      const recipient = contactEmailRecipient(userData);
+      if (!recipient) {
+        res.status(400).json({
+          error: "Add a contact email address before requesting a code.",
+          code: "no-contact-email",
+        });
+        return;
+      }
+
+      const existing = await verificationRef(uid).get();
+      const sentAt = existing.exists
+        ? (existing.data()?.sentAt as number | undefined)
+        : undefined;
+      if (typeof sentAt === "number" && Date.now() - sentAt < RESEND_COOLDOWN_MS) {
+        res.status(429).json({
+          error: "Please wait a moment before requesting another code.",
+          code: "rate-limited",
+        });
+        return;
+      }
+
+      const code = generateCode();
+      const now = Date.now();
+
+      // A fresh send REPLACES any prior record outright (set, not
+      // update/merge): it always resets attempts to 0, and it always binds
+      // to whichever address is on file right now -- even if the previous
+      // record was for a since-changed address that was never verified.
+      await verificationRef(uid).set({
+        emailHash: hashContactEmail(recipient),
+        codeHash: hashVerificationCode(code, uid),
+        expiresAt: now + EXPIRY_MS,
+        attempts: 0,
+        sentAt: now,
+      });
+
+      const { subject, text, html } = buildVerificationEmail(code);
+      // Non-transactional: unlike upload-failure-notify.ts's enqueueMail,
+      // there is nothing else to keep consistent with the send -- this is a
+      // direct response to a request the researcher just made, which is
+      // exactly the case mail.ts's sendMail doc comment names.
+      await sendMail({
+        to: recipient,
+        subject,
+        text,
+        html,
+        meta: { kind: "contact-email-verification", owner: uid },
+      });
+
+      res.status(200).json({ success: true });
+    } catch (error) {
+      console.error(
+        `send-contact-email-verification failed for ${uid}:`,
+        error instanceof Error ? error.message : "Unknown error"
+      );
+      res.status(500).json({
+        error: "Could not send the verification code. Please try again.",
+      });
+    }
+  }
+);

--- a/functions/src/upload-failure-notify.ts
+++ b/functions/src/upload-failure-notify.ts
@@ -1,0 +1,443 @@
+// First-failure upload notification: tell a researcher ONCE when their data
+// stops arriving, and not again until the problem clears.
+//
+// The whole feature is an exercise in not crying wolf. One participant
+// submission can produce a raw file, a main CSV and one sidecar per extracted
+// column (metadata-derived-upload.ts), so "twenty files failed" is a routine
+// event, not an exotic one -- and a naive implementation mails twenty times.
+// Worse, several of the failures DataPipe records are not failures at all:
+// compaction diverts writes into the queue on purpose (compaction-gate.ts),
+// and CONTENTION/AUTH_EXPIRED blips heal themselves within a minute
+// (queue-upload.ts's fast and probe tiers). A researcher who learns that these
+// mails are usually noise stops reading the one that isn't.
+//
+// So: one mail per EPISODE, an episode opens only at a failure DataPipe has
+// already tried and failed to fix, and it closes when the experiment's queue
+// drains. A 24-hour floor backstops a queue that flaps.
+//
+// ---------------------------------------------------------------------------
+// WHY A DEDICATED TRIGGER, AND NOT THE OTHER TWO OBVIOUS PLACES
+// ---------------------------------------------------------------------------
+//
+// Not a hook inside queueUpload: scheduled-pending-recovery.ts writes
+// uploadQueue documents by hand in its own transaction and never calls it, and
+// the signal that actually matters -- handleRetryFailure in
+// scheduled-upload-retry.ts -- is not in that path at all. A Firestore trigger
+// sees every writer, including writers not yet written.
+//
+// Not folded into onUploadQueueChanged (compaction-triggers.ts), even though
+// it watches the exact same collection path. That function's runtime and
+// throw semantics belong to COMPACTION: it runs at 1GiB/540s because a pass
+// holds a batch and an assembled zip in memory, and anything it throws is a
+// compaction failure. Enqueuing mail there would mean a mail-write error
+// re-runs a compaction pass, and a compaction error suppresses a
+// notification -- two unrelated concerns sharing one retry envelope. Separate
+// concerns, separate functions, 256MiB here because this one reads two
+// documents and writes two.
+//
+// Firestore triggers are at-least-once, so the same event can arrive twice.
+// That is harmless by construction: the second delivery finds notifiedAt
+// already set and takes the count-only branch. It cannot produce a second
+// mail.
+
+import { onDocumentWritten } from "firebase-functions/v2/firestore";
+import { Timestamp, FieldValue } from "firebase-admin/firestore";
+import { db } from "./app.js";
+import { contactEmailRecipient, enqueueMail, newMailRef } from "./mail.js";
+import type { MailMeta } from "./mail.js";
+import { buildUploadFailureEmail } from "./email/upload-failure-copy.js";
+import type { UploadFailureState } from "./interfaces.js";
+
+// One mail per experiment per 24 hours, maximum, no matter how often the queue
+// flaps clear->fail. A study that breaks every hour for a week produces seven
+// mails, not 168. This is also the backstop for the one residual race the
+// transactions below cannot close -- see clearIfDrained.
+export const RATE_LIMIT_MS = 24 * 60 * 60 * 1000;
+
+// "Not resolved yet, from the researcher's point of view." Deliberately the
+// predicate the dashboard already uses (pages/admin/[experiment_id].js:46-53
+// and api-queue-status.ts:143-144), INCLUDING `failed`, and deliberately not
+// finalization.ts's, which excludes `failed` so that a permanently dead file
+// cannot block sealing forever.
+//
+// Including `failed` is what stops the notification re-arming while a dead
+// file is still sitting there: that file is an unresolved problem the
+// researcher has not dealt with, and re-arming would mail them again about a
+// queue that never actually got better. The episode closes when the last
+// unresolved entry either completes or is swept away by cleanupOldEntries at
+// seven days.
+export const UNRESOLVED_STATUSES = ["pending", "processing", "failed"];
+
+// The Admin SDK default is 5, which is not enough here. The motivating case is
+// the ordinary one: a metadataActive submission produces a raw file, a main
+// CSV and one sidecar per extracted column, so a single participant can put
+// ~20 entries in the queue, and when the provider is down the retry worker
+// fails all of them in one run -- firing ~20 trigger invocations that contend
+// for the SAME experiments/{id} document at once. Each loser re-runs, and in
+// the worst ordering a transaction needs about one attempt per contender. At
+// the default it would give up and throw, which on a notification path means
+// silently losing the mail. Attempts are cheap; the failure is not.
+const TRANSACTION_ATTEMPTS = 25;
+
+type QueueData = FirebaseFirestore.DocumentData | undefined;
+
+// Wider than the sketch in the plan ("mailed" | "cleared" | "noop") on
+// purpose: the suppressed branches are the ones most likely to break silently,
+// and a test that can only see "not mailed" cannot tell a rate-limited
+// suppression from a missing contact address from a predicate that never
+// fired.
+export type QueueWriteOutcome =
+  | "mailed"
+  | "counted"
+  | "rate-limited"
+  | "no-contact-email"
+  | "cleared"
+  | "noop";
+
+/**
+ * Has DataPipe already tried and failed on this file?
+ *
+ * Decided from the event payload alone, with zero Firestore reads, so the
+ * overwhelming majority of queue writes cost nothing.
+ *
+ * THE QUEUE-TIME CASE IS EXCLUDED DELIBERATELY, and it is the point of the
+ * whole predicate:
+ *
+ *  - Compaction would false-alarm on every pass. api-data.ts diverts
+ *    submissions into the queue whenever isCompactionInFlight, and the retry
+ *    worker then reschedules those entries WITHOUT incrementing retryCount
+ *    (scheduled-upload-retry.ts's COMPACTION_HOLD_REASON branch). Keying on
+ *    retryCount makes a write buffer invisible here -- the retry worker
+ *    already draws exactly the line this needs.
+ *
+ *  - The fast and probe tiers exist because these failures self-heal.
+ *    CONTENTION clears in seconds; an AUTH_EXPIRED on Zenodo is often a token
+ *    a concurrent refresh rotated away moments ago. Mailing before the
+ *    60-second probe has run tells researchers to go check on something that
+ *    fixed itself before they opened the mail.
+ *
+ * The cost is a delay, and it is small against the alternative: fast/probe
+ * tier means the mail lands ~5 minutes after the failure (the 60-second
+ * nextRetryAt floor, plus the retry worker's five-minute cron cadence), slow
+ * tier ~1 hour. The job is to get someone to check in, not to page them.
+ */
+export function isFailureEvent(before: QueueData, after: QueueData): boolean {
+  // Fires on EVERY retry increment, not only the first. That is intended: the
+  // notifiedAt flag, not this predicate, is what makes the mail singular, and
+  // a later increment on an already-open episode is a genuine additional
+  // failure worth counting.
+  const attemptFailed =
+    after?.status === "pending" && (after.retryCount ?? 0) > (before?.retryCount ?? 0);
+
+  // The five paths that never take a retry: owner missing, experiment missing,
+  // experiment finalized while queued, unreadable payload (all four write
+  // `failed` directly with retryCount untouched), plus max-retries exhaustion.
+  const wentTerminal = after?.status === "failed" && before?.status !== "failed";
+
+  return attemptFailed || wentTerminal;
+}
+
+/**
+ * Did an entry just leave the unresolved set?
+ *
+ * A completion, or a DELETE. The delete case is load-bearing and is the trap
+ * this function exists to avoid: cleanupOldEntries removes queue documents
+ * outright, so `after` is undefined, and compaction-triggers.ts's sibling
+ * trigger returns early on exactly that condition. Here, a delete can be the
+ * very event that drains the queue -- the last `failed` entry aging out at
+ * seven days is the normal way a dead episode ends.
+ */
+export function isDrainCandidate(before: QueueData, after: QueueData): boolean {
+  if (!after) {
+    return !!before;
+  }
+  return after.status === "completed" && before?.status !== "completed";
+}
+
+// Is there an open episode at all? Cheap guard used twice: once outside the
+// drain transaction to avoid opening one at all, and once inside it as the
+// authoritative check.
+function hasEpisodeToClear(state: UploadFailureState | undefined): boolean {
+  if (!state) return false;
+  return (
+    state.notifiedAt != null ||
+    state.firstFailureAt != null ||
+    state.suppressedReason != null ||
+    (state.failureCount ?? 0) > 0
+  );
+}
+
+// Defensive read of a stored Timestamp, in the same spirit as
+// compaction-gate.ts's typeof guard: a hand-edited or future-written value
+// that is not a Timestamp must not throw inside a transaction and turn every
+// subsequent failure on this experiment into an unhandled error.
+function millisOrZero(value: FirebaseFirestore.Timestamp | null | undefined): number {
+  if (!value || typeof (value as { toMillis?: unknown }).toMillis !== "function") {
+    return 0;
+  }
+  return value.toMillis();
+}
+
+/**
+ * FAILURE PATH. Opens an episode, or counts against an open one.
+ *
+ * Everything happens in ONE transaction on experiments/{id}: the read of the
+ * experiment, the read of the owner, the flag write, and the tx.create of the
+ * mail document. That is what makes twenty simultaneous failures produce
+ * exactly one mail -- Firestore transactions are serializable, so nineteen of
+ * them lose, re-run, re-read notifiedAt as non-null, and take the count-only
+ * branch. Because the mail is created in the same commit as the flag, there is
+ * no window in which a researcher is mailed but the "already told them" flag
+ * is lost, which would mail them again on the very next file.
+ */
+async function notifyFailure(
+  experimentID: string,
+  queueData: FirebaseFirestore.DocumentData,
+  docId: string
+): Promise<QueueWriteOutcome> {
+  const owner = typeof queueData.owner === "string" ? queueData.owner : undefined;
+  const experimentRef = db.collection("experiments").doc(experimentID);
+  const userRef = owner ? db.collection("users").doc(owner) : null;
+
+  // Allocated BEFORE the transaction body: a transaction cannot allocate a
+  // document id mid-flight (see newMailRef in mail.ts). Reusing the same ref
+  // across transaction retries is safe precisely because a retried attempt
+  // never committed, so the ref is still unwritten and tx.create still holds.
+  const mailRef = newMailRef();
+
+  return db.runTransaction<QueueWriteOutcome>(async (tx) => {
+    // ---------------- ALL READS FIRST (Firestore transaction law) ----------
+    const expSnap = await tx.get(experimentRef);
+    const userSnap = userRef ? await tx.get(userRef) : null;
+    // ---------------- NO READS BELOW THIS LINE -----------------------------
+
+    // The experiment is gone -- which is one of the terminal failure paths
+    // that got us here in the first place ("Experiment not found"). Writing
+    // anything now would CREATE the document: a ghost experiment carrying
+    // nothing but uploadFailure, visible to the dashboard's queries. Say
+    // nothing instead; there is no experiment page to send anyone to.
+    if (!expSnap.exists) {
+      return "noop";
+    }
+
+    const expData = expSnap.data() ?? {};
+    const state = (expData.uploadFailure ?? {}) as UploadFailureState;
+    const now = Timestamp.now();
+
+    // `any` rather than `unknown`: this object is handed to tx.update, whose
+    // UpdateData<DocumentData> type resolves to an index signature of `any`,
+    // and it holds a mix of Timestamps, nulls and a FieldValue transform.
+    const updates: Record<string, any> = {
+      // A field transform, so concurrent counters do not clobber each other
+      // even across the retry boundary.
+      "uploadFailure.failureCount": FieldValue.increment(1),
+    };
+    if (state.firstFailureAt == null) {
+      updates["uploadFailure.firstFailureAt"] = now;
+    }
+
+    // ARMED already: the researcher has been told about this episode (or the
+    // episode was armed to suppress a burst). Count and stop.
+    if (state.notifiedAt != null) {
+      tx.update(experimentRef, updates);
+      return "counted";
+    }
+
+    // From here on the episode is opening, so notifiedAt is set on EVERY
+    // branch below including the ones that send nothing. Suppressing the burst
+    // matters as much as suppressing the duplicate mail: without the flag,
+    // twenty derived-file failures each open a transaction and each re-decide.
+    updates["uploadFailure.notifiedAt"] = now;
+
+    // lastNotifiedAt survives the drain, so this is a floor across episodes,
+    // not within one.
+    if (now.toMillis() - millisOrZero(state.lastNotifiedAt) < RATE_LIMIT_MS) {
+      updates["uploadFailure.suppressedReason"] = "rate-limited";
+      tx.update(experimentRef, updates);
+      return "rate-limited";
+    }
+
+    const recipient = contactEmailRecipient(
+      userSnap && userSnap.exists ? userSnap.data() : undefined
+    );
+    if (!recipient || !owner) {
+      // Feature 1's contact-email gate closes this population over time. Until
+      // then the episode is armed and the reason recorded, so the owner can
+      // see in Firestore why nothing was sent.
+      updates["uploadFailure.suppressedReason"] = "no-contact-email";
+      tx.update(experimentRef, updates);
+      return "no-contact-email";
+    }
+
+    const email = buildUploadFailureEmail({
+      experimentID,
+      title: expData.title as string | undefined,
+      // The queue entry's provider is the one that actually refused the write;
+      // the experiment's is the fallback for legacy entries that carry none.
+      storageProvider: queueData.storageProvider ?? expData.storageProvider,
+      providerErrorCode: queueData.providerErrorCode,
+      // The count this failure produces. Normally 1 -- this branch only runs
+      // when the episode was closed -- so the copy renders the burst line only
+      // when it is genuinely higher.
+      failureCount: (state.failureCount ?? 0) + 1,
+    });
+
+    // Built key by key rather than as a literal: Firestore rejects undefined
+    // field values, and mail.ts spreads this straight into the document.
+    const meta: MailMeta = { kind: "upload-failure", owner, experimentID };
+    meta.queueDocId = docId;
+    if (queueData.providerErrorCode) {
+      meta.providerErrorCode = queueData.providerErrorCode;
+    }
+
+    enqueueMail(tx, mailRef, {
+      to: recipient,
+      subject: email.subject,
+      text: email.text,
+      html: email.html,
+      meta,
+    });
+
+    updates["uploadFailure.lastNotifiedAt"] = now;
+    updates["uploadFailure.suppressedReason"] = null;
+    tx.update(experimentRef, updates);
+    return "mailed";
+  }, { maxAttempts: TRANSACTION_ATTEMPTS });
+}
+
+/**
+ * DRAIN PATH. Closes the episode once nothing is left unresolved.
+ *
+ * Re-arming is the other half of "mail once": without it, an experiment that
+ * broke in March would stay silent through a genuinely new failure in April.
+ *
+ * lastNotifiedAt is deliberately NOT cleared here. It is the flap backstop,
+ * and it is also what closes the one race these transactions cannot: a drain
+ * whose query ran a moment before a new failure was written can clear a flag
+ * that the failure had just armed. The failure's own mail was already sent, so
+ * the only cost is that the NEXT failure sees a disarmed flag -- and the
+ * 24-hour floor, read from a field the drain never touches, suppresses it.
+ */
+async function clearIfDrained(experimentID: string): Promise<QueueWriteOutcome> {
+  const experimentRef = db.collection("experiments").doc(experimentID);
+
+  // Pre-check outside any transaction. EVERY successful queued upload produces
+  // a completed event, and almost none of those experiments have an episode
+  // open, so transacting on each would spend a transaction and a query to
+  // learn there was nothing to do. This can only skip work, never decide
+  // wrongly: the transaction below re-reads the same field authoritatively,
+  // and a read that misses an episode armed a moment later is a read for which
+  // the queue is necessarily non-empty anyway (that failure's own entry is
+  // unresolved), so clearing would have been wrong.
+  const preSnap = await experimentRef.get();
+  if (!preSnap.exists || !hasEpisodeToClear(preSnap.data()?.uploadFailure)) {
+    return "noop";
+  }
+
+  // limit(1) rather than count(): a plain query inside a transaction is
+  // universally supported by the Admin SDK and the emulator, costs one
+  // document read, and answers the only question being asked -- "is anything
+  // still unresolved?". Index-wise this is `experimentID ==` + `status in`,
+  // which the existing composite (experimentID, status, providerErrorCode)
+  // serves as a prefix, and finalization.ts already runs the same shape.
+  const stillUnresolved = db
+    .collection("uploadQueue")
+    .where("experimentID", "==", experimentID)
+    .where("status", "in", UNRESOLVED_STATUSES)
+    .limit(1);
+
+  return db.runTransaction<QueueWriteOutcome>(async (tx) => {
+    // ---------------- ALL READS FIRST (Firestore transaction law) ----------
+    // The experiment document is read FIRST, and it is read even though the
+    // QUERY is what decides. The read is what puts experiments/{id} under this
+    // transaction's lock for the rest of its life, which is what serializes a
+    // drain against a concurrent failure on the same experiment -- otherwise a
+    // transaction that only ever WROTE that document could interleave between
+    // a failure's read and its write.
+    const expSnap = await tx.get(experimentRef);
+    const queued = await tx.get(stillUnresolved);
+    // ---------------- NO READS BELOW THIS LINE -----------------------------
+
+    if (!expSnap.exists) {
+      return "noop";
+    }
+    if (!hasEpisodeToClear(expSnap.data()?.uploadFailure as UploadFailureState)) {
+      return "noop";
+    }
+    if (!queued.empty) {
+      // Something is still pending, processing, or permanently failed. Not
+      // drained -- this is the lingering-dead-file case, and it is why the
+      // predicate includes `failed`.
+      return "noop";
+    }
+
+    tx.update(experimentRef, {
+      "uploadFailure.notifiedAt": null,
+      "uploadFailure.firstFailureAt": null,
+      "uploadFailure.failureCount": 0,
+      "uploadFailure.suppressedReason": null,
+      // lastNotifiedAt: NEVER cleared. See the doc comment above.
+    });
+    return "cleared";
+  }, { maxAttempts: TRANSACTION_ATTEMPTS });
+}
+
+/**
+ * The whole state machine, as a plain function.
+ *
+ * Exported as the test seam this codebase already uses for scheduled work
+ * (retryPendingUploads' ownerScope, recoverPendingUploads' prefix): tests drive
+ * it in-process with synthesized before/after payloads instead of trying to
+ * provoke real trigger deliveries out of the emulator.
+ *
+ * `before` and `after` are the raw document data from the event -- either may
+ * be undefined (a create has no before, a DELETE has no after).
+ */
+export async function handleQueueWrite(
+  before: QueueData,
+  after: QueueData,
+  docId: string
+): Promise<QueueWriteOutcome> {
+  // On a delete there is no `after`, so the experiment this entry belonged to
+  // has to come from `before`.
+  const data = after ?? before;
+  const experimentID = typeof data?.experimentID === "string" ? data.experimentID : undefined;
+  if (!experimentID) {
+    return "noop";
+  }
+
+  // Mutually exclusive by construction: a failure event has an `after` whose
+  // status is pending or failed, a drain candidate has no `after` at all or a
+  // completed one.
+  if (isFailureEvent(before, after)) {
+    return notifyFailure(experimentID, after as FirebaseFirestore.DocumentData, docId);
+  }
+  if (isDrainCandidate(before, after)) {
+    return clearIfDrained(experimentID);
+  }
+  return "noop";
+}
+
+// 256MiB: this reads two documents and one single-result query, and writes
+// two documents. Nothing here holds a payload -- the queue entry's bytes live
+// in Cloud Storage, and this function never touches them.
+//
+// No `retry: true`. An error here is logged and dropped rather than replayed
+// for up to seven days, which is the right trade for a notification: the flag
+// write and the mail create are one commit, so a failed attempt leaves the
+// episode closed, and the NEXT failure on the same experiment re-decides from
+// scratch. A replay storm on a notification path would be worse than a missed
+// notification.
+export const onUploadFailure = onDocumentWritten(
+  { document: "uploadQueue/{docId}", memory: "256MiB" },
+  async (event) => {
+    const outcome = await handleQueueWrite(
+      event.data?.before.data(),
+      event.data?.after.data(),
+      event.params.docId
+    );
+    if (outcome !== "noop") {
+      console.log(`upload-failure-notify: ${event.params.docId} -> ${outcome}`);
+    }
+  }
+);

--- a/functions/src/verify-contact-email.ts
+++ b/functions/src/verify-contact-email.ts
@@ -1,0 +1,188 @@
+import { onRequest } from "firebase-functions/v2/https";
+import { db, auth } from "./app.js";
+import { contactEmailRecipient } from "./mail.js";
+import {
+  VERIFICATIONS_COLLECTION,
+  hashVerificationCode,
+  hashContactEmail,
+} from "./send-contact-email-verification.js";
+
+// Redeem a 6-digit code and, on success, set the ONE flag no client can ever
+// write itself: users/{uid}.contactEmailVerified = true.
+// firestore.rules' contactEmailNotSelfCertified() refuses that value from
+// every client-write shape (create and update alike) -- this Admin-SDK path,
+// reached only after a hash comparison the client cannot forge, is the only
+// place it is ever set.
+//
+// Auth shape copied from delete-account.ts / api-queue-status.ts /
+// send-contact-email-verification.ts exactly: method check, then
+// `Authorization: Bearer <idToken>`, then auth.verifyIdToken.
+//
+// THE STALE-ADDRESS GUARD is the reason this is a transaction and not a
+// sequence of independent reads and writes. A researcher can save a NEW
+// contactEmail (components/account/ContactEmail.js's edit form) at any time
+// after requesting a code for the old one -- buildContactEmailUpdate()
+// always resets contactEmailVerified to false on that save, but it does not
+// touch, and has no way to touch, a contactEmailVerifications/{uid} record
+// already in flight for the address that used to be there. Without the
+// emailHash comparison below, a correct code for the OLD address would still
+// verify the NEW one, because both writes land on the same uid-keyed
+// document. The check re-reads users/{uid}.contactEmail inside the same
+// transaction that decides the outcome, so there is no window between "read
+// the current address" and "grant verified" for another save to slip
+// through.
+const MAX_ATTEMPTS = 5; // plan §2.2
+
+interface Outcome {
+  status: number;
+  body: Record<string, unknown>;
+}
+
+function verificationRef(uid: string): FirebaseFirestore.DocumentReference {
+  return db.collection(VERIFICATIONS_COLLECTION).doc(uid);
+}
+
+export const verifyContactEmail = onRequest({ cors: true }, async (req, res) => {
+  if (req.method !== "POST") {
+    res.status(405).json({ error: "Method not allowed" });
+    return;
+  }
+
+  const authHeader = req.headers.authorization;
+  if (!authHeader || !authHeader.startsWith("Bearer ")) {
+    res.status(401).json({ error: "Authentication required" });
+    return;
+  }
+
+  let uid: string;
+  try {
+    const idToken = authHeader.split("Bearer ")[1];
+    const decodedToken = await auth.verifyIdToken(idToken);
+    uid = decodedToken.uid;
+  } catch {
+    res.status(401).json({ error: "Invalid authentication token" });
+    return;
+  }
+
+  const rawCode =
+    typeof req.body?.code === "string" ? req.body.code.trim() : "";
+  if (!/^\d{6}$/.test(rawCode)) {
+    res
+      .status(400)
+      .json({ error: "Enter the 6-digit code.", code: "invalid-code" });
+    return;
+  }
+
+  try {
+    const userRef = db.doc(`users/${uid}`);
+    const vRef = verificationRef(uid);
+
+    const outcome = await db.runTransaction<Outcome>(async (tx) => {
+      // ---------------- ALL READS FIRST (Firestore transaction law) -------
+      const userSnap = await tx.get(userRef);
+      const vSnap = await tx.get(vRef);
+      // ---------------- NO READS BELOW THIS LINE ----------------------------
+
+      const userData = userSnap.exists ? userSnap.data() : undefined;
+
+      if (userData?.contactEmailVerified === true) {
+        return { status: 200, body: { success: true, alreadyVerified: true } };
+      }
+
+      // The address as it stands RIGHT NOW, read inside this transaction --
+      // the stale-address guard depends on this being the live value, not
+      // one captured before the transaction began.
+      const currentAddress = contactEmailRecipient(userData);
+      if (!currentAddress) {
+        return {
+          status: 400,
+          body: {
+            error: "Add a contact email address before verifying.",
+            code: "no-contact-email",
+          },
+        };
+      }
+
+      if (!vSnap.exists) {
+        return {
+          status: 400,
+          body: {
+            error: "Request a new verification code.",
+            code: "no-code-requested",
+          },
+        };
+      }
+
+      const v = vSnap.data()!;
+      const expiresAt = typeof v.expiresAt === "number" ? v.expiresAt : 0;
+      if (Date.now() > expiresAt) {
+        return {
+          status: 400,
+          body: {
+            error: "That code has expired. Request a new one.",
+            code: "expired",
+          },
+        };
+      }
+
+      const attempts = typeof v.attempts === "number" ? v.attempts : 0;
+      // Checked BEFORE the code comparison, and it must be: a sixth guess
+      // must be refused even if it happens to be correct, or the attempt cap
+      // is not actually a cap.
+      if (attempts >= MAX_ATTEMPTS) {
+        return {
+          status: 429,
+          body: {
+            error: "Too many incorrect attempts. Request a new code.",
+            code: "too-many-attempts",
+          },
+        };
+      }
+
+      // THE STALE-ADDRESS GUARD. See the module header. A mismatch here
+      // means the code in hand was minted for an address that is no longer
+      // users/{uid}.contactEmail -- not a guessing attempt, so it does not
+      // consume one of the five attempts above.
+      if (v.emailHash !== hashContactEmail(currentAddress)) {
+        return {
+          status: 400,
+          body: {
+            error:
+              "This code was sent to a different address. Request a new code.",
+            code: "stale-address",
+          },
+        };
+      }
+
+      if (v.codeHash !== hashVerificationCode(rawCode, uid)) {
+        tx.update(vRef, { attempts: attempts + 1 });
+        return {
+          status: 400,
+          body: {
+            error: "That code is incorrect.",
+            code: "invalid-code",
+            attemptsRemaining: Math.max(0, MAX_ATTEMPTS - (attempts + 1)),
+          },
+        };
+      }
+
+      // Success. contactEmailVerified is written here and ONLY here --
+      // firestore.rules refuses this value from any client-write shape, so
+      // this Admin SDK write (rules do not apply to it) is the single path
+      // by which the flag ever becomes true.
+      tx.update(userRef, { contactEmailVerified: true });
+      tx.delete(vRef);
+      return { status: 200, body: { success: true } };
+    });
+
+    res.status(outcome.status).json(outcome.body);
+  } catch (error) {
+    console.error(
+      `verify-contact-email failed for ${uid}:`,
+      error instanceof Error ? error.message : "Unknown error"
+    );
+    res
+      .status(500)
+      .json({ error: "Could not verify the code. Please try again." });
+  }
+});

--- a/lib/contact-email.js
+++ b/lib/contact-email.js
@@ -1,0 +1,143 @@
+// Single source of truth for what counts as a usable DataPipe contact address.
+//
+// `users/{uid}.contactEmail` is the address DataPipe uses to tell a researcher
+// that their data stopped arriving. It is deliberately NOT the Firebase Auth
+// `user.email`: Auth enforces global uniqueness on that field (a lab that
+// wants failures to land in lab-data@university.edu for two accounts would be
+// refused with auth/email-already-in-use), and writing it would change the
+// identifier a password signs in with -- see
+// components/account/LinkedAccounts.js, which builds
+// EmailAuthProvider.credential(user.email, password). A notification address
+// is not a credential address.
+//
+// Every module that decides "does this user have a reachable address?" must
+// come through here: the AuthCheck gate, the account page, and the
+// notification path. The backend mirror of these predicates lives in
+// functions/src/mail.ts -- functions/ is a separate package whose tsconfig
+// rootDir is ./src and whose deploy bundle contains only functions/, so this
+// file cannot be imported there. THE TWO MUST BE KEPT IN SYNC; the rules that
+// matter (the synthetic-OSF pattern and the 254-character cap) are restated in
+// firestore.rules as well.
+
+// Mirrors the cap asserted in firestore.rules (isContactEmailUpdate). 254 is
+// the maximum length of an addr-spec that SMTP is required to accept.
+export const MAX_CONTACT_EMAIL_LENGTH = 254;
+
+// Provenance marker on users/{uid}.contactEmailSource. Diagnostic only --
+// nothing branches on it, and firestore.rules does not constrain its value.
+//
+// There is no "osf-backfill" source. See SEEDING RULE below: an address that
+// came from OSF is never seedable, so no code may ever record that it was.
+export const CONTACT_EMAIL_SOURCES = Object.freeze({
+  // Copied from the Firebase Auth record (`user.email`) at signup, or by a
+  // backfill that reads Firebase Auth. The only automatic source there is.
+  AUTH: "auth",
+  // Typed by the researcher, in the gate or on the account page.
+  USER: "user",
+});
+
+// oauth2-callback.ts seeds `let osfEmail = user-${osfUserId}@osf.io` as a
+// fallback and keeps it whenever the OSF emails endpoint returns nothing
+// usable, so this exact shape sits in the `email` field of real user documents
+// today. It is undeliverable. A naive truthiness check on contactEmail would
+// treat it as an address and mail into a void forever, which is why the gate
+// tests it explicitly.
+export const OSF_SYNTHETIC_EMAIL_PATTERN = /^user-[a-z0-9]+@osf\.io$/i;
+
+// Deliberately conservative: exactly one "@", no whitespace, a non-empty local
+// part, and a dotted domain with no empty labels. Format validation cannot
+// prove deliverability -- that is what the verification code is for (§2.2 of
+// the plan) -- so this only needs to reject the typos a researcher can see.
+const EMAIL_FORMAT = /^[^\s@]+@[^\s@.]+(\.[^\s@.]+)+$/;
+
+// One canonical stored form. Lowercased as well as trimmed because the
+// verification flow hashes the lowercased address to bind a code to the
+// address it was sent to; keeping storage and hash input identical means the
+// binding can compare against the stored value directly. Every mail provider
+// that matters treats the local part case-insensitively, so nothing becomes
+// undeliverable by being lowercased.
+export function normalizeContactEmail(value) {
+  return typeof value === "string" ? value.trim().toLowerCase() : "";
+}
+
+export function isValidEmailFormat(value) {
+  const v = normalizeContactEmail(value);
+  return v.length > 0 && v.length <= MAX_CONTACT_EMAIL_LENGTH && EMAIL_FORMAT.test(v);
+}
+
+export function isSyntheticOsfEmail(value) {
+  return OSF_SYNTHETIC_EMAIL_PATTERN.test(normalizeContactEmail(value));
+}
+
+// The gate's predicate. `userDoc` is the users/{uid} document (or undefined
+// while it loads -- callers must handle loading themselves; undefined here is
+// simply "no address").
+export function hasContactEmail(userDoc) {
+  const v = normalizeContactEmail(userDoc?.contactEmail);
+  return v.length > 0 && isValidEmailFormat(v) && !isSyntheticOsfEmail(v);
+}
+
+// ---------------------------------------------------------------------------
+// SEEDING RULE -- read before writing any code that fills contactEmail in
+// automatically.
+//
+// contactEmail may only ever be seeded from the FIREBASE AUTH record's
+// `user.email`. That covers email/password signups (always present) and
+// federated signups that supply one (Google always, GitHub usually), including
+// a researcher who started with email/password and later linked OAuth.
+//
+// It may NEVER be seeded from `users/{uid}.email`. That field is
+// provenance-mixed and, for the OSF-era population, entirely OSF-supplied:
+// OSF sign-in mints a Firebase custom token, so those accounts have no Auth
+// email at all, and the stored value came from the OSF API or from the
+// synthetic `user-{id}@osf.io` fallback. OSF account creation never produced
+// an address the researcher gave to DataPipe, so no OSF-derived address is
+// seedable -- not the synthetic ones, and not the real-looking ones either.
+// Those users type an address into the gate, or they have none.
+//
+// isSyntheticOsfEmail() above is a backstop for values already sitting in the
+// database, NOT a filter that makes the rest of the OSF addresses acceptable.
+// ---------------------------------------------------------------------------
+
+// Returns the four contactEmail fields to write for a new user document, given
+// the Firebase Auth user. An account with no Auth email (ORCID, OSF-era) gets
+// contactEmail: "" and meets the gate on its first /admin load -- the intended
+// path, not a failure.
+//
+// contactEmailVerified is ALWAYS false here, including for Google, whose
+// address is provider-verified: firestore.rules refuses a client-written
+// `true` in every shape, and one extra confirmation click for the population
+// with the least friction elsewhere is not worth a rules exception.
+export function contactEmailSeedFromAuthUser(authUser) {
+  const candidate = normalizeContactEmail(authUser?.email);
+  if (!isValidEmailFormat(candidate) || isSyntheticOsfEmail(candidate)) {
+    // No source is recorded, because nothing was sourced. The field appears
+    // the first time the researcher saves an address.
+    return { contactEmail: "", contactEmailVerified: false };
+  }
+  return {
+    contactEmail: candidate,
+    contactEmailVerified: false,
+    contactEmailSource: CONTACT_EMAIL_SOURCES.AUTH,
+  };
+}
+
+// Builds the exact field set a client write of a contact address is allowed to
+// touch. Use this rather than assembling the object at each call site:
+// firestore.rules' isContactEmailUpdate() permits ONLY these four keys in a
+// single write (touching `experiments` in the same operation fails the whole
+// write), and it refuses any post-state where contactEmailVerified is true.
+//
+// That last part is why contactEmailVerified: false is included unconditionally
+// rather than omitted: on an update, request.resource.data is the MERGED
+// document, so changing the address on an already-verified account without
+// resetting the flag would leave `true` standing against a new, unconfirmed
+// address -- and the rules deny exactly that write.
+export function buildContactEmailUpdate(email, { source = CONTACT_EMAIL_SOURCES.USER } = {}) {
+  return {
+    contactEmail: normalizeContactEmail(email),
+    contactEmailVerified: false,
+    contactEmailUpdatedAt: Date.now(),
+    contactEmailSource: source,
+  };
+}

--- a/lib/user-bootstrap.js
+++ b/lib/user-bootstrap.js
@@ -1,5 +1,6 @@
 import { doc, getDoc, setDoc } from "firebase/firestore";
 import { db } from "./firebase";
+import { contactEmailSeedFromAuthUser } from "./contact-email";
 
 // Creates the users/{uid} Firestore document if it does not already exist.
 //
@@ -33,6 +34,16 @@ export async function ensureUserDocument(user) {
       // Nothing downstream may assume a user doc has a usable address.
       email: user.email || "",
       experiments: [],
+      // Seeds contactEmail from the FIREBASE AUTH record ONLY, per the
+      // SEEDING RULE in lib/contact-email.js: never from an OSF-supplied
+      // address. Email/password and Google always carry a usable
+      // user.email here (Google's is provider-verified, but
+      // contactEmailVerified is still seeded false -- firestore.rules
+      // refuses a client-written `true` in every shape); GitHub, only when
+      // the researcher disclosed one; ORCID routinely has none. An account
+      // with no usable Auth email is seeded contactEmail: "" and meets the
+      // gate on its first /admin load -- the intended path, not a failure.
+      ...contactEmailSeedFromAuthUser(user),
     },
     { merge: true }
   );

--- a/migrations/2026-08-contact-email-backfill.cjs
+++ b/migrations/2026-08-contact-email-backfill.cjs
@@ -1,0 +1,228 @@
+// Backfill users/{uid}.contactEmail for accounts that already have a usable
+// address sitting in Firebase Auth but never got the four contactEmail
+// fields written (every account that existed before the required-contact-
+// email feature shipped).
+//
+// ---------------------------------------------------------------------------
+// WHY THIS ITERATES FIREBASE AUTH, NOT users/{uid}.email
+// ---------------------------------------------------------------------------
+//
+// OSF OAuth account creation NEVER produced a real email. OSF sign-in mints a
+// Firebase custom token (oauth2-callback.ts), so an OSF-era account has no
+// Auth email at all, and the `email` field oauth2-callback.ts wrote into the
+// user document is either the OSF API's address (never confirmed to
+// DataPipe -- the researcher typed it into OSF, not here) or the synthetic
+// `user-{osfUserId}@osf.io` fallback it uses when OSF returns nothing usable.
+// Every OSF-supplied address is synthetic or unconfirmed. Seeding contactEmail
+// from it would plant an address DataPipe cannot vouch for into the one field
+// the whole notification feature depends on.
+//
+// The only legitimate backfill source is Firebase Auth's `user.email`:
+// present for email/password signups (always) and for federated signups that
+// supply one (Google always, GitHub usually) -- INCLUDING an OSF-era or
+// ORCID-only researcher who later linked a password or a Google account,
+// because Auth's top-level `user.email` reflects whatever the account has
+// today, not how it was created. That is exactly what lib/contact-email.js's
+// `contactEmailSeedFromAuthUser(authUser)` encodes, and exactly why this
+// script walks `admin.auth().listUsers()` -- paginated, 1000 at a time --
+// instead of querying the `users` collection.
+//
+// This file is CommonJS (migrations/ has no package.json with
+// "type": "module", and lib/contact-email.js is ES module syntax that plain
+// `require()` cannot parse), so the validation logic below is a MIRROR of
+// lib/contact-email.js, in the same spirit as functions/src/mail.ts's mirror
+// of the same file. Keep the three in sync:
+//   - lib/contact-email.js       (frontend)
+//   - functions/src/mail.ts      (backend)
+//   - this file                  (one-off migration)
+//
+// ---------------------------------------------------------------------------
+// SAFETY
+// ---------------------------------------------------------------------------
+//
+// Dry run by default. Pass --apply to write. Idempotent: a user document that
+// already has a non-empty contactEmail is left alone -- this script only
+// fills a gap, it never overwrites an address a researcher (or an earlier run
+// of this same script) already set.
+const admin = require('firebase-admin');
+const path = require('path');
+const os = require('os');
+
+const APPLY = process.argv.includes('--apply');
+const DRY_RUN = !APPLY;
+
+// ---------------------------------------------------------------------------
+// Mirror of lib/contact-email.js. See the block comment above for why this
+// cannot be an import.
+// ---------------------------------------------------------------------------
+const MAX_CONTACT_EMAIL_LENGTH = 254;
+const OSF_SYNTHETIC_EMAIL_PATTERN = /^user-[a-z0-9]+@osf\.io$/i;
+const EMAIL_FORMAT = /^[^\s@]+@[^\s@.]+(\.[^\s@.]+)+$/;
+const CONTACT_EMAIL_SOURCE_AUTH = 'auth';
+
+function normalizeContactEmail(value) {
+  return typeof value === 'string' ? value.trim().toLowerCase() : '';
+}
+
+function isValidEmailFormat(value) {
+  const v = normalizeContactEmail(value);
+  return v.length > 0 && v.length <= MAX_CONTACT_EMAIL_LENGTH && EMAIL_FORMAT.test(v);
+}
+
+function isSyntheticOsfEmail(value) {
+  return OSF_SYNTHETIC_EMAIL_PATTERN.test(normalizeContactEmail(value));
+}
+
+// Mirrors contactEmailSeedFromAuthUser(authUser) in lib/contact-email.js.
+// Returns null when the Auth record has nothing seedable -- ORCID-only and
+// OSF-era accounts that never linked anything else land here, and are left
+// for the gate (or the researcher) to fill in, never for this script.
+function seedFromAuthUser(authUser) {
+  const candidate = normalizeContactEmail(authUser.email);
+  if (!isValidEmailFormat(candidate) || isSyntheticOsfEmail(candidate)) {
+    return null;
+  }
+  return {
+    contactEmail: candidate,
+    contactEmailVerified: false,
+    contactEmailUpdatedAt: Date.now(),
+    contactEmailSource: CONTACT_EMAIL_SOURCE_AUTH,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Firebase Admin init -- same three-way branch as the other scripts in this
+// directory (2025-09-29-osf-integration.cjs, encrypt-tokens.cjs).
+// ---------------------------------------------------------------------------
+if (!admin.apps.length) {
+  if (process.env.NODE_ENV === 'production' || process.env.CI) {
+    const credentials = process.env.GOOGLE_CREDENTIALS
+      ? JSON.parse(process.env.GOOGLE_CREDENTIALS)
+      : undefined;
+
+    admin.initializeApp({
+      credential: credentials ? admin.credential.cert(credentials) : admin.credential.applicationDefault(),
+      projectId: process.env.FIREBASE_PROJECT_ID || 'datapipe-prod'
+    });
+  } else if (process.env.USE_LOCAL_SERVICE_ACCOUNT) {
+    const serviceAccountPath = path.join(os.homedir(), '.config', 'datapipe', 'datapipe-service-account.json');
+    const serviceAccount = require(serviceAccountPath);
+
+    admin.initializeApp({
+      credential: admin.credential.cert(serviceAccount),
+      projectId: process.env.FIREBASE_PROJECT_ID || 'datapipe-test'
+    });
+  } else {
+    process.env.FIRESTORE_EMULATOR_HOST = 'localhost:8080';
+    process.env.FIREBASE_AUTH_EMULATOR_HOST = 'localhost:9099';
+    admin.initializeApp({
+      projectId: 'datapipe-test'
+    });
+  }
+}
+
+const db = admin.firestore();
+const auth = admin.auth();
+
+const AUTH_PAGE_SIZE = 1000; // admin.auth().listUsers() max per page.
+const BATCH_LIMIT = 500; // Firestore batch write limit.
+
+async function backfillContactEmails() {
+  console.log(`Starting contact-email backfill...${DRY_RUN ? ' (DRY RUN -- pass --apply to write)' : ' (APPLYING WRITES)'}`);
+
+  const counts = {
+    authUsersSeen: 0,
+    seeded: 0, // wrote contactEmail from a usable Auth email
+    skippedAlreadySet: 0, // users/{uid}.contactEmail already non-empty
+    skippedNoUserDoc: 0, // Auth user has no users/{uid} document at all
+    noUsableAuthEmail: 0, // Auth email absent, malformed, or synthetic-OSF
+  };
+
+  let batch = db.batch();
+  let batchCount = 0;
+  let pageToken;
+  let pageNumber = 0;
+
+  async function commitBatchIfNeeded(force) {
+    if (DRY_RUN) return;
+    if (batchCount === 0) return;
+    if (!force && batchCount < BATCH_LIMIT) return;
+    await batch.commit();
+    batch = db.batch();
+    batchCount = 0;
+  }
+
+  do {
+    pageNumber += 1;
+    const page = await auth.listUsers(AUTH_PAGE_SIZE, pageToken);
+    pageToken = page.pageToken;
+
+    console.log(`Page ${pageNumber}: ${page.users.length} auth user(s)...`);
+
+    for (const authUser of page.users) {
+      counts.authUsersSeen += 1;
+
+      const seed = seedFromAuthUser(authUser);
+      if (!seed) {
+        counts.noUsableAuthEmail += 1;
+        continue;
+      }
+
+      const userRef = db.collection('users').doc(authUser.uid);
+      const userSnap = await userRef.get();
+
+      if (!userSnap.exists) {
+        // No users/{uid} document to backfill. ensureUserDocument() will seed
+        // this correctly on the account's next sign-in; nothing to do here.
+        counts.skippedNoUserDoc += 1;
+        continue;
+      }
+
+      const existing = userSnap.data() || {};
+      // Never overwrite an existing contactEmail -- a researcher's own choice
+      // (or a previous run of this script) always wins.
+      if (typeof existing.contactEmail === 'string' && existing.contactEmail.trim().length > 0) {
+        counts.skippedAlreadySet += 1;
+        continue;
+      }
+
+      if (DRY_RUN) {
+        console.log(`  [DRY RUN] Would set contactEmail for ${authUser.uid}: ${seed.contactEmail}`);
+      } else {
+        batch.update(userRef, seed);
+        batchCount += 1;
+        await commitBatchIfNeeded(false);
+      }
+      counts.seeded += 1;
+    }
+
+    console.log(
+      `  Page ${pageNumber} running totals -- seeded: ${counts.seeded}, ` +
+      `already set: ${counts.skippedAlreadySet}, no user doc: ${counts.skippedNoUserDoc}, ` +
+      `no usable auth email: ${counts.noUsableAuthEmail}`
+    );
+  } while (pageToken);
+
+  await commitBatchIfNeeded(true);
+
+  console.log(`Backfill completed${DRY_RUN ? ' (DRY RUN -- nothing written)' : ''}.`);
+  console.log(`  Auth users seen:            ${counts.authUsersSeen}`);
+  console.log(`  Seeded contactEmail:        ${counts.seeded}`);
+  console.log(`  Skipped (already set):      ${counts.skippedAlreadySet}`);
+  console.log(`  Skipped (no user doc):      ${counts.skippedNoUserDoc}`);
+  console.log(`  No usable auth email:       ${counts.noUsableAuthEmail}`);
+
+  return counts;
+}
+
+// Run migration if called directly
+if (require.main === module) {
+  backfillContactEmails()
+    .then(() => process.exit(0))
+    .catch((error) => {
+      console.error('Backfill failed:', error);
+      process.exit(1);
+    });
+}
+
+module.exports = { backfillContactEmails, seedFromAuthUser };

--- a/pages/admin/account.js
+++ b/pages/admin/account.js
@@ -7,6 +7,7 @@ import { useState, useContext } from "react";
 import SelectAuth from "../../components/account/SelectAuth";
 import LinkedAccounts from "../../components/account/LinkedAccounts";
 import ProviderConnections from "../../components/account/ProviderConnections";
+import ContactEmail from "../../components/account/ContactEmail";
 import { UserContext } from "../../lib/context";
 import { useRouter } from "next/router";
 import NextLink from "next/link";
@@ -92,7 +93,16 @@ export default function AccountPage() {
     ".";
 
   return (
-    <AuthCheck fallbackRoute={deleting ? "/admin/deleted-account" : null}>
+    <AuthCheck
+      fallbackRoute={deleting ? "/admin/deleted-account" : null}
+      // /admin/account is the one route AuthCheck's contact-email gate
+      // (components/ContactEmailGate.js) must never wall off -- blocking
+      // it would put the account deletion control below behind the very
+      // wall a researcher who declines to give an address needs to get
+      // past. This page renders the same contact-email section itself,
+      // just below, so there is no dead end.
+      requireContactEmail={false}
+    >
       <VStack gap={0} w="100%" maxW="560px" align="stretch">
         <Box mb={10}>
           <Heading>Account settings</Heading>
@@ -121,13 +131,26 @@ export default function AccountPage() {
         {/* Spacing carries the grouping -- no separators. DESIGN.md §4:
             mt={10} between routine sections, mt={16} before the Danger Zone,
             so the break before the irreversible section is the one break
-            that reads as different. */}
+            that reads as different.
+
+            Pinned above Sign-in methods (plan §2.3): this is the one route
+            the contact-email gate never walls off, so its unfilled state
+            has to be reachable from here, and reachable first. */}
         <SettingsSection
-          title="Sign-in methods"
-          description="How you sign in to DataPipe. Add a second method so you keep access if you lose one."
+          title="Contact email"
+          description="Where DataPipe reaches you if your data stops arriving. Never shown to participants."
         >
-          <LinkedAccounts />
+          <ContactEmail data={data} />
         </SettingsSection>
+
+        <Box mt={10}>
+          <SettingsSection
+            title="Sign-in methods"
+            description="How you sign in to DataPipe. Add a second method so you keep access if you lose one."
+          >
+            <LinkedAccounts />
+          </SettingsSection>
+        </Box>
 
         <Box mt={10}>
           <SettingsSection


### PR DESCRIPTION
## What this is

Two owner-directed features, built as five disjoint packages on one branch:

### A required, deliverable email for every account

- `users/{uid}` gains `contactEmail` (+ verified/updatedAt/source) behind an adversarial rules gate: clients can set an address but can never certify it — `contactEmailVerified: true` is writable only by the backend verification endpoint, and an address change always resets it.
- **The wall**: signed-in users with no address get a full blocking panel on every admin route (except `/admin/account`, so account deletion stays reachable). Copy leads with the why: service disruptions and upload-failure notifications. No skip. The page unblocks reactively the moment the address saves.
- **Who never sees it**: new email/password signups seed automatically from their auth email, and the included backfill migration (dry-run by default) seeds existing email/password accounts the same way — iterating Firebase **Auth** users only, since OSF OAuth account-creation never produced a real address (owner-confirmed; all OSF-supplied emails are synthetic). Only genuinely email-less OAuth-created accounts get interrupted.
- **Verification** (never gating): 6-digit code round trip, hash-only storage in a default-deny collection, attempt caps checked before hash comparison, and a stale-address guard so a code sent to an old address can't verify a new one. Unverified just shows a neutral status in account settings.

### First-failure upload notifications

- A dedicated `uploadQueue` trigger mails the experiment owner on the **first real failure** — first retry-count increase or terminal `failed` — so compaction holds and self-healing blips can't false-alarm. Subsequent failures count silently. When the queue drains (including drain-by-deletion during cleanup), the flag re-arms; a fresh failure after a clear notifies again. A 24-hour backstop stops a flapping queue from mailing hourly.
- Race-safe by construction: one transaction reads state, checks drain, arms the flag, and creates the mail doc. The emulator suite proves 20 concurrent failures produce exactly one mail.
- The email leads with "The file is not lost," states the real retry window (five attempts over ~31 hours), names the provider error in human terms, and links the experiment page.

### Mail pipeline

Functions write to a `mail` collection per the Firebase Trigger Email extension contract — no SMTP in code, provider chosen at deploy. `docs/deploy-contact-email.md` covers the install, the SPF/DKIM warning, rules-before-functions deploy order (load-bearing), and the rollout sequence that seeds most researchers before the gate ever renders. Account purge removes verification docs and queued mail.

## Testing

- Rules: 53/53 (24 new adversarial cases: self-certification, four-key gate, legacy-shape regressions, default-deny collections)
- Emulator: notification state machine 15/15 (race, flap, drain-by-delete, compaction-hold, suppression), verification 15/15 (stale-address, attempt exhaustion with correct code, rate limit), purge 7/7
- Pure: email copy builder 29/29 · Frontend: 242/242 (gate suite, section suite, fixture updates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)