### PR TITLE
docs: copy-level fixes from Diátaxis review

### DIFF
--- a/pages/docs/data/finalizing.js
+++ b/pages/docs/data/finalizing.js
@@ -21,7 +21,8 @@ export default function FinishingAStudyPage() {
         data is coming.
       </Text>
       <Text maxW="70ch" mt={4}>
-        Finalizing is optional. An experiment you stop using keeps its files
+        Finalizing is optional, and today it applies to Zenodo experiments
+        only. An experiment you stop using keeps its files
         exactly as they are; finalizing is for turning a finished collection
         into one tidy, citable object.
       </Text>

--- a/pages/docs/experiments/conditions.js
+++ b/pages/docs/experiments/conditions.js
@@ -49,8 +49,8 @@ export default function ConditionAssignmentPage() {
           <strong>Set the number when you turn the switch on.</strong> A new
           DataPipe experiment is created with one condition, and with one
           condition every participant is handed 0 and nothing ever advances. The
-          dashboard field will not go below 2, so a study that needs conditions
-          needs you to type the number in.
+          dashboard field will not go below 2, so a study with multiple
+          conditions requires you to type the number in.
         </Text>
         <Text maxW="70ch">
           Underneath, DataPipe keeps a single counter on the experiment. Each

--- a/pages/docs/experiments/sending-data.js
+++ b/pages/docs/experiments/sending-data.js
@@ -114,8 +114,9 @@ export default function SendingDataPage() {
         <Text maxW="70ch">Three things to know before you rely on it:</Text>
         <List.Root maxW="70ch" gap={2} ps={6}>
           <List.Item>
-            It has its own switch, which works independently of the other one.
-            Turn on <strong>Accept base64 file uploads</strong> on the
+            It has its own switch, which works independently of{" "}
+            <strong>Accept new data</strong>. Turn on{" "}
+            <strong>Accept base64 file uploads</strong> on the
             dashboard, or these requests are rejected with{" "}
             <Code>BASE64DATA_COLLECTION_NOT_ACTIVE</Code> — and equally, this
             switch keeps accepting files after you have turned off{" "}
@@ -180,7 +181,7 @@ export default function SendingDataPage() {
           >
             CompressionStream API
           </ProseLink>{" "}
-          and setting the <Code>Content-Encoding: gzip</Code> header. The server
+          and set the <Code>Content-Encoding: gzip</Code> header. The server
           will decompress the body automatically.
         </Text>
         <Text maxW="70ch">
@@ -200,8 +201,8 @@ export default function SendingDataPage() {
 
       <DocsSection id="what-the-response-means" title="What the response means">
         <Text maxW="70ch">
-          Every submission gets one of three answers, and only one of them means
-          you should do something about it.
+          In normal operation every submission gets one of three answers, and
+          only one of them means you should do something about it.
         </Text>
         <List.Root maxW="70ch" gap={3} ps={6}>
           <List.Item>

--- a/pages/docs/providers/connecting.js
+++ b/pages/docs/providers/connecting.js
@@ -105,7 +105,8 @@ export default function ConnectingAndReconnectingPage() {
 
       <DocsSection id="dataverse" title="Dataverse">
         <Text maxW="70ch">
-          Dataverse opens a short form instead of a redirect. It needs the full
+          For Dataverse, clicking Connect opens a short form instead of handing
+          you to another site. It needs the full
           address of your institution&apos;s installation — for example,{" "}
           <Code>https://dataverse.harvard.edu</Code> — and an API token, which
           you create under the{" "}


### PR DESCRIPTION
## Summary

Copy-level fixes from a Diátaxis-framework review of the `/docs` section. The section's architecture (tutorial cross-linked outside `/docs`, clean API reference, hybrid how-to/explanation topic pages) was left as is — these are six targeted prose edits across four pages. No section ids, nav entries, or structure changed.

- **sending-data**: grammar fix ("and *setting* the header" → "and *set*"); "independently of the other one" now names **Accept new data**; "every submission gets one of three answers" softened to "in normal operation" so it no longer contradicts the API reference's `500` row.
- **providers/connecting**: Dataverse section now opens in parallel with the Drive/Zenodo sections ("For Dataverse, clicking Connect opens a short form…").
- **data/finalizing**: intro now says finalizing applies to Zenodo experiments only, before the first section references "your Zenodo deposition".
- **experiments/conditions**: "a study that needs conditions needs you to type" → "a study with multiple conditions requires you to type".

## Test plan

- [x] `npx eslint` clean on all four files
- [ ] Visual spot-check of the four pages in `npm run dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015sgaqqAebNujGsZ5mKbK52