### PR TITLE
feat(metadata): freeze the Psych-DS setting once an experiment has data

### DIFF
--- a/__tests__/firestore-rules.test.js
+++ b/__tests__/firestore-rules.test.js
@@ -306,6 +306,103 @@ describe('/experiments — provider-migration generalization (step 7a)', () => {
     });
   });
 
+  // metadataActive decides where a submission is stored (container root vs
+  // data/raw/) and which namespace the collision cache claims in, so flipping
+  // it mid-collection strands the files already written and resets duplicate
+  // detection against them. It freezes at the first submission -- not at
+  // creation, because before any data exists the choice is harmless and
+  // correcting it pre-pilot is the case researchers actually hit.
+  describe('3b. metadataActive freezes once data has been collected', () => {
+    function gdriveExp(docId, overrides = {}) {
+      return baseFields({
+        id: docId,
+        owner: 'user123',
+        storageProvider: 'gdrive',
+        providerContainer: { provider: 'gdrive', folderId: 'folder-abc' },
+        metadataActive: false,
+        ...overrides,
+      });
+    }
+
+    it('ALLOWS the owner to change it while the experiment has no data', async () => {
+      const docId = 'exp-meta-lock-fresh';
+      await seedDB({ [`experiments/${docId}`]: gdriveExp(docId, { sessions: 0 }) });
+
+      const user123 = testEnv.authenticatedContext('user123');
+      await assertSucceeds(
+        updateDoc(doc(user123.firestore(), `experiments/${docId}`), { metadataActive: true })
+      );
+    });
+
+    it('DENIES a change once sessions have been recorded', async () => {
+      const docId = 'exp-meta-lock-sessions';
+      await seedDB({ [`experiments/${docId}`]: gdriveExp(docId, { sessions: 3 }) });
+
+      const user123 = testEnv.authenticatedContext('user123');
+      await assertFails(
+        updateDoc(doc(user123.firestore(), `experiments/${docId}`), { metadataActive: true })
+      );
+    });
+
+    it('DENIES turning it OFF too, not just on', async () => {
+      const docId = 'exp-meta-lock-off';
+      await seedDB({
+        [`experiments/${docId}`]: gdriveExp(docId, { sessions: 3, metadataActive: true }),
+      });
+
+      const user123 = testEnv.authenticatedContext('user123');
+      await assertFails(
+        updateDoc(doc(user123.firestore(), `experiments/${docId}`), { metadataActive: false })
+      );
+    });
+
+    // collisionCache is server-managed and clients cannot write it, so it
+    // survives a client that zeroed its own sessions counter to get the
+    // setting back.
+    it('DENIES a change when collisionCache exists even if sessions reads 0', async () => {
+      const docId = 'exp-meta-lock-cache';
+      await seedDB({
+        [`experiments/${docId}`]: gdriveExp(docId, {
+          sessions: 0,
+          collisionCache: { salt: 'seeded-salt' },
+        }),
+      });
+
+      const user123 = testEnv.authenticatedContext('user123');
+      await assertFails(
+        updateDoc(doc(user123.firestore(), `experiments/${docId}`), { metadataActive: true })
+      );
+    });
+
+    // The lock is scoped to ONE field: a collecting experiment must stay
+    // otherwise editable (pausing collection, retitling, condition changes).
+    it('still ALLOWS other edits on a collecting experiment', async () => {
+      const docId = 'exp-meta-lock-others';
+      await seedDB({ [`experiments/${docId}`]: gdriveExp(docId, { sessions: 3 }) });
+
+      const user123 = testEnv.authenticatedContext('user123');
+      await assertSucceeds(
+        updateDoc(doc(user123.firestore(), `experiments/${docId}`), {
+          active: true,
+          title: 'Renamed mid-study',
+        })
+      );
+    });
+
+    // A no-op write that merely restates the current value changes nothing,
+    // so affectedKeys() never flags it -- worth pinning so a future rewrite
+    // does not start rejecting the dashboard's own idempotent merge writes.
+    it('ALLOWS a write that re-states the SAME value on a collecting experiment', async () => {
+      const docId = 'exp-meta-lock-noop';
+      await seedDB({ [`experiments/${docId}`]: gdriveExp(docId, { sessions: 3 }) });
+
+      const user123 = testEnv.authenticatedContext('user123');
+      await assertSucceeds(
+        updateDoc(doc(user123.firestore(), `experiments/${docId}`), { metadataActive: false })
+      );
+    });
+  });
+
   describe('4. /users hasOnly unchanged (regression guard)', () => {
     it('rejects account-creation writes that include connectedAccounts -- clients can never write it', async () => {
       const user123 = testEnv.authenticatedContext('user123');

--- a/__tests__/metadata-control.test.jsx
+++ b/__tests__/metadata-control.test.jsx
@@ -1,0 +1,89 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { ChakraProvider } from "@chakra-ui/react";
+import { system } from "../lib/theme";
+import "@testing-library/jest-dom";
+
+import MetadataControl from "../components/dashboard/MetadataControl";
+
+// The component writes straight to Firestore on change; stub the SDK so the
+// only thing under test is whether it OFFERS the write.
+const setDocMock = jest.fn(() => Promise.resolve());
+jest.mock("firebase/firestore", () => ({
+  setDoc: (...args) => setDocMock(...args),
+  doc: jest.fn(() => ({})),
+}));
+jest.mock("../lib/firebase", () => ({ db: {} }));
+
+function renderWithChakra(ui) {
+  return render(<ChakraProvider value={system}>{ui}</ChakraProvider>);
+}
+
+const experiment = (overrides = {}) => ({
+  id: "exp-1",
+  metadataActive: false,
+  sessions: 0,
+  ...overrides,
+});
+
+beforeEach(() => {
+  setDocMock.mockClear();
+});
+
+// Psych-DS metadata decides WHERE a submission is stored (container root vs
+// data/raw/) and which namespace the duplicate-detection cache claims in, so
+// it freezes at the first submission. firestore.rules is the real gate; these
+// cover what the dashboard offers, which is what stops a researcher hitting a
+// refusal they were given no warning about.
+describe("MetadataControl — before any data is collected", () => {
+  it("leaves the switch operable and saves a change", async () => {
+    renderWithChakra(<MetadataControl data={experiment()} />);
+
+    const toggle = screen.getByRole("checkbox");
+    expect(toggle).toBeEnabled();
+
+    fireEvent.click(toggle);
+    await waitFor(() => expect(setDocMock).toHaveBeenCalledTimes(1));
+    expect(setDocMock.mock.calls[0][1]).toEqual({ metadataActive: true });
+  });
+
+  it("shows no lock explanation", () => {
+    renderWithChakra(<MetadataControl data={experiment()} />);
+    expect(screen.queryByText(/Locked because/i)).not.toBeInTheDocument();
+  });
+});
+
+describe("MetadataControl — once data has been collected", () => {
+  it("disables the switch when sessions have been recorded", () => {
+    renderWithChakra(<MetadataControl data={experiment({ sessions: 4 })} />);
+    expect(screen.getByRole("checkbox")).toBeDisabled();
+  });
+
+  // collisionCache is server-managed and clients cannot write it, so it still
+  // reports "this experiment has data" if the sessions counter reads 0.
+  it("disables the switch when only collisionCache reports data", () => {
+    renderWithChakra(
+      <MetadataControl data={experiment({ sessions: 0, collisionCache: { salt: "s" } })} />
+    );
+    expect(screen.getByRole("checkbox")).toBeDisabled();
+  });
+
+  it("explains WHY it is locked rather than just appearing broken", () => {
+    renderWithChakra(<MetadataControl data={experiment({ sessions: 4 })} />);
+    expect(screen.getByText(/Locked because this experiment has collected data/i)).toBeInTheDocument();
+  });
+
+  // The write is the observable contract, and it is what the server rule
+  // would refuse. Deliberately NOT asserting the input's `checked` state:
+  // jsdom flips a disabled checkbox's raw DOM state for a synthetically
+  // dispatched click, so that assertion would be measuring jsdom rather than
+  // this component -- React state never changes, and no write is issued.
+  it("never issues a write, even if the switch is activated directly", async () => {
+    renderWithChakra(<MetadataControl data={experiment({ sessions: 4 })} />);
+    const toggle = screen.getByRole("checkbox");
+
+    fireEvent.click(toggle);
+
+    expect(setDocMock).not.toHaveBeenCalled();
+    expect(toggle).toBeDisabled();
+  });
+});

--- a/components/dashboard/MetadataControl.js
+++ b/components/dashboard/MetadataControl.js
@@ -17,11 +17,41 @@ function writeMetadataActive(expId, active) {
   );
 }
 
+// Whether this experiment has already collected data, and therefore whether
+// the metadata setting is frozen.
+//
+// The setting decides WHERE a submission is stored -- at the container root
+// with it off, under data/raw/ with it on (uploadPathFor in
+// functions/src/metadata-derived-files.ts) -- and which namespace the
+// duplicate-detection cache claims in. Flipping it mid-collection therefore
+// strands everything already written at the old location and resets duplicate
+// detection against it, so a participant resubmitting a filename from before
+// the flip gets a second file instead of being recognised. Before the first
+// submission none of that exists yet and the choice is free, which is why the
+// lock is "has data", not "was created".
+//
+// `sessions` is the honest signal. `collisionCache` is the tamper-resistant
+// one -- it is server-managed and firestore.rules forbids clients touching it
+// -- and covers an experiment whose sessions counter was somehow reset. The
+// matching server rule is the gate that actually enforces this; this function
+// only decides what the UI offers.
+function hasCollectedData(data) {
+  return (typeof data.sessions === "number" && data.sessions > 0) || !!data.collisionCache;
+}
+
 export default function MetadataControl({ data }) {
+  const locked = hasCollectedData(data);
+
   return (
     <SettingsRow
       label="Generate Psych-DS metadata"
       checked={data.metadataActive}
+      disabled={locked}
+      description={
+        locked
+          ? "Locked because this experiment has collected data. This setting decides where files are stored, so changing it now would separate new submissions from the ones you already have. Create a new experiment to collect with a different setting."
+          : undefined
+      }
       onSave={(next) => writeMetadataActive(data.id, next)}
       failureMessage="Could not change metadata production. The setting is unchanged -- check your connection and try again."
       badge={

--- a/components/ui/SettingsRow.js
+++ b/components/ui/SettingsRow.js
@@ -201,6 +201,12 @@ export default function SettingsRow({
   onSave,
   failureMessage,
   savedLabel,
+  // Renders the switch inert. For settings that become permanent rather than
+  // merely unavailable -- pass `description` to say WHY, because a control
+  // that is off with no explanation reads as broken (Nielsen 1). The server
+  // rule is the real gate; this only keeps the UI from offering a write that
+  // is going to be refused.
+  disabled = false,
   children,
 }) {
   if (process.env.NODE_ENV !== "production") {
@@ -228,6 +234,10 @@ export default function SettingsRow({
   }
 
   const handleChange = (next) => {
+    // Belt and braces with the `disabled` prop below: Chakra's disabled Switch
+    // already blocks pointer and keyboard activation, but a locked setting
+    // must not be writable by any route that reaches this handler.
+    if (disabled) return;
     const previous = value;
     setValue(next);
     if (onChange) onChange(next);
@@ -255,6 +265,7 @@ export default function SettingsRow({
             colorPalette="brandGreen"
             size="md"
             checked={value}
+            disabled={disabled}
             onCheckedChange={(e) => handleChange(e.checked)}
           >
             <Switch.HiddenInput />

--- a/firestore.rules
+++ b/firestore.rules
@@ -126,11 +126,40 @@ service cloud.firestore {
         return !request.resource.data.diff(resource.data).affectedKeys()
           .hasAny(['finalized', 'finalizedAt', 'finalization', 'compaction', 'collisionCache', 'uploadFailure']);
       }
+      // metadataActive decides WHERE a submission is stored -- container root
+      // with it off, data/raw/<flattened name> with it on (uploadPathFor in
+      // functions/src/metadata-derived-files.ts) -- and therefore which
+      // namespace the collision cache claims in. Flipping it mid-collection
+      // strands every file already written at the old location and resets
+      // duplicate detection against them: a participant resubmitting a
+      // filename from before the flip is no longer recognised and gets a
+      // second file. On Drive, where the cache is the only duplicate gate,
+      // there is no provider-side conflict to catch that either.
+      //
+      // So it freezes at the FIRST SUBMISSION rather than at creation. Before
+      // any data exists none of the above is reachable and the researcher is
+      // free to correct the choice -- which is the case they actually hit,
+      // creating an experiment and fixing the setting before piloting.
+      // Experiments already mid-collection are covered by the same test with
+      // no migration: they have sessions, so they are already locked.
+      //
+      // `sessions` is the honest signal; `collisionCache` is the
+      // tamper-resistant one, since serverManagedFieldsUntouched() above
+      // forbids clients writing it at all. Either one being present means
+      // data has landed.
+      function hasCollectedData() {
+        return (('sessions' in resource.data) && resource.data.sessions is int && resource.data.sessions > 0) ||
+          ('collisionCache' in resource.data);
+      }
+      function metadataChoiceRespected() {
+        return !hasCollectedData() ||
+          !request.resource.data.diff(resource.data).affectedKeys().hasAny(['metadataActive']);
+      }
       // UPDATE shape: legacy-tolerant. An experiment created before the
       // provider-migration schema carries the OSF triple and no
       // storageProvider, and must stay editable through the OSF wind-down.
       function verifyFields() {
-        return baseFields() && serverManagedFieldsUntouched() &&
+        return baseFields() && serverManagedFieldsUntouched() && metadataChoiceRespected() &&
           (('storageProvider' in request.resource.data)
             ? request.resource.data.keys().hasAll(['storageProvider', 'providerContainer'])
             : request.resource.data.keys().hasAll(['osfRepo', 'osfComponent', 'osfFilesLink']));

--- a/pages/docs/experiments/metadata.js
+++ b/pages/docs/experiments/metadata.js
@@ -104,6 +104,31 @@ export default function PsychDsMetadataPage() {
         </GuidanceLine>
       </DocsSection>
 
+      <DocsSection
+        id="decide-before-you-collect"
+        title="Decide before you start collecting"
+      >
+        <Text maxW="70ch">
+          You can turn this setting on or off freely until the first submission
+          arrives. After that it is locked for the life of the experiment, and
+          the switch on your dashboard becomes read-only.
+        </Text>
+        <Text maxW="70ch">
+          The reason is that the setting decides <em>where</em> your files are
+          stored — at the top of your dataset with it off, under{" "}
+          <Code>data/raw/</Code> with it on. Changing it partway through would
+          leave the sessions you already collected in one place and every
+          session after it in another, and DataPipe&apos;s duplicate detection
+          would no longer recognise the earlier files — so a participant who
+          resubmitted a filename from before the change would get a second copy
+          rather than being caught as a repeat.
+        </Text>
+        <Text maxW="70ch">
+          If you need to change it after collecting data, create a new
+          experiment with the setting you want.
+        </Text>
+      </DocsSection>
+
       <DocsSection id="folder-names-are-flattened" title="Folder names are flattened">
         <Text maxW="70ch">
           You will not get subfolders inside your dataset, whatever filenames


### PR DESCRIPTION
> **Stacked on #192** (which is stacked on #191). Merge in order; each retargets automatically.

## Why

`metadataActive` decides **where** a submission is stored — container root with it off, `data/raw/<flattened name>` with it on — and therefore which namespace the collision cache claims in. Flipping it mid-collection strands every file already written at the old location and resets duplicate detection against them: a participant resubmitting a filename from before the flip is no longer recognised and gets a second file. On Drive, where the cache is the only duplicate gate, no provider-side conflict catches that either.

## The rule

Frozen at the **first submission**, not at creation.

Before any data exists none of the above is reachable, and the researcher is free to correct the choice — which is the case they actually hit: create an experiment, look at the dashboard, realise you wanted metadata on, flip it before piloting. Locking at creation would forbid that harmless correction and force a delete-and-recreate for a typo.

**Experiments already mid-collection need no migration** — they have sessions, so the same test already locks them at their current value.

## Enforcement

`firestore.rules` is the gate:

- `sessions > 0` is the honest signal.
- `collisionCache` present is the tamper-resistant one — `serverManagedFieldsUntouched()` forbids clients writing it at all, so a client that zeroed its own `sessions` counter still cannot unlock the setting.

Scoped to the single field: a collecting experiment stays otherwise editable (pause, retitle, conditions), and a no-op write restating the same value is still allowed since `affectedKeys()` never flags it.

The dashboard switch is disabled to match, with a sentence saying why — a control that is inert with no explanation reads as broken. `SettingsRow` grows a `disabled` prop for this, which also early-returns from its change handler so no route through the component issues the write. **The UI only decides what is offered; the rule is what enforces.**

## Tests

`firestore-rules` 3b — allowed while empty, denied once sessions exist, denied in **both** directions, denied via `collisionCache` with `sessions: 0`, other fields still editable, same-value no-op still allowed.

`metadata-control` (new) — switch state, the explanation text, and that no write is issued even when the switch is activated directly.

**75 suites / 1036 tests green.**

## Note for review

Two things worth a look:

1. **Deploy order.** Rules and hosting ship together; if rules land marginally first, a researcher on a stale page could still see an enabled toggle and get a refusal. `SettingsRow` surfaces that as a visible failure and reverts the switch, so it degrades correctly rather than lying — but worth knowing it is possible during the window.
2. `sessions` is not itself protected from client writes (pre-existing — it is not in `serverManagedFieldsUntouched`). That is why the rule also accepts `collisionCache` as evidence. Tightening `sessions` is a separate question I have not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015sgaqqAebNujGsZ5mKbK52