### PR TITLE
fix(gdrive): claim collisions on the full path, not the bare leaf

### DIFF
--- a/functions/src/__tests__/collision-cache.test.js
+++ b/functions/src/__tests__/collision-cache.test.js
@@ -23,6 +23,7 @@ import {
   CLAIM_TTL_MS,
   STALE_PENDING_TAKEOVER_MS,
   REHYDRATION_LEASE_MS,
+  CLAIM_NAMESPACE_VERSION,
   CollisionCacheUnavailableError,
 } from "../../lib/collision-cache.js";
 
@@ -74,13 +75,21 @@ async function createExperiment(experimentID, overrides = {}) {
 // Pre-warms the cache with a known salt and a future warmUntil so tests that
 // aren't *about* rehydration don't incidentally exercise it. Returns the salt
 // so callers can compute expected claim-doc hashes.
-async function warmExperiment(experimentID, { salt, warmUntilMs } = {}) {
+// Defaults to the CURRENT namespace, because "warm" in almost every test
+// means "genuinely usable". Pass namespaceVersion explicitly (or null, for
+// the pre-versioning shape) to build a cache that is warm by timestamp but
+// stale by namespace.
+async function warmExperiment(
+  experimentID,
+  { salt, warmUntilMs, namespaceVersion = CLAIM_NAMESPACE_VERSION } = {}
+) {
   const resolvedSalt = salt || randomUUID().replace(/-/g, "");
   const warmUntil = Timestamp.fromMillis(warmUntilMs ?? Date.now() + 24 * 60 * 60 * 1000);
-  await db
-    .collection("experiments")
-    .doc(experimentID)
-    .set({ collisionCache: { salt: resolvedSalt, warmUntil } }, { merge: true });
+  const collisionCache = { salt: resolvedSalt, warmUntil };
+  if (namespaceVersion !== null) {
+    collisionCache.namespaceVersion = namespaceVersion;
+  }
+  await db.collection("experiments").doc(experimentID).set({ collisionCache }, { merge: true });
   return resolvedSalt;
 }
 
@@ -425,6 +434,67 @@ describe("12. warm cache", () => {
     const result = await claimFilename(experimentID, "warm.csv", randomUUID(), listFilesFn);
 
     expect(result).toEqual({ claimed: true });
+    expect(listFilesFn).not.toHaveBeenCalled();
+  });
+});
+
+// A cache is only usable if its hashes are in the namespace the code will
+// look them up under. When an adapter changes what it claims or reports (see
+// CLAIM_NAMESPACE_VERSION), a cache warmed under the old rule holds hashes
+// nothing will ever match again -- so it has to read as COLD despite a
+// warmUntil far in the future, or every lookup misses in silence for up to
+// the 90-day TTL. On Drive, which has no NAME_CONFLICT backstop, that window
+// is duplicates written with nothing to catch them.
+describe("13. namespace versioning", () => {
+  it("treats a cache warmed under an older namespace as cold and rehydrates it", async () => {
+    const experimentID = freshExperimentId("ns-old");
+    await createExperiment(experimentID);
+    const salt = await warmExperiment(experimentID, {
+      namespaceVersion: CLAIM_NAMESPACE_VERSION - 1,
+    });
+    const listFilesFn = jest.fn().mockResolvedValue([{ name: "data/raw/existing.json" }]);
+
+    // Rehydration runs despite warmUntil being in the future...
+    const result = await claimFilename(experimentID, "fresh.json", randomUUID(), listFilesFn);
+    expect(listFilesFn).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ claimed: true });
+
+    // ...and the listing it pulled in is now claimable-against, in the new
+    // namespace, under the full path the adapter reports.
+    const dup = await claimFilename(
+      experimentID,
+      "data/raw/existing.json",
+      randomUUID(),
+      listFilesFn
+    );
+    expect(dup).toEqual({ claimed: false, reason: "duplicate" });
+
+    const after = await getExperimentData(experimentID);
+    expect(after.collisionCache.namespaceVersion).toBe(CLAIM_NAMESPACE_VERSION);
+    expect(after.collisionCache.salt).toBe(salt); // salt is never rotated
+  });
+
+  it("treats a pre-versioning cache (no namespaceVersion field) as namespace 1", async () => {
+    const experimentID = freshExperimentId("ns-absent");
+    await createExperiment(experimentID);
+    await warmExperiment(experimentID, { namespaceVersion: null });
+    const listFilesFn = jest.fn().mockResolvedValue([]);
+
+    await claimFilename(experimentID, "fresh.json", randomUUID(), listFilesFn);
+
+    expect(listFilesFn).toHaveBeenCalledTimes(1);
+    const after = await getExperimentData(experimentID);
+    expect(after.collisionCache.namespaceVersion).toBe(CLAIM_NAMESPACE_VERSION);
+  });
+
+  it("does not re-rehydrate a cache already warm in the current namespace", async () => {
+    const experimentID = freshExperimentId("ns-current");
+    await createExperiment(experimentID);
+    await warmExperiment(experimentID, { namespaceVersion: CLAIM_NAMESPACE_VERSION });
+    const listFilesFn = jest.fn().mockResolvedValue([]);
+
+    await claimFilename(experimentID, "fresh.json", randomUUID(), listFilesFn);
+
     expect(listFilesFn).not.toHaveBeenCalled();
   });
 });

