### PR TITLE
fix(metadata): readable, collision-free flattening of researcher subfolders

### DIFF
--- a/docs/provider-migration-design.md
+++ b/docs/provider-migration-design.md
@@ -817,7 +817,8 @@ Google Drive provider is announced:
   Live keys stay flat and the compaction archive carries the real Psych-DS
   tree. What made (a) safe rather than merely cheapest is that the
   reconstruction turned out to be **exact, not heuristic**:
-  `metadata-derived-files.ts` flattens researcher subfolders with `-` *before*
+  `metadata-derived-files.ts` flattens researcher subfolders with `-` (plus a
+  `~<digest>` suffix disambiguating names that collapse alike) *before*
   building a path, so a leaf reaching a provider never contains a slash, and
   the only shapes DataPipe writes are `data/raw/<leaf>`,
   `data/<stem>_data.csv`, `dataset_description.json` and `.psychds-ignore`.

--- a/functions/src/__tests__/metadata-derived-files.test.js
+++ b/functions/src/__tests__/metadata-derived-files.test.js
@@ -33,26 +33,117 @@ describe('rawDataPath', () => {
     expect(rawDataPath('abc123.json')).toBe('data/raw/abc123.json');
   });
 
-  it('encodes researcher subfolders into the flattened name', () => {
-    expect(rawDataPath('condition-A/abc123.json')).toBe('data/raw/condition-A%2Fabc123.json');
-    expect(rawDataPath('a/b/abc123.json')).toBe('data/raw/a%2Fb%2Fabc123.json');
+  // --- the untouched majority -------------------------------------------
+  //
+  // A name with no "/", "\" or "~" is passed through byte-for-byte. This is
+  // the case for effectively every real submission, and it is what keeps the
+  // stored filename recognisable to the researcher who chose it.
+
+  it.each([
+    'abc123.json',
+    'my-file_2.json',
+    'subject-01.csv',
+    '50%.json',
+    'a b (copy).json',
+    'ünïcödé.json',
+    '.hidden',
+    'no-extension',
+  ])('passes %s through byte-identical', (name) => {
+    expect(rawDataPath(name)).toBe(`data/raw/${name}`);
   });
 
-  it('keeps names without separators or "%" byte-identical', () => {
-    expect(rawDataPath('my-file_2.json')).toBe('data/raw/my-file_2.json');
+  // --- the flattened minority -------------------------------------------
+
+  it('collapses researcher subfolders to hyphens and appends a disambiguating hash', () => {
+    expect(rawDataPath('condition-A/abc123.json')).toBe('data/raw/condition-A-abc123~612613de.json');
+    expect(rawDataPath('a/b/abc123.json')).toBe('data/raw/a-b-abc123~65b435d0.json');
   });
+
+  it('inserts the hash before the extension, not after it', () => {
+    expect(rawDataPath('condition-A/data.json')).toMatch(/^data\/raw\/condition-A-data~[0-9a-f]{8}\.json$/);
+  });
+
+  it('appends the hash at the end when the name has no extension', () => {
+    expect(rawDataPath('nested/dir/archive')).toBe('data/raw/nested-dir-archive~c97f4ec2');
+  });
+
+  it('treats a leading dot as part of the name, not as an extension', () => {
+    // ".psychds-ignore"-shaped names have their dot at index 0; the hash must
+    // still land at the end rather than splitting the name in two.
+    expect(rawDataPath('dir/.hidden')).toMatch(/^data\/raw\/dir-\.hidden~[0-9a-f]{8}$/);
+  });
+
+  it('is deterministic across calls', () => {
+    expect(rawDataPath('condition-A/data.json')).toBe(rawDataPath('condition-A/data.json'));
+  });
+
+  it('normalises backslashes and repeated separators in the readable part', () => {
+    expect(rawDataPath('a\\b.json')).toMatch(/^data\/raw\/a-b~[0-9a-f]{8}\.json$/);
+    expect(rawDataPath('a//b.json')).toMatch(/^data\/raw\/a-b~[0-9a-f]{8}\.json$/);
+  });
+
+  // --- injectivity -------------------------------------------------------
+  //
+  // The property that matters: two DISTINCT submitted names must never reach
+  // the same raw path, because that path is the collision-cache claim and a
+  // shared claim means a legitimate submission is rejected as a duplicate.
 
   it('keeps two same-leaf-name submissions from different subfolders collision-free', () => {
     expect(rawDataPath('condition-A/data.json')).not.toBe(rawDataPath('condition-B/data.json'));
   });
 
   it('keeps a prefixed name distinct from its flattened look-alike', () => {
+    // The regression that motivated the hash: under a bare "/" -> "-"
+    // collapse these two produced the same path, so the second one to arrive
+    // was rejected as a duplicate. The look-alike carries no "~", the
+    // flattened name always does, so they can never meet.
     expect(rawDataPath('condition-A/data.json')).not.toBe(rawDataPath('condition-A-data.json'));
+    expect(rawDataPath('condition-A-data.json')).toBe('data/raw/condition-A-data.json');
   });
 
-  it('escapes the escape marker itself, so pre-encoded names stay distinct', () => {
-    expect(rawDataPath('50%.json')).toBe('data/raw/50%25.json');
-    expect(rawDataPath('a%2Fb.json')).not.toBe(rawDataPath('a/b.json'));
+  it('disambiguates separator variants that collapse to the same readable name', () => {
+    const variants = ['a/b.json', 'a\\b.json', 'a//b.json', 'a/\\b.json'];
+    expect(new Set(variants.map(rawDataPath)).size).toBe(variants.length);
+  });
+
+  it('disambiguates a submitted name that already contains the hash marker', () => {
+    // "a~b.json" contains no separator but does contain "~", so it takes the
+    // suffixed branch too -- otherwise it could pass through unchanged and
+    // land on some slashed name's flattened output.
+    expect(rawDataPath('a~b.json')).toBe('data/raw/a~b~fca59991.json');
+    expect(rawDataPath('a~b.json')).not.toBe(rawDataPath('a/b.json'));
+  });
+
+  it('never lets a passed-through name collide with a flattened one', () => {
+    // Structural guarantee, stated as a test: pass-through outputs contain no
+    // "~" and flattened outputs always contain one, so the two sets are
+    // disjoint by construction rather than by luck.
+    const passedThrough = ['condition-A-data.json', 'a-b.json', 'abc123.json', '50%.json'];
+    const flattened = ['condition-A/data.json', 'a/b.json', 'a\\b.json', 'x/abc123.json'];
+
+    for (const name of passedThrough) expect(rawDataPath(name)).not.toContain('~');
+    for (const name of flattened) expect(rawDataPath(name)).toContain('~');
+  });
+
+  it('maps a broad set of adversarial names to distinct paths', () => {
+    const names = [
+      'data.json',
+      'condition-A/data.json',
+      'condition-A-data.json',
+      'condition-B/data.json',
+      'a/b/data.json',
+      'a/b-data.json',
+      'a-b/data.json',
+      'a-b-data.json',
+      'a\\b\\data.json',
+      'a//b//data.json',
+      'a~b~data.json',
+      '50%.json',
+      '50%2F.json',
+      'data',
+      'dir/data',
+    ];
+    expect(new Set(names.map(rawDataPath)).size).toBe(names.length);
   });
 });
 

--- a/functions/src/__tests__/scheduled-pending-recovery-emulator.test.js
+++ b/functions/src/__tests__/scheduled-pending-recovery-emulator.test.js
@@ -21,6 +21,12 @@ const { getFirestore } = require("firebase-admin/firestore");
 const { getStorage } = require("firebase-admin/storage");
 const { promoteToQueue } = require("../../lib/scheduled-pending-recovery.js");
 const { persistPending } = require("../../lib/persist-pending.js");
+// The expected path comes from the layout module rather than being spelled
+// out here: this suite's job is to prove recovery agrees with the Psych-DS
+// layout, not to re-assert the flattening rules (metadata-derived-files.test
+// pins those). Hardcoding the encoding here is what silently went stale when
+// the flattening changed.
+const { uploadPathFor } = require("../../lib/metadata-derived-files.js");
 
 jest.setTimeout(30000);
 
@@ -68,13 +74,17 @@ describe("scheduled-pending-recovery layout awareness", () => {
 
     await promoteToQueue(file);
 
-    const expectedDedupKey = `${experimentID}:data/raw/condition-A-data.json`;
+    const expectedFilename = uploadPathFor(true, "condition-A/data.json");
+    const expectedDedupKey = `${experimentID}:${expectedFilename}`;
     const docId = expectedDedupKey.replace(/[/\\]/g, "_");
     createdQueueDocIds.push(docId);
     const doc = await db.collection("uploadQueue").doc(docId).get();
 
     expect(doc.exists).toBe(true);
-    expect(doc.data().filename).toBe("data/raw/condition-A-data.json");
+    // Sanity-check the shape so a uploadPathFor that silently became identity
+    // could not make this test pass vacuously.
+    expect(expectedFilename).toMatch(/^data\/raw\/condition-A-data~[0-9a-f]{8}\.json$/);
+    expect(doc.data().filename).toBe(expectedFilename);
     expect(doc.data().deduplicationKey).toBe(expectedDedupKey);
   });
 

--- a/functions/src/metadata-derived-files.ts
+++ b/functions/src/metadata-derived-files.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'crypto';
 import {
   deriveFallbackBase,
   buildPsychDSDataFiles,
@@ -28,19 +29,56 @@ export interface DerivedFileSource extends ExtractionResult {
  * Researcher-supplied folder prefixes (e.g. "condition-A/abc.json") are
  * flattened into the Psych-DS layout: the CLI converts whole directories into
  * a flat data/ folder, and DataPipe matches it, so the path is encoded into a
- * single filename rather than nested. The encoding is percent-escaping
- * restricted to exactly "%", "/" and "\" ("%25", "%2F", "%5C"), which makes
- * it injective: no two distinct submitted names can flatten to the same raw
- * path or collision-cache claim. (The previous separator->"-" collapse let
- * "condition-A/data.json" shadow "condition-A-data.json", so the second
- * valid submission was rejected as a duplicate.) Names containing none of
- * the three characters -- the overwhelming majority -- pass through
- * unchanged. Derived CSV/sidecar stems built from this name additionally go
- * through the library's lossy toPsychDSValue sanitiser; the raw path and
- * its collision-cache claim are the duplicate guard, not the derived names.
+ * single filename rather than nested. Flattening is DataPipe's job rather
+ * than the provider's because two of the four backends rewrite slashed names
+ * themselves -- Zenodo's keyspace is flat and silently renames, Drive stores
+ * by bare leaf -- and the collision cache matches names exactly, so a
+ * server-side rename we did not predict becomes a duplicate or an overwrite.
+ *
+ * Separators collapse to "-" and a short digest of the ORIGINAL name is
+ * appended before the extension: "condition-A/data.json" ->
+ * "condition-A-data~a8c61a73.json". Names containing no "/", "\" or "~" --
+ * effectively every real submission -- pass through byte-for-byte, so the
+ * stored file keeps the name the researcher chose.
+ *
+ * WHY THE DIGEST. The raw path doubles as the collision-cache claim, so two
+ * distinct submitted names reaching one path means a legitimate submission is
+ * rejected as a duplicate. A bare "/" -> "-" collapse is not injective: it let
+ * "condition-A/data.json" shadow "condition-A-data.json". The digest splits
+ * the output into two provably disjoint sets -- a passed-through name can
+ * never contain "~", a flattened one always does -- which closes that
+ * shadowing case by construction rather than by chance. Within the flattened
+ * set two names collide only if they collapse identically AND their digests
+ * match; that is a 2^-32 tail on an input set of names differing only in
+ * their separators, not a general birthday bound. A submitted name that
+ * already contains "~" takes the flattened branch for the same reason, so it
+ * cannot impersonate a flattened one.
+ *
+ * Derived CSV/sidecar stems built from this name additionally go through the
+ * library's lossy toPsychDSValue sanitiser; the raw path and its
+ * collision-cache claim are the duplicate guard, not the derived names.
  */
+const NEEDS_FLATTENING = /[/\\~]/;
+const DIGEST_LENGTH = 8;
+
 function flattenName(dataFilename: string): string {
-  return dataFilename.replace(/[%/\\]/g, (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`);
+  if (!NEEDS_FLATTENING.test(dataFilename)) return dataFilename;
+
+  const collapsed = dataFilename.replace(/[/\\]+/g, '-');
+  const digest = createHash('sha256')
+    .update(dataFilename, 'utf8')
+    .digest('hex')
+    .slice(0, DIGEST_LENGTH);
+
+  // The extension is read off the ORIGINAL leaf, not the collapsed string: a
+  // dotfile leaf ("dir/.hidden") has no extension, but collapsing moves its
+  // dot away from index 0 where a naive lastIndexOf would mistake it for one.
+  const leaf = dataFilename.split(/[/\\]/).pop() as string;
+  const dotIndex = leaf.lastIndexOf('.');
+  const extension = dotIndex <= 0 ? '' : leaf.slice(dotIndex);
+  const stem = extension ? collapsed.slice(0, collapsed.length - extension.length) : collapsed;
+
+  return `${stem}~${digest}${extension}`;
 }
 
 /**

--- a/functions/src/providers/types.ts
+++ b/functions/src/providers/types.ts
@@ -267,7 +267,8 @@ export interface StorageProvider {
   // many-to-one (Zenodo maps every run of slashes to a single "_"). It is
   // exact only over the paths DATAPIPE ITSELF writes, which is all it is ever
   // asked about: metadata-derived-files.ts flattens researcher subfolders with
-  // "-" BEFORE building a path, so a leaf never contains a slash and the only
+  // "-" (plus a "~<digest>" disambiguator) BEFORE building a path, so a leaf
+  // never contains a slash and the only
   // shapes that reach a provider are `data/raw/<leaf>`, `data/<stem>_data.csv`,
   // `dataset_description.json`, and `.psychds-ignore`. Callers pass
   // metadataActive so the reconstruction is skipped entirely for experiments

--- a/functions/src/providers/zenodo.ts
+++ b/functions/src/providers/zenodo.ts
@@ -212,9 +212,14 @@ function toZenodoKey(name: string): string {
 //   .psychds-ignore            -> unchanged
 //
 // The leaf is safe to hand back untouched because metadata-derived-files.ts
-// flattens researcher-supplied subfolders with "-" BEFORE the path is built,
-// so a leaf reaching Zenodo never contains a slash and there is no second
-// separator left to guess at. The one remaining ambiguity -- a researcher
+// flattens researcher-supplied subfolders with "-" (plus a "~<digest>" suffix
+// that disambiguates names which collapse alike) BEFORE the path is built, so
+// a leaf reaching Zenodo never contains a slash and there is no second
+// separator left to guess at. That flattening is load-bearing for THIS
+// function, not just for the collision cache: if researcher subfolders ever
+// became real path segments, `data/raw/cond-A/x.json` would arrive as
+// `data_raw_cond-A_x.json` and the subfolder boundary would be
+// unrecoverable. The one remaining ambiguity -- a researcher
 // naming their own file `data_x.json` in an experiment that writes no slashed
 // paths at all -- is removed by the caller, not here: compaction only applies
 // this to metadataActive experiments (see archivePathsFor in compaction.ts).

--- a/jest.config.js
+++ b/jest.config.js
@@ -14,6 +14,16 @@ const customJestConfig = {
   // if using TypeScript with a baseUrl set to the root directory then you need the below for alias' to work
   moduleDirectories: ['node_modules', '<rootDir>/'],
   testEnvironment: 'jest-environment-jsdom',
+  // Scratch directories that hold a full copy of the repo. `.claude/worktrees/`
+  // is where agent worktrees land; each one carries its own
+  // functions/metadata/package.json, and Jest's haste map refuses to resolve
+  // `@jspsych/metadata` when two packages claim the name -- every suite that
+  // imports it dies with "looked up in the Haste module map". `.firebase/` is
+  // the deploy staging copy and collides the same way on the root package
+  // name. Neither is a test root, and neither exists in CI (both untracked),
+  // so this only shows up locally -- which is exactly why it is worth pinning
+  // here rather than rediscovering it each time.
+  modulePathIgnorePatterns: ['<rootDir>/.claude/', '<rootDir>/.firebase/'],
 }
 
 // createJestConfig is exported this way to ensure that next/jest can load the Next.js config which is async

--- a/pages/docs/data/files.js
+++ b/pages/docs/data/files.js
@@ -157,9 +157,13 @@ export default function FilenamesArchivesAndYourStoragePage() {
           your data — is on, a name like{" "}
           <Code>condition-A/abc.json</Code> is flattened with hyphens before the
           path is built, so it is stored at{" "}
-          <Code>data/raw/condition-A-abc.json</Code>. The prefix is kept rather
-          than discarded, so two submissions that share a name after the last
-          slash still do not collide.
+          <Code>data/raw/condition-A-abc~a145753b.json</Code>. The prefix is
+          kept rather than discarded, so two submissions that share a name after
+          the last slash still do not collide. The short code after{" "}
+          <Code>~</Code> is derived from the name you sent and is stable across
+          resubmissions; it keeps <Code>condition-A/abc.json</Code> distinct
+          from a file literally named <Code>condition-A-abc.json</Code>. Names
+          without a slash are stored exactly as sent and get no code.
         </Text>
         <Text maxW="70ch">
           <strong>Zenodo cannot store a slash at all.</strong> It holds every
@@ -173,10 +177,16 @@ export default function FilenamesArchivesAndYourStoragePage() {
           archives described below, where DataPipe controls the paths.
         </Text>
         <Text maxW="70ch">
-          One consequence on Google Drive: only the last segment of a slashed
-          name is used, so <Code>condition-A/abc.json</Code> and{" "}
-          <Code>condition-B/abc.json</Code> are treated as the same name. Make
-          the part after the last slash distinct, not the prefix.
+          <strong>One consequence on Google Drive, with metadata off.</strong>{" "}
+          Drive identifies a file by the last segment of its path, so{" "}
+          <Code>condition-A/abc.json</Code> and{" "}
+          <Code>condition-B/abc.json</Code> are treated as the same name and the
+          second submission is rejected as a duplicate. Make the part after the
+          last slash distinct, not the prefix. This does not apply when metadata
+          is on: the flattening described above removes your slashes before
+          Drive ever sees the name, so the two become{" "}
+          <Code>condition-A-abc~…json</Code> and{" "}
+          <Code>condition-B-abc~…json</Code> and stay distinct.
         </Text>
         <GuidanceLine
           href="/docs/experiments/metadata"

--- a/pages/docs/experiments/metadata.js
+++ b/pages/docs/experiments/metadata.js
@@ -109,15 +109,25 @@ export default function PsychDsMetadataPage() {
           You will not get subfolders inside your dataset, whatever filenames
           you send. If a filename contains a folder — say{" "}
           <Code>condition-A/abc.json</Code> — DataPipe replaces the slash with a
-          hyphen before building any path, so the file is stored as{" "}
-          <Code>data/raw/condition-A-abc.json</Code> and its derived tables
-          follow the same name.
+          hyphen and appends a short code before building any path, so the file
+          is stored as <Code>data/raw/condition-A-abc~a145753b.json</Code> and
+          its derived tables follow the same name.
         </Text>
         <Text maxW="70ch">
           This is deliberate: a Psych-DS dataset keeps a flat{" "}
-          <Code>data/</Code> folder, and encoding the prefix rather than
-          dropping it keeps two participants&apos; files from colliding when
+          <Code>data/</Code> folder, and keeping the prefix rather than
+          dropping it stops two participants&apos; files from colliding when
           they share a leaf name in different folders.
+        </Text>
+        <Text maxW="70ch">
+          The code after <Code>~</Code> is derived from the name you sent, so
+          it is stable — resend the same filename and you get the same stored
+          name. It exists because the hyphen alone is ambiguous:{" "}
+          <Code>condition-A/abc.json</Code> and <Code>condition-A-abc.json</Code>{" "}
+          are different submissions, and without the code they would flatten to
+          the same path and the second one would be rejected as a duplicate.
+          Filenames with no slash in them are stored exactly as you sent them
+          and never pick up a code.
         </Text>
       </DocsSection>
 


### PR DESCRIPTION
## What

Researcher-supplied folder prefixes have to be flattened into the Psych-DS layout, because two of the four backends rewrite slashed names themselves (Zenodo's keyspace is flat and silently renames; Drive stores by bare leaf) and the collision cache matches names exactly.

The previous encoding was percent-escaping. It was correct, but it put `%2F` into the filename researchers actually see on OSF, Drive, Dataverse and Zenodo — and **nothing downstream ever decodes it**. This swaps it for a hyphen collapse plus a short digest of the original name:

| submitted | stored |
|---|---|
| `abc123.json` | `abc123.json` *(unchanged)* |
| `50%.json` | `50%.json` *(unchanged)* |
| `condition-A/data.json` | `condition-A-data~a8c61a73.json` |
| `condition-A-data.json` | `condition-A-data.json` *(unchanged)* |

Names containing no `/`, `\` or `~` — effectively every real submission — pass through byte-for-byte.

## Why it's still safe

The raw path doubles as the collision-cache claim, so two distinct submitted names reaching one path means a legitimate submission is rejected as a duplicate. A bare `/` → `-` collapse is not injective — that was the bug fixed in #188.

The `~` marker splits the output into **two provably disjoint sets**: a passed-through name can never contain it, a flattened one always does. That closes the shadowing case by construction rather than by probability. The digest carries only the residual case — names that collapse alike, e.g. `a/b-data.json` vs `a-b/data.json` — where it's a 2⁻³² tail on a tiny input set, not a general birthday bound. A submitted name that already contains `~` takes the flattened branch so it can't impersonate one.

## Tests

`rawDataPath` coverage goes 6 → 21 cases: byte-identical pass-through (incl. unicode, spaces, `%`, dotfiles), digest placement before the extension, no-extension and leading-dot handling, determinism, separator-variant disambiguation, both disjointness properties as explicit assertions, and a 15-name adversarial set asserted all-distinct.

`scheduled-pending-recovery-emulator` now derives its expectation from `uploadPathFor` instead of re-spelling the encoding. That duplicated knowledge is what silently went stale and **broke CI on `test`** when the flattening last changed — this PR fixes that failure too.

Full suite: **74 suites, 1018 tests passing** (was 1003).

## Docs

Both user-facing pages (`docs/experiments/metadata`, `docs/data/files`) and the three internal comments resting on the "leaf never contains a slash" invariant (`zenodo.ts` `fromZenodoKey`, `providers/types.ts` `archivePathFor`, `provider-migration-design.md`). Those three said "flattens with `-`" — the `%2F` change had made them stale; they're accurate again and now mention the digest. The `zenodo.ts` one additionally records *why* that invariant is load-bearing for archive reconstruction, not just for the collision cache.

**Corrects a docs error found while reading:** `files.js` warned that Drive collapses `condition-A/abc.json` and `condition-B/abc.json` to one name, unscoped. That holds only with metadata **off**; with metadata on, flattening removes the slashes before Drive sees them.

## Also

Pins `.claude/` and `.firebase/` in `modulePathIgnorePatterns`. Both hold a full repo copy whose `functions/metadata/package.json` collides with the real one in Jest's haste map, breaking every suite that imports `@jspsych/metadata`. Both untracked, so it only ever bites locally.

## Note for review

This changes stored filenames going forward, for slashed names only. Files already written under the previous encoding keep their names, and the collision cache rehydrates from `listFiles` — so for an in-flight experiment that uses slashed filenames, an old file and a new submission of the same name will no longer match. Same one-time discontinuity the `%2F` change already introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015sgaqqAebNujGsZ5mKbK52