--- a/functions/src/__tests__/compaction-emulator.test.js
+++ b/functions/src/__tests__/compaction-emulator.test.js
@@ -252,6 +252,7 @@ let buildArchive;
 let archivePathsFor;
 let claimDocId;
 let claimFilename;
+let CLAIM_NAMESPACE_VERSION;
 let zenodoProvider;
 
 beforeAll(async () => {
@@ -280,6 +281,7 @@ beforeAll(async () => {
   const cache = await import("../../lib/collision-cache.js");
   claimDocId = cache.claimDocId;
   claimFilename = cache.claimFilename;
+  CLAIM_NAMESPACE_VERSION = cache.CLAIM_NAMESPACE_VERSION;
 
   zenodoProvider = (await import("../../lib/providers/zenodo.js")).zenodoProvider;
 
@@ -372,6 +374,10 @@ async function seedExperiment({ sessionCount = SESSIONS, metadataActive = true, 
       collisionCache: {
         salt: SALT,
         warmUntil: Timestamp.fromMillis(Date.now() + 86400000),
+        // Stamped so the cache is warm in the CURRENT namespace. Without it
+        // the fixture reads as pre-versioning (namespace 1), goes cold, and
+        // every test here rehydrates against a provider it never set up.
+        namespaceVersion: CLAIM_NAMESPACE_VERSION,
       },
     });
 

--- a/functions/src/__tests__/finalization-emulator.test.js
+++ b/functions/src/__tests__/finalization-emulator.test.js
@@ -214,6 +214,7 @@ let finalizeExperiment;
 let buildArchive;
 let archivePathsFor;
 let claimDocId;
+let CLAIM_NAMESPACE_VERSION;
 let zenodoProvider;
 let retryPendingUploads;
 
@@ -236,6 +237,7 @@ beforeAll(async () => {
   archivePathsFor = compaction.archivePathsFor;
 
   const cache = await import("../../lib/collision-cache.js");
+  CLAIM_NAMESPACE_VERSION = cache.CLAIM_NAMESPACE_VERSION;
   claimDocId = cache.claimDocId;
 
   zenodoProvider = (await import("../../lib/providers/zenodo.js")).zenodoProvider;
@@ -358,6 +360,7 @@ async function seedFinalizableExperiment({ metadataActive = true } = {}) {
       collisionCache: {
         salt: SALT,
         warmUntil: Timestamp.fromMillis(Date.now() + 86400000),
+        namespaceVersion: CLAIM_NAMESPACE_VERSION,
       },
     });
 
@@ -467,7 +470,11 @@ describe("F2. byte fidelity through the batch -> unzip -> rezip round trip", () 
         owner: OWNER_ID,
         storageProvider: "zenodo",
         providerContainer: containerFor(),
-        collisionCache: { salt: SALT, warmUntil: Timestamp.fromMillis(Date.now() + 86400000) },
+        collisionCache: {
+          salt: SALT,
+          warmUntil: Timestamp.fromMillis(Date.now() + 86400000),
+          namespaceVersion: CLAIM_NAMESPACE_VERSION,
+        },
       });
     const claims = db.collection("experiments").doc(experimentID).collection("filenameClaims");
     await claims.doc(claimDocId(SALT, "datapipe-batch-0001.zip")).set({
@@ -798,7 +805,11 @@ describe("F6. eligibility", () => {
         sessions: 0,
         storageProvider: "zenodo",
         providerContainer: containerFor(),
-        collisionCache: { salt: SALT, warmUntil: Timestamp.fromMillis(Date.now() + 86400000) },
+        collisionCache: {
+          salt: SALT,
+          warmUntil: Timestamp.fromMillis(Date.now() + 86400000),
+          namespaceVersion: CLAIM_NAMESPACE_VERSION,
+        },
       });
 
     const result = await finalizeExperiment(experimentID);

--- a/functions/src/__tests__/gdrive-emulator.test.js
+++ b/functions/src/__tests__/gdrive-emulator.test.js
@@ -360,10 +360,30 @@ function createMockDriveServer() {
             });
             return id;
           },
-          // Leaf-name lookup (not full-path), matching how listFiles reports
-          // every file regardless of which folder it was found in.
+          // Leaf-name lookup. Ambiguous by construction when two folders hold
+          // the same leaf -- use getContentByPath for those.
           getContentByLeafName: (name) => {
             const file = Array.from(filesById.values()).find((f) => f.name === name && f.mimeType !== FOLDER_MIME);
+            return file ? file.content : null;
+          },
+          // Full-path lookup, walking real folders from the container root the
+          // way listFiles' recursion does. Needed wherever a test has two files
+          // that share a leaf in different folders, which is precisely the case
+          // a leaf-only lookup cannot distinguish.
+          getContentByPath: (rootFolderId, fullPath) => {
+            const segments = fullPath.split("/");
+            const leafName = segments.pop();
+            let parentId = rootFolderId;
+            for (const segment of segments) {
+              const folder = Array.from(filesById.values()).find(
+                (f) => f.name === segment && f.mimeType === FOLDER_MIME && f.parents.includes(parentId)
+              );
+              if (!folder) return null;
+              parentId = folder.id;
+            }
+            const file = Array.from(filesById.values()).find(
+              (f) => f.name === leafName && f.mimeType !== FOLDER_MIME && f.parents.includes(parentId)
+            );
             return file ? file.content : null;
           },
           reset: () => {
@@ -503,6 +523,58 @@ describe("13. gdrive experiment: duplicate filename is rejected without a second
   });
 });
 
+// The counterpart to 13: names that LOOK alike to a leaf-only view but are
+// genuinely different files. Drive is the only provider where this can lose
+// data silently -- it never returns NAME_CONFLICT, so the collision cache is
+// the sole duplicate gate, and a cache that over-claims has nothing behind it
+// to catch the mistake.
+//
+// Before listFiles reported container-relative paths, both submissions hashed
+// to the bare leaf "abc.json" and the second participant's data was rejected
+// as a duplicate that never existed. Only reachable with metadata OFF: with
+// it on, metadata-derived-files.ts folds the prefix into the leaf before the
+// path is ever built.
+describe("13b. gdrive experiment: two submissions differing only by folder prefix are not duplicates", () => {
+  it("both POSTs succeed and both files land under their own folder", async () => {
+    const experimentID = `gdrive-int13b-${randomUUID()}`;
+    const folderId = `folder-${randomUUID()}`;
+    const leaf = `shared-${randomUUID()}.json`;
+    await createGdriveExperiment(experimentID, folderId); // metadataActive: false
+
+    const first = await saveData({
+      experimentID,
+      data: sampleData,
+      filename: `condition-A/${leaf}`,
+    });
+    expect(first.status).toBe(201);
+
+    const second = await saveData({
+      experimentID,
+      data: sampleData,
+      filename: `condition-B/${leaf}`,
+    });
+    expect(second.status).toBe(201);
+
+    // Both really exist, each in its own folder -- not one overwritten by the
+    // other, and not one silently dropped.
+    expect(mockDrive.getContentByPath(folderId, `condition-A/${leaf}`)).not.toBeNull();
+    expect(mockDrive.getContentByPath(folderId, `condition-B/${leaf}`)).not.toBeNull();
+  });
+
+  it("still rejects a genuine repeat of the same full path", async () => {
+    const experimentID = `gdrive-int13c-${randomUUID()}`;
+    const folderId = `folder-${randomUUID()}`;
+    const filename = `condition-A/repeat-${randomUUID()}.json`;
+    await createGdriveExperiment(experimentID, folderId);
+
+    expect((await saveData({ experimentID, data: sampleData, filename })).status).toBe(201);
+
+    const second = await saveData({ experimentID, data: sampleData, filename });
+    expect(second.status).toBe(400);
+    expect(second.body).toEqual({ ...MESSAGES.OSF_FILE_EXISTS, metadataMessage: "" });
+  });
+});
+
 describe("14. metadata on gdrive", () => {
   it("first submission creates dataset_description.json via multipart and stores the ref; second submission media-PATCHes that ref'd id with no second create", async () => {
     const experimentID = `gdrive-int14-${randomUUID()}`;
@@ -613,8 +685,9 @@ describe("16. OSF experiment in the same run still works (legacy dispatch untouc
 // This is also the one place gdrive's rehydration test has to do MORE than
 // its Dataverse/Zenodo counterparts: the seeded file has to sit several real
 // folder levels deep (data/raw/<name>), because listFiles' recursion into
-// subfolders -- and its collapsing of every result down to the bare leaf
-// name, per storedNameFor -- is exactly the mechanism this test is meant to
+// subfolders -- and its reporting of each result under its full
+// container-relative path, which is what makes the rehydrated claim match the
+// one a write makes -- is exactly the mechanism this test is meant to
 // exercise. A file seeded flat at the folder root would not touch that path
 // at all.
 describe("17. cold collision cache rehydrates from a nested (data/raw/) folder listing", () => {

--- a/functions/src/__tests__/providers-gdrive.test.js
+++ b/functions/src/__tests__/providers-gdrive.test.js
@@ -44,6 +44,7 @@ jest.mock("node-fetch", () => ({
 
 import { gdriveProvider } from "../../lib/providers/gdrive.js";
 import { osfProvider } from "../../lib/providers/osf.js";
+import { claimNameFor } from "../../lib/providers/index.js";
 
 const API_BASE = "https://gdrive.mock.test";
 
@@ -524,13 +525,16 @@ describe("4. listFiles pagination", () => {
     const container = { provider: "gdrive", folderId: "folder-xyz" };
     const result = await gdriveProvider.listFiles(auth, container);
 
-    // Files from every level are concatenated, keyed by their own leaf name
-    // (not qualified by folder) so hashing `salt:name` matches a claim made
-    // on the raw leaf filename.
+    // Files from every level are concatenated, each QUALIFIED BY THE FOLDER
+    // PATH it was found under (relative to the container root), so hashing
+    // `salt:name` matches the claim a write makes -- storedNameFor is
+    // identity on this adapter. "c.csv" sits inside "subdir", so it comes
+    // back as "subdir/c.csv", not a bare leaf that would collide with any
+    // other c.csv elsewhere in the tree.
     expect(result).toEqual([
       { name: "a.csv", id: "f1" },
       { name: "b.csv", id: "f2" },
-      { name: "c.csv", id: "f3" },
+      { name: "subdir/c.csv", id: "f3" },
     ]);
 
     expect(mockFetch).toHaveBeenCalledTimes(3);
@@ -1042,16 +1046,34 @@ describe("9. the findOrCreateFolder race (spike gate H)", () => {
 });
 
 describe("storedNameFor (collision-cache namespace)", () => {
-  it("keeps only the leaf, matching what listFiles reports", () => {
-    expect(gdriveProvider.storedNameFor("data/raw/abc123.json")).toBe("abc123.json");
-    expect(gdriveProvider.storedNameFor("flat.json")).toBe("flat.json");
+  // gdrive declares no storedNameFor at all: it stores path prefixes as real
+  // nested folders and listFiles reports every file under its full
+  // container-relative path, so identity is already correct and omitting the
+  // hook is how the interface spells that (see StorageProvider.storedNameFor).
+  //
+  // It used to keep only the leaf, deliberately over-claiming so two folders
+  // could not hide a duplicate from a leaf-only listing. That cost more than
+  // it bought: Drive returns no NAME_CONFLICT, so the cache is the only
+  // duplicate gate, and the over-claim rejected legitimate submissions that
+  // differed only by folder.
+  it("is absent, so claimNameFor passes the path through unchanged", () => {
+    expect(gdriveProvider.storedNameFor).toBeUndefined();
+    expect(claimNameFor(gdriveProvider, "data/raw/abc123.json")).toBe("data/raw/abc123.json");
+    expect(claimNameFor(gdriveProvider, "condition-A/abc.json")).toBe("condition-A/abc.json");
+    expect(claimNameFor(gdriveProvider, "flat.json")).toBe("flat.json");
   });
 
-  // OSF is the opposite: it keeps the path as real nested folders AND answers
-  // a duplicate write with 409, so distinct paths stay distinct claims and
-  // collapsing them would falsely reject a second submission to a different
-  // subfolder.
-  it("is NOT what osf does -- osf keeps the whole path", () => {
+  // Two paths sharing a leaf must stay distinct claims -- the regression this
+  // adapter used to have.
+  it("keeps same-leaf files in different folders in separate claim namespaces", () => {
+    expect(claimNameFor(gdriveProvider, "condition-A/abc.json")).not.toBe(
+      claimNameFor(gdriveProvider, "condition-B/abc.json")
+    );
+  });
+
+  // OSF agrees, by a different route: it keeps the path as real nested folders
+  // AND answers a duplicate write with 409.
+  it("matches osf, which also keeps the whole path", () => {
     expect(osfProvider.storedNameFor("data/raw/abc123.json")).toBe("data/raw/abc123.json");
   });
 });

--- a/functions/src/collision-cache.ts
+++ b/functions/src/collision-cache.ts
@@ -11,6 +11,7 @@
 //   experiments/{id}.collisionCache: {
 //     salt: string,
 //     warmUntil: Timestamp,
+//     namespaceVersion?: number,   // absent === 1; see CLAIM_NAMESPACE_VERSION
 //     rehydratingUntil?: Timestamp,
 //   }
 //   experiments/{id}/filenameClaims/{sha256hex(salt + ":" + filename)}: {
@@ -31,6 +32,22 @@ import { FileRef } from "./providers/types.js";
 export const CLAIM_TTL_MS = 90 * 24 * 60 * 60 * 1000; // 90 days
 export const STALE_PENDING_TAKEOVER_MS = 15 * 60 * 1000; // 15 minutes
 export const REHYDRATION_LEASE_MS = 60 * 1000; // 60 seconds
+
+// Identifies the NAMESPACE a cache's claim hashes were written in -- i.e. the
+// rule mapping a file to the name that gets hashed. Bump this whenever any
+// adapter changes what storedNameFor returns or what listFiles reports, and
+// every existing cache is treated as cold and rehydrates itself into the new
+// namespace on next use.
+//
+// Without it such a change is silently unsafe for up to CLAIM_TTL_MS: the
+// experiment doc still says warmUntil is in the future, so no rehydration is
+// triggered, while every lookup hashes a name in the new namespace and misses
+// the old claims. On a provider with no NAME_CONFLICT backstop (Drive) that
+// means duplicates written with nothing to catch them.
+//
+// v2: gdrive listFiles/storedNameFor moved from bare leaf to full
+// container-relative path.
+export const CLAIM_NAMESPACE_VERSION = 2;
 
 // Thrown when a cold cache needs to rehydrate but the caller-supplied
 // listFilesFn fails (e.g. container missing, access revoked). Callers must
@@ -78,8 +95,14 @@ async function ensureSalt(experimentID: string): Promise<string> {
 
 async function isCacheWarm(experimentID: string): Promise<boolean> {
   const snap = await experimentRef(experimentID).get();
-  const warmUntil = snap.data()?.collisionCache?.warmUntil as FirebaseFirestore.Timestamp | undefined;
-  return !!warmUntil && warmUntil.toMillis() > Date.now();
+  const cache = snap.data()?.collisionCache;
+  const warmUntil = cache?.warmUntil as FirebaseFirestore.Timestamp | undefined;
+  if (!warmUntil || warmUntil.toMillis() <= Date.now()) return false;
+  // A cache warmed under an older naming rule is COLD, however recent it is --
+  // its hashes are in a namespace nothing looks up any more. Caches written
+  // before versioning have no field at all, which is namespace 1.
+  const version = (cache?.namespaceVersion as number | undefined) ?? 1;
+  return version === CLAIM_NAMESPACE_VERSION;
 }
 
 // Rehydrates a cold cache: acquires a short lease, lists every file the
@@ -149,6 +172,9 @@ async function rehydrate(
   const warmUntil = Timestamp.fromMillis(Date.now() + CLAIM_TTL_MS);
   await expRef.update({
     "collisionCache.warmUntil": warmUntil,
+    // Stamped in the same write that marks the cache warm, so a cache can
+    // never be warm without recording which namespace it was warmed in.
+    "collisionCache.namespaceVersion": CLAIM_NAMESPACE_VERSION,
     "collisionCache.rehydratingUntil": FieldValue.delete(),
   });
 

--- a/functions/src/providers/gdrive.ts
+++ b/functions/src/providers/gdrive.ts
@@ -386,17 +386,16 @@ export const gdriveProvider: StorageProvider = {
     return { provider: "gdrive", folderId };
   },
 
-  // Drive stores a path prefix as real nested FOLDERS and the file itself
-  // under its bare leaf name, and listFiles below collects every file it finds
-  // under that leaf regardless of which folder it came from -- so the leaf is
-  // what the collision cache must hash. Two submissions whose paths differ
-  // only in their folder prefix therefore collide by design here; that is the
-  // pre-existing behavior listFiles was written for, and it is the safe
-  // direction, since Drive returns no NAME_CONFLICT for the cache to fall back
-  // on. See claimNameFor.
-  storedNameFor(filename: string): string {
-    return filename.split("/").pop() as string;
-  },
+  // No storedNameFor: Drive stores a path prefix as real nested FOLDERS, and
+  // listFiles below reports every file under its full path relative to the
+  // container root, so the name a write is claimed under is already the name
+  // the listing reports. Identity is correct, which is what omitting this
+  // means (see StorageProvider.storedNameFor).
+  //
+  // It used to return the bare leaf, deliberately over-claiming so that two
+  // folders could not hide a duplicate from a leaf-only listing. Now that the
+  // listing carries folder context the over-claim is pure loss -- it rejected
+  // legitimate submissions that differed only by folder. See listFiles.
 
   async writeSessionFile(
     auth: ResolvedAuth,
@@ -504,20 +503,32 @@ export const gdriveProvider: StorageProvider = {
     const gdriveContainer = container as GdriveContainerRef;
 
     // Recurses into subfolders (BFS) so collision-cache rehydration finds raw
-    // files now stored under nested Psych-DS paths (e.g. data/raw/). Every
-    // FILE entry is collected under its own leaf name — regardless of which
-    // folder it was found in — so hashing `salt:name` matches the claim made
-    // on the raw leaf filename. A failed listing at ANY level MUST throw
-    // (never return a partial/empty result): collision-cache rehydration
-    // treats the returned list as the complete set of existing filenames, and
-    // Drive has no 409 backstop — silently returning a partial list here
-    // would warm the cache incomplete and let duplicates through. The throw
-    // surfaces as CollisionCacheUnavailableError.
+    // files stored under nested Psych-DS paths (e.g. data/raw/). Every FILE
+    // entry is reported under its full path RELATIVE TO THE CONTAINER ROOT,
+    // matching what storedNameFor claims for the same write.
+    //
+    // This used to report the bare leaf instead, which over-claimed: on Drive
+    // the cache is the only duplicate gate (Drive never returns
+    // NAME_CONFLICT), so two submissions differing only in their folder --
+    // "condition-A/abc.json" and "condition-B/abc.json" with metadata OFF --
+    // hashed to one claim and the second participant's data was rejected as a
+    // duplicate. Metadata-ON experiments were unaffected, because
+    // metadata-derived-files.ts flattens researcher subfolders into the leaf
+    // before the path is built.
+    //
+    // A failed listing at ANY level MUST throw (never return a partial/empty
+    // result): collision-cache rehydration treats the returned list as the
+    // complete set of existing filenames, and Drive has no 409 backstop --
+    // silently returning a partial list here would warm the cache incomplete
+    // and let duplicates through. The throw surfaces as
+    // CollisionCacheUnavailableError.
     const results: FileRef[] = [];
-    const foldersToVisit: string[] = [gdriveContainer.folderId];
+    const foldersToVisit: { id: string; prefix: string }[] = [
+      { id: gdriveContainer.folderId, prefix: "" },
+    ];
 
     while (foldersToVisit.length > 0) {
-      const folderId = foldersToVisit.shift() as string;
+      const { id: folderId, prefix } = foldersToVisit.shift() as { id: string; prefix: string };
       const q = `'${folderId}' in parents and trashed=false`;
       let pageToken: string | undefined;
 
@@ -552,11 +563,12 @@ export const gdriveProvider: StorageProvider = {
         };
 
         for (const file of body.files || []) {
+          const path = prefix ? `${prefix}/${file.name}` : file.name;
           if (file.mimeType === FOLDER_MIME) {
-            foldersToVisit.push(file.id);
+            foldersToVisit.push({ id: file.id, prefix: path });
             continue;
           }
-          results.push({ id: file.id, name: file.name });
+          results.push({ id: file.id, name: path });
         }
 
         pageToken = body.nextPageToken;

--- a/functions/src/providers/types.ts
+++ b/functions/src/providers/types.ts
@@ -248,11 +248,16 @@ export interface StorageProvider {
   // the two sides silently disagreed. The cache hashes a name at claim time
   // and rehydrates a cold cache from listFiles, so the two MUST live in the
   // same namespace -- but adapters legitimately transform the requested path:
-  // Zenodo flattens slashes into "_", Drive stores only the leaf under a
-  // nested folder. A claim made on the raw leaf name therefore never matched
-  // a rehydrated one, and the providers that cannot return NAME_CONFLICT
-  // (Zenodo's PUT overwrites in place, Dataverse silently renames) had no
-  // backstop to catch what slipped through.
+  // Zenodo flattens slashes into "_". A claim made on the raw leaf name
+  // therefore never matched a rehydrated one, and the providers that cannot
+  // return NAME_CONFLICT (Zenodo's PUT overwrites in place, Dataverse
+  // silently renames) had no backstop to catch what slipped through.
+  //
+  // Note the symmetry runs BOTH ways: an adapter is free to make its
+  // listFiles report the full path instead of implementing this hook, which
+  // is what gdrive does. Prefer that where the provider has real folders --
+  // an over-claiming storedNameFor is lossy, and on a provider with no
+  // NAME_CONFLICT it silently rejects legitimate submissions.
   //
   // Any new adapter whose writeSessionFile does not store the requested path
   // verbatim MUST implement this. See claimNameFor in providers/index.ts.

--- a/pages/docs/data/files.js
+++ b/pages/docs/data/files.js
@@ -177,16 +177,11 @@ export default function FilenamesArchivesAndYourStoragePage() {
           archives described below, where DataPipe controls the paths.
         </Text>
         <Text maxW="70ch">
-          <strong>One consequence on Google Drive, with metadata off.</strong>{" "}
-          Drive identifies a file by the last segment of its path, so{" "}
-          <Code>condition-A/abc.json</Code> and{" "}
-          <Code>condition-B/abc.json</Code> are treated as the same name and the
-          second submission is rejected as a duplicate. Make the part after the
-          last slash distinct, not the prefix. This does not apply when metadata
-          is on: the flattening described above removes your slashes before
-          Drive ever sees the name, so the two become{" "}
-          <Code>condition-A-abc~…json</Code> and{" "}
-          <Code>condition-B-abc~…json</Code> and stay distinct.
+          <strong>On Google Drive, slashes do create real folders</strong> when
+          metadata is off — <Code>condition-A/abc.json</Code> lands in a{" "}
+          <Code>condition-A</Code> folder. Two submissions that share a name
+          after the last slash but sit in different folders are different files
+          and both are kept.
         </Text>
         <GuidanceLine
           href="/docs/experiments/metadata"


### PR DESCRIPTION
> **Stacked on #191** — base is `flatten-name-hash`, because the `docs/data/files` edit revises text that PR introduces. Merge #191 first; this retargets to `test` automatically.

## The bug

Drive returns no `NAME_CONFLICT` (it allows duplicate names in one folder), so **the collision cache is the only duplicate gate for gdrive experiments**. The adapter claimed on the bare leaf, and `listFiles` reported bare leaves to match. That over-claimed:

```
condition-A/abc.json  ->  claim "abc.json"
condition-B/abc.json  ->  claim "abc.json"   <- rejected as a duplicate, wrongly
```

Two participants' files, one claim, second submission lost.

Only reachable with **metadata OFF**. With it on, `metadata-derived-files.ts` folds the researcher's prefix into the leaf before the path is built, so the leaves were already distinct. That's the counterintuitive part worth calling out: turning Psych-DS metadata *on* silently protected against a data-loss edge that existed when it was off.

## The fix

Drive stores path prefixes as real nested folders, so the answer is to stop discarding folder context. `listFiles` now reports each file under its full container-relative path, and `storedNameFor` is dropped entirely — identity, which is what omitting the hook means. Both sides land in the same namespace, which is the invariant `claimNameFor` exists to hold.

This also **fixes compaction and finalization archives for gdrive**, which had been laying members out under bare leaves and losing the `data/raw/` structure — `archivePathFor` is absent on this adapter, so it takes `listFiles`' names verbatim.

## `CLAIM_NAMESPACE_VERSION` — please look here

Changing what a name hashes to is silently unsafe for live experiments without invalidation. The experiment doc still says `warmUntil` is 90 days out, so nothing rehydrates, while every lookup hashes in the new namespace and misses the old claims. On Drive that window is **duplicates written with nothing to catch them**.

So the cache now records which namespace it was warmed in, and a cache warmed under an older one reads as cold however recent it is — rehydrating itself into the new namespace on next use. Caches predating the field are namespace 1. Bump the constant on any future change to `storedNameFor` or `listFiles` naming.

This touches shared code used by all four providers, so it's the part most worth a second pair of eyes.

## Tests

- **gdrive 13b** covers the regression directly: two folder-prefixed submissions both land in their own folders; a genuine repeat of one full path is still rejected. I verified this test **fails against the old leaf behavior** before keeping it.
- **collision-cache 13** covers versioning: stale namespace rehydrates and re-stamps, absent field is treated as 1, current version does not re-rehydrate.
- Warm-cache fixtures in compaction/finalization now stamp the version — an unstamped fixture reads as cold and rehydrates against a provider the test never set up (this is how C10 surfaced).
- `providers-gdrive` unit tests updated to the new contract.

**74 suites / 1024 tests green.**

## Not included

The metadata on/off divergence has a second sharp edge — toggling `metadataActive` mid-study relocates writes from the container root to `data/raw/` and changes the claim namespace, so a resubmitted filename from before the toggle no longer matches. That's a product decision (lock at creation vs. lock after first submission) and is being handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015sgaqqAebNujGsZ5mKbK52