### PR TITLE
Standardize the new-experiment form across providers

### DIFF
--- a/__tests__/new-experiment-page.test.jsx
+++ b/__tests__/new-experiment-page.test.jsx
@@ -539,6 +539,9 @@ describe("NewExperimentPage — Dataverse provider (provider-generic rendering)"
 
     renderPage();
     await selectDataverse();
+    // Types contactEmail "jane@example.edu" -- deliberately NOT the account's
+    // "researcher@example.edu" above, so the assertions below can tell "the
+    // typed value survived" apart from "the account seed came back".
     fillDataverseFields({ collectionAlias: "stale-lab" });
 
     expect(screen.getByLabelText(/Collection alias/i)).toHaveValue("stale-lab");
@@ -548,9 +551,51 @@ describe("NewExperimentPage — Dataverse provider (provider-generic rendering)"
 
     expect(screen.getByLabelText(/Collection alias/i)).toHaveValue("");
     expect(screen.getByLabelText(/Author name/i)).toHaveValue("");
-    expect(screen.getByLabelText(/Contact email/i)).toHaveValue("");
     expect(screen.getByLabelText(/Description/i)).toHaveValue("");
     expect(screen.getByLabelText(/Subject/i)).toHaveValue("");
+    // Contact email comes back to the ACCOUNT's address, not to empty and not
+    // to what was typed. The guarantee this test exists for is that nothing
+    // the researcher typed leaks across a provider switch, and that holds: the
+    // typed "jane@example.edu" is gone. What replaces it is the same seed a
+    // fresh load of the form would show, so clearing it to "" would make
+    // switching provider twice a worse starting state than never touching it.
+    expect(screen.getByLabelText(/Contact email/i)).toHaveValue(
+      "researcher@example.edu"
+    );
+  });
+
+  it("prefills contact email from the account, and lets a typed value override it", async () => {
+    useDocumentData.mockReturnValue([
+      {
+        contactEmail: "researcher@example.edu",
+        refreshToken: "osf-refresh-token",
+        connectedAccounts: { dataverse: true },
+      },
+      false,
+      undefined,
+    ]);
+
+    renderPage();
+    await selectDataverse();
+
+    // users/{uid}.contactEmail is mandatory and gated by ContactEmailGate, so
+    // it is always available here -- asking a researcher to retype it was pure
+    // duplication. Every other Dataverse field has no account-level
+    // counterpart yet and stays empty.
+    expect(screen.getByLabelText(/Contact email/i)).toHaveValue(
+      "researcher@example.edu"
+    );
+    expect(screen.getByLabelText(/Author name/i)).toHaveValue("");
+
+    // A seed, never a lock: Dataverse publishes datasetContact on the dataset,
+    // and the address a researcher wants public is not always the one DataPipe
+    // emails them at.
+    fireEvent.change(screen.getByLabelText(/Contact email/i), {
+      target: { value: "lab-inbox@example.edu" },
+    });
+    expect(screen.getByLabelText(/Contact email/i)).toHaveValue(
+      "lab-inbox@example.edu"
+    );
   });
 });
 

--- a/components/dashboard/Title.js
+++ b/components/dashboard/Title.js
@@ -1,15 +1,31 @@
 import { useState } from "react";
-import { Editable, IconButton, Flex, Stack } from "@chakra-ui/react";
+import { Editable, IconButton, Flex, Stack, Text } from "@chakra-ui/react";
 
 import { Check, X, Pencil } from "lucide-react";
 
 import { db } from "../../lib/firebase";
 import { doc, setDoc } from "firebase/firestore";
+import { STORAGE_PROVIDERS } from "../../lib/provider-config";
 import { SaveStatus, useTrackedSave } from "../ui/SettingsRow";
 
 export default function ExperimentTitle({ data }) {
   // Remount counter for the Editable. See handleCommit.
   const [resetKey, setResetKey] = useState(0);
+  // Whether the Editable is currently in edit mode, so the caveat below is
+  // shown only to someone actually renaming -- it is a footnote about the
+  // rename, not a standing fact about the experiment, and a permanent line of
+  // small print under the page's H1 would be exactly the wrong weight for it.
+  const [editing, setEditing] = useState(false);
+
+  // What a rename does NOT touch. `title` is fixed at creation for every
+  // provider: it named the Drive folder / Dataverse dataset / Zenodo
+  // deposition when createDataContainer ran, and no adapter implements a
+  // container rename, so this write moves DataPipe's title only and the two
+  // diverge permanently. The researcher gets told that here rather than
+  // discovering it in their storage account months later. Undefined for
+  // legacy OSF experiments (STORAGE_PROVIDERS has no osf entry), which simply
+  // show no caveat.
+  const containerLabel = STORAGE_PROVIDERS[data.storageProvider]?.containerLabel;
 
   const titleSave = useTrackedSave(
     "Could not rename this experiment. It is still called “" +
@@ -46,6 +62,7 @@ export default function ExperimentTitle({ data }) {
         fontWeight="bold"
         color="fg"
         onValueCommit={(details) => handleCommit(details.value)}
+        onEditChange={(details) => setEditing(details.edit)}
         as={Flex}
         align="center"
       >
@@ -87,6 +104,13 @@ export default function ExperimentTitle({ data }) {
           </Editable.CancelTrigger>
         </Editable.Control>
       </Editable.Root>
+
+      {editing && containerLabel && (
+        <Text fontSize="sm" color="fg.muted">
+          This renames the experiment in DataPipe only. Your{" "}
+          {containerLabel.toLowerCase()} keeps the name it was created with.
+        </Text>
+      )}
 
       <SaveStatus
         saved={titleSave.saved}

--- a/functions/src/__tests__/create-experiment-emulator.test.js
+++ b/functions/src/__tests__/create-experiment-emulator.test.js
@@ -311,6 +311,42 @@ describe("6. createExperiment provider validation", () => {
     expect(status).toBe(400);
     expect((await experimentsForOwner(uid)).length).toBe(0);
   });
+
+  // `title` is the name of a real folder/dataset/deposition in the
+  // researcher's own account, and DataPipe has no rename path for any
+  // provider -- so a container created with a whitespace-only name is stuck
+  // with it. The old `!title` guard let " " through (a non-empty string), and
+  // so did the client's `providerTitle.length === 0`. Both now trim first.
+  it("returns 400 for a whitespace-only title and creates nothing", async () => {
+    const { uid, idToken } = await signUpEmulatorUser();
+    await seedGdriveUser(uid);
+
+    const { status } = await callCreateExperiment({ provider: "gdrive", title: "   ", idToken, uid });
+
+    expect(status).toBe(400);
+    expect((await experimentsForOwner(uid)).length).toBe(0);
+  });
+
+  // The trimmed value is what gets STORED and what is sent to the provider,
+  // so DataPipe's title and the Drive folder's name cannot disagree by a
+  // stray space the researcher never sees.
+  it("stores a padded title trimmed, and names the Drive folder with the same trimmed value", async () => {
+    const { uid, idToken } = await signUpEmulatorUser();
+    await seedGdriveUser(uid);
+    const title = `Case6 Padded ${randomUUID()}`;
+
+    const { status, body } = await callCreateExperiment({
+      provider: "gdrive",
+      title: `  ${title}  `,
+      idToken,
+      uid,
+    });
+
+    expect(status).toBe(200);
+    const experimentDoc = await db.collection("experiments").doc(body.experimentID).get();
+    expect(experimentDoc.data().title).toBe(title);
+    expect(mockDrive.getFolderId(title)).toBeTruthy();
+  });
 });
 
 describe("7. createExperiment with no connected gdrive account", () => {

--- a/functions/src/__tests__/providers-container-input.test.js
+++ b/functions/src/__tests__/providers-container-input.test.js
@@ -48,4 +48,38 @@ describe("provider containerInput conformance", () => {
       }
     }
   });
+
+  // The create form (pages/admin/new.js) renders one helper line per field
+  // saying what the provider does with the value. A field that declares no
+  // helperText renders as a bare labelled box -- which is how "Collection
+  // alias" shipped, explained nowhere but /docs/experiments. Hidden fields are
+  // exempt: they have no rendered field to explain (gdrive's parentId comes
+  // from the Google Picker, whose own copy lives in the page).
+  it("every rendered containerInput field explains itself", () => {
+    for (const id of listProviders()) {
+      for (const field of getProvider(id).containerInput) {
+        if (field.inputType === "hidden") continue;
+        expect(typeof field.helperText).toBe("string");
+        expect(field.helperText.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  // Two providers asking the same question must ask it in the same words.
+  // Dataverse's `authorName` and Zenodo's `creatorName` are the motivating
+  // case: they carry different wire names because the two APIs do, but a
+  // researcher filling in this form is answering one question, so they share
+  // the label "Author name". This pins that any field name meaning the same
+  // thing across providers keeps one label.
+  it("fields meaning the same thing share a label across providers", () => {
+    const labelsFor = (providerId, fieldName) =>
+      getProvider(providerId)
+        .containerInput.filter((f) => f.name === fieldName)
+        .map((f) => f.label);
+
+    expect(labelsFor("dataverse", "authorName")).toEqual(["Author name"]);
+    expect(labelsFor("zenodo", "creatorName")).toEqual(["Author name"]);
+    expect(labelsFor("dataverse", "description")).toEqual(["Description"]);
+    expect(labelsFor("zenodo", "description")).toEqual(["Description"]);
+  });
 });

--- a/functions/src/create-experiment.ts
+++ b/functions/src/create-experiment.ts
@@ -84,7 +84,14 @@ export const createExperiment = onRequest({ cors: true }, async (req, res) => {
       researcherInput?: Record<string, unknown>;
     } = req.body || {};
 
-    if (!provider || !title || !uid) {
+    // Trimmed here, not just in the client. `title` becomes the name of a real
+    // folder/dataset/deposition in the researcher's account, and `!title` alone
+    // accepts " " (a non-empty string), which produced a container named with a
+    // single space and no way to rename it. The trimmed value is what gets
+    // stored AND what is sent to the provider, so the two never disagree.
+    const trimmedTitle = typeof title === "string" ? title.trim() : "";
+
+    if (!provider || !trimmedTitle || !uid) {
       res.status(400).json(MESSAGES.MISSING_PARAMETER);
       return;
     }
@@ -115,8 +122,8 @@ export const createExperiment = onRequest({ cors: true }, async (req, res) => {
     // here. `title` is always injected: every provider needs a human name
     // for its container, and gdrive's adapter reads it as `name`.
     const containerInput: Record<string, unknown> = {
-      name: title,
-      title,
+      name: trimmedTitle,
+      title: trimmedTitle,
       ...(researcherInput || {}),
     };
     // Legacy wire param: this predates the containerInput mechanism above.
@@ -184,7 +191,7 @@ export const createExperiment = onRequest({ cors: true }, async (req, res) => {
 
     const batch = db.batch();
     batch.set(experimentDocRef, {
-      title,
+      title: trimmedTitle,
       active: false,
       activeBase64: false,
       activeConditionAssignment: false,

--- a/functions/src/providers/dataverse.ts
+++ b/functions/src/providers/dataverse.ts
@@ -288,12 +288,49 @@ export const dataverseProvider: StorageProvider = {
     quotaNote: "File size and storage limits are set by the researcher's hosting Dataverse installation",
   },
 
+  // Every required field here is required by DATAVERSE, not by DataPipe:
+  // collectionAlias is the POST path itself (/api/dataverses/{alias}/datasets)
+  // and has no possible default, while author, contact and description are
+  // required fields of the citation metadata block, which the server rejects
+  // a dataset without. `subject` is required by Dataverse too but is optional
+  // here because createDataContainer defaults it -- see the `subject` const.
   containerInput: [
-    { name: "collectionAlias", label: "Collection alias", required: true, placeholder: "my-lab" },
-    { name: "authorName", label: "Author name", required: true, placeholder: "Lastname, Firstname" },
-    { name: "contactEmail", label: "Contact email", required: true, placeholder: "you@example.edu" },
-    { name: "description", label: "Description", required: true, inputType: "textarea" },
-    { name: "subject", label: "Subject", required: false, placeholder: "Social Sciences" },
+    {
+      name: "collectionAlias",
+      label: "Collection alias",
+      required: true,
+      placeholder: "my-lab",
+      helperText:
+        "The short name in your collection's URL -- the my-lab in dataverse.harvard.edu/dataverse/my-lab.",
+    },
+    {
+      name: "authorName",
+      label: "Author name",
+      required: true,
+      placeholder: "Lastname, Firstname",
+      helperText: "Recorded as the dataset's author in its citation metadata.",
+    },
+    {
+      name: "contactEmail",
+      label: "Contact email",
+      required: true,
+      placeholder: "you@example.edu",
+      helperText: "Dataverse publishes this on the dataset as the contact for questions about the data.",
+    },
+    {
+      name: "description",
+      label: "Description",
+      required: true,
+      inputType: "textarea",
+      helperText: "Shown on the dataset page. A sentence about what the experiment collects is enough.",
+    },
+    {
+      name: "subject",
+      label: "Subject",
+      required: false,
+      placeholder: "Social Sciences",
+      helperText: "Dataverse requires one. Left blank, DataPipe sends Social Sciences.",
+    },
   ],
 
   async resolveToken(userData: UserData, _owner: string): Promise<TokenResult> {

--- a/functions/src/providers/types.ts
+++ b/functions/src/providers/types.ts
@@ -155,6 +155,17 @@ export interface ContainerInputField {
   label: string;
   required: boolean;
   placeholder?: string;
+  // One line under the field saying what the provider does with this value.
+  // Presentational only -- the server never reads it -- but it lives here
+  // beside the label so the two cannot drift apart, and so a new adapter
+  // cannot declare a field the create form has no way to explain.
+  //
+  // Labels are DELIBERATELY UNIFIED ACROSS PROVIDERS where the concept is the
+  // same: Dataverse's `authorName` and Zenodo's `creatorName` are both
+  // labelled "Author name", because a researcher filling in this form is
+  // answering one question, not two. The provider's own term (Zenodo says
+  // "creator") belongs in helperText, not in the label.
+  helperText?: string;
   // "hidden" means the client supplies this through a bespoke UI (gdrive's
   // Google Picker) rather than a rendered text field.
   inputType?: "text" | "textarea" | "hidden";

--- a/functions/src/providers/zenodo.ts
+++ b/functions/src/providers/zenodo.ts
@@ -384,10 +384,40 @@ export const zenodoProvider: StorageProvider = {
       "Zenodo allows up to 100 files and 50 GB per record. DataPipe compacts completed sessions into archives to stay under the file limit.",
   },
 
+  // Unlike Dataverse's, these two required fields are DATAPIPE'S REQUIREMENT,
+  // not Zenodo's. POST /api/deposit/depositions accepts an incomplete draft --
+  // Zenodo only validates metadata at PUBLISH time, and DataPipe never
+  // publishes (nothing in this adapter calls the publish action; the
+  // deposition stays a draft the researcher finishes themselves). They are
+  // asked for up front deliberately: a deposition with no creator and no
+  // description cannot be published, and discovering that at the end of data
+  // collection is far worse than typing a sentence at the start.
+  //
+  // `creatorName` is labelled "Author name" to match Dataverse's `authorName`
+  // -- same question, same answer, one label. Zenodo's own term is in the
+  // helper text. See ContainerInputField in types.ts.
   containerInput: [
-    { name: "creatorName", label: "Creator name", required: true, placeholder: "Lastname, Firstname" },
-    { name: "description", label: "Description", required: true, inputType: "textarea" },
-    { name: "affiliation", label: "Affiliation", required: false, placeholder: "Your institution" },
+    {
+      name: "creatorName",
+      label: "Author name",
+      required: true,
+      placeholder: "Lastname, Firstname",
+      helperText: "Recorded as the deposition's creator. Zenodo needs one before you can publish.",
+    },
+    {
+      name: "description",
+      label: "Description",
+      required: true,
+      inputType: "textarea",
+      helperText: "Shown on the deposition page. A sentence about what the experiment collects is enough.",
+    },
+    {
+      name: "affiliation",
+      label: "Affiliation",
+      required: false,
+      placeholder: "Your institution",
+      helperText: "Listed next to the author name on the deposition.",
+    },
   ],
 
   // A method rather than a static object so env vars are read at CALL time,

--- a/lib/provider-config.js
+++ b/lib/provider-config.js
@@ -41,6 +41,20 @@ export const STORAGE_PROVIDERS = {
       `https://drive.google.com/drive/folders/${exp.providerContainer?.folderId}`,
     containerLabel: "Google Drive Folder",
     containerLinkText: "Open folder",
+    // What the Title field on pages/admin/new.js actually names. Purely
+    // presentational and client-only (like containerLabel above), with no
+    // server counterpart: create-experiment.ts injects `title` into every
+    // provider's containerInput generically and never knows what the provider
+    // does with it.
+    //
+    // The second sentence is not a nicety. `title` is fixed at creation:
+    // renaming an experiment (components/dashboard/Title.js) writes Firestore
+    // only, and NO adapter implements a container rename -- so DataPipe's
+    // title and the container's title diverge permanently after a rename,
+    // and DataPipe never displays the container's real name. Until a rename
+    // path exists, saying so here is the only warning a researcher gets.
+    containerTitleHelp:
+      "Names the folder DataPipe creates in your Drive. Renaming the experiment later will not rename the folder.",
     // gdrive's only containerInput field (parentId) is "hidden" server-side --
     // supplied by the Google Picker, never typed into a rendered field -- so
     // there is nothing here for the new-experiment page to render.
@@ -70,15 +84,51 @@ export const STORAGE_PROVIDERS = {
       )}`,
     containerLabel: "Dataverse Dataset",
     containerLinkText: "Open dataset",
+    // See gdrive's containerTitleHelp for why the rename caveat is here.
+    containerTitleHelp:
+      "Names the dataset DataPipe creates in your collection. Renaming the experiment later will not retitle the dataset.",
     // Mirrors functions/src/providers/dataverse.ts's containerInput exactly
-    // (labels, required-ness, placeholders). `description` gets `multiline`
-    // because the server declares it inputType "textarea".
+    // (labels, required-ness, placeholders, helper text). `description` gets
+    // `multiline` because the server declares it inputType "textarea".
     containerInputFields: [
-      { name: "collectionAlias", label: "Collection alias", required: true, placeholder: "my-lab" },
-      { name: "authorName", label: "Author name", required: true, placeholder: "Lastname, Firstname" },
-      { name: "contactEmail", label: "Contact email", required: true, placeholder: "you@example.edu" },
-      { name: "description", label: "Description", required: true, multiline: true },
-      { name: "subject", label: "Subject", required: false, placeholder: "Social Sciences" },
+      {
+        name: "collectionAlias",
+        label: "Collection alias",
+        required: true,
+        placeholder: "my-lab",
+        helperText:
+          "The short name in your collection's URL -- the my-lab in dataverse.harvard.edu/dataverse/my-lab.",
+      },
+      {
+        name: "authorName",
+        label: "Author name",
+        required: true,
+        placeholder: "Lastname, Firstname",
+        helperText: "Recorded as the dataset's author in its citation metadata.",
+      },
+      {
+        name: "contactEmail",
+        label: "Contact email",
+        required: true,
+        placeholder: "you@example.edu",
+        helperText:
+          "Dataverse publishes this on the dataset as the contact for questions about the data.",
+      },
+      {
+        name: "description",
+        label: "Description",
+        required: true,
+        multiline: true,
+        helperText:
+          "Shown on the dataset page. A sentence about what the experiment collects is enough.",
+      },
+      {
+        name: "subject",
+        label: "Subject",
+        required: false,
+        placeholder: "Social Sciences",
+        helperText: "Dataverse requires one. Left blank, DataPipe sends Social Sciences.",
+      },
     ],
   },
   zenodo: {
@@ -107,11 +157,37 @@ export const STORAGE_PROVIDERS = {
       `${exp.providerContainer?.serverUrl ?? ZENODO_HOST}/deposit/${exp.providerContainer?.depositionId}`,
     containerLabel: "Zenodo Deposition",
     containerLinkText: "Open deposition",
-    // Mirrors functions/src/providers/zenodo.ts's containerInput exactly.
+    // See gdrive's containerTitleHelp for why the rename caveat is here. The
+    // title is also editable on Zenodo itself while the deposition is still a
+    // draft, which is the escape hatch DataPipe cannot offer yet.
+    containerTitleHelp:
+      "Names the deposition DataPipe creates in your Zenodo account. Renaming the experiment later will not retitle the deposition.",
+    // Mirrors functions/src/providers/zenodo.ts's containerInput exactly --
+    // including the "Author name" label on `creatorName`, which is unified
+    // with Dataverse's `authorName` on purpose. See that adapter's comment.
     containerInputFields: [
-      { name: "creatorName", label: "Creator name", required: true, placeholder: "Lastname, Firstname" },
-      { name: "description", label: "Description", required: true, multiline: true },
-      { name: "affiliation", label: "Affiliation", required: false, placeholder: "Your institution" },
+      {
+        name: "creatorName",
+        label: "Author name",
+        required: true,
+        placeholder: "Lastname, Firstname",
+        helperText: "Recorded as the deposition's creator. Zenodo needs one before you can publish.",
+      },
+      {
+        name: "description",
+        label: "Description",
+        required: true,
+        multiline: true,
+        helperText:
+          "Shown on the deposition page. A sentence about what the experiment collects is enough.",
+      },
+      {
+        name: "affiliation",
+        label: "Affiliation",
+        required: false,
+        placeholder: "Your institution",
+        helperText: "Listed next to the author name on the deposition.",
+      },
     ],
   },
 };

--- a/pages/admin/new.js
+++ b/pages/admin/new.js
@@ -1,7 +1,7 @@
 import AuthCheck from "../../components/AuthCheck";
 import { doc } from "firebase/firestore";
 import { db, auth } from "../../lib/firebase";
-import { useContext, useEffect, useState } from "react";
+import { useContext, useEffect, useRef, useState } from "react";
 import { UserContext } from "../../lib/context";
 import { useDocumentData } from "react-firebase-hooks/firestore";
 import Link from "next/link";
@@ -9,6 +9,7 @@ import Router from "next/router";
 import { createProviderExperiment } from "../../lib/experiment-creation";
 import { pickDriveFolder } from "../../lib/google-picker";
 import { STORAGE_PROVIDERS } from "../../lib/provider-config";
+import { normalizeContactEmail } from "../../lib/contact-email";
 import {
   Button,
   Stack,
@@ -64,6 +65,54 @@ function writeDraftTitle(value) {
 // Existing OSF experiments keep collecting; see lib/osf-sunset.js.
 const DEFAULT_PROVIDER = Object.keys(STORAGE_PROVIDERS)[0];
 
+// One labelling rule for every field on this form: required fields carry a
+// bare label, optional ones say so. Before this the only field that admitted
+// to being optional was the Drive folder picker -- and it said so by
+// hardcoding "(optional)" into its label string -- so Subject and Affiliation
+// looked exactly as mandatory as Description, which really is required.
+function FieldLabel({ children, optional }) {
+  return (
+    <Field.Label>
+      {children}
+      {optional && (
+        <Text as="span" color="fg.muted" fontWeight="normal" ms={1}>
+          (optional)
+        </Text>
+      )}
+    </Field.Label>
+  );
+}
+
+// Account-level values that seed a provider field, so a researcher does not
+// retype what DataPipe already holds.
+//
+// Deliberately narrow. `contactEmail` is the only containerInput field with an
+// unambiguous account-level counterpart: users/{uid}.contactEmail is mandatory
+// and gated by ContactEmailGate (components/AuthCheck.js), so it is always
+// present by the time this form renders. Author name, collection alias and
+// affiliation are just as stable per researcher, but nothing stores them yet
+// -- putting them on the provider connection is the follow-up this map is
+// shaped to absorb.
+//
+// A seed is a starting value, never a lock: Dataverse publishes datasetContact
+// on the dataset, and the address a researcher wants public is not always the
+// one DataPipe emails them at, so the field stays editable.
+function prefillFor(fieldName, userDoc) {
+  if (fieldName === "contactEmail") {
+    return normalizeContactEmail(userDoc?.contactEmail) || "";
+  }
+  return "";
+}
+
+function seedContainerValues(providerId, userDoc) {
+  const seeded = {};
+  for (const field of STORAGE_PROVIDERS[providerId]?.containerInputFields || []) {
+    const value = prefillFor(field.name, userDoc);
+    if (value) seeded[field.name] = value;
+  }
+  return seeded;
+}
+
 export default function NewExperimentPage({}) {
   return (
     <AuthCheck>
@@ -106,9 +155,27 @@ function NewExperimentForm() {
 
   const providerConnected = STORAGE_PROVIDERS[provider]?.isConnected(data);
 
+  // Seed the account-level prefills ONCE, when the user document first
+  // arrives. handleProviderChange seeds every later provider switch itself, so
+  // this only covers the initial render, where `data` is still undefined.
+  //
+  // Guarded by a ref rather than re-running on every `data` snapshot: this
+  // page holds a live Firestore subscription, and any unrelated field changing
+  // on users/{uid} mid-form would otherwise push the stored address back over
+  // whatever the researcher had typed. `...prev` last for the same reason.
+  const seededRef = useRef(false);
+  useEffect(() => {
+    if (seededRef.current || !data) return;
+    seededRef.current = true;
+    setContainerValues((prev) => ({ ...seedContainerValues(provider, data), ...prev }));
+  }, [data, provider]);
+
   const handleProviderChange = (newProvider) => {
     setProvider(newProvider);
-    setContainerValues({});
+    // Reset, then re-seed from the account for the NEW provider -- a bare {}
+    // here would drop the prefilled contact email the moment someone switched
+    // provider and switched back.
+    setContainerValues(seedContainerValues(newProvider, data));
     setContainerFieldErrors({});
     // A picked Drive folder is meaningless to any other provider, and it is
     // sent as the top-level parentFolderId on submit -- without this reset,
@@ -173,7 +240,13 @@ function NewExperimentForm() {
     setProviderSubmitting(true);
     setProviderError(null);
 
-    if (providerTitle.length === 0) {
+    // Trimmed, not raw. This value becomes the name of a real folder/dataset/
+    // deposition in the researcher's own account, and a title of " " passed
+    // both this check (length 1) and the server's (`!title` is false for a
+    // space), creating a container named with a single space that DataPipe
+    // then offers no way to rename.
+    const trimmedTitle = providerTitle.trim();
+    if (trimmedTitle.length === 0) {
       setProviderTitleError(true);
       setProviderSubmitting(false);
       return;
@@ -201,19 +274,22 @@ function NewExperimentForm() {
     }
 
     // Send only the declared field names, and omit empty optional fields --
-    // never spread arbitrary containerValues state.
+    // never spread arbitrary containerValues state. Values are sent TRIMMED,
+    // matching the check above: a field validated on its trimmed value and
+    // then sent raw meant trailing whitespace reached provider metadata (a
+    // Dataverse author of "Smith, Jane " is what gets cited).
     const researcherInput = {};
     for (const field of fields) {
       const value = containerValues[field.name];
       if (value && value.trim().length > 0) {
-        researcherInput[field.name] = value;
+        researcherInput[field.name] = value.trim();
       }
     }
 
     try {
       const result = await createProviderExperiment(
         provider,
-        providerTitle,
+        trimmedTitle,
         selectedFolder?.id,
         researcherInput
       );
@@ -395,7 +471,7 @@ function NewExperimentForm() {
                 </Alert.Root>
               ))}
               <Field.Root invalid={providerTitleError}>
-                <Field.Label>Title</Field.Label>
+                <FieldLabel>Title</FieldLabel>
                 <Input
                   type="text"
                   value={providerTitle}
@@ -405,6 +481,14 @@ function NewExperimentForm() {
                     setProviderTitleError(false);
                   }}
                 />
+                {/* The one field on this form that names something in the
+                    researcher's OWN account, and it said only "Title". What it
+                    names differs per provider (folder / dataset / deposition)
+                    and it is fixed at creation, so the copy comes from the
+                    provider -- see containerTitleHelp in lib/provider-config.js. */}
+                <Field.HelperText>
+                  {STORAGE_PROVIDERS[provider]?.containerTitleHelp}
+                </Field.HelperText>
                 {/* `color="red.400"` dropped -- the Field recipe already owns
                     error text coloring, and the literal was a raw palette
                     step (DESIGN.md §8.5). */}
@@ -413,7 +497,7 @@ function NewExperimentForm() {
 
               {STORAGE_PROVIDERS[provider]?.containerInputFields.map((field) => (
                 <Field.Root key={field.name} invalid={!!containerFieldErrors[field.name]}>
-                  <Field.Label>{field.label}</Field.Label>
+                  <FieldLabel optional={!field.required}>{field.label}</FieldLabel>
                   {field.multiline ? (
                     <Textarea
                       value={containerValues[field.name] || ""}
@@ -432,6 +516,15 @@ function NewExperimentForm() {
                       }
                     />
                   )}
+                  {/* Every provider field now explains what the provider does
+                      with it. These asks are not arbitrary -- all four required
+                      Dataverse fields are ones Dataverse itself rejects a
+                      dataset without -- but the form gave no way to tell that
+                      from a field DataPipe invented, and "Collection alias"
+                      was explained only in /docs/experiments. */}
+                  {field.helperText && (
+                    <Field.HelperText>{field.helperText}</Field.HelperText>
+                  )}
                   <Field.ErrorText>This field is required</Field.ErrorText>
                 </Field.Root>
               ))}
@@ -442,7 +535,10 @@ function NewExperimentForm() {
                   belong in the containerInputFields render above. */}
               {provider === "gdrive" && (
                 <Field.Root>
-                  <Field.Label>Parent Drive Folder (optional)</Field.Label>
+                  {/* "(optional)" comes from FieldLabel now, not from a
+                      hardcoded label string, so this field marks itself
+                      optional the same way Subject and Affiliation do. */}
+                  <FieldLabel optional>Parent Drive folder</FieldLabel>
                   <HStack gap={3}>
                     {/* Neutral outline, not green. DESIGN.md §5: one primary
                         per screen, and on this form the primary is Create.

--- a/pages/docs/experiments/index.js
+++ b/pages/docs/experiments/index.js
@@ -49,8 +49,17 @@ export default function CreatingAnExperimentPage() {
         <Text maxW="70ch">
           Click <strong>New Experiment</strong> in the navigation bar. Pick your
           storage provider at the top of the form and give the experiment a{" "}
-          <strong>Title</strong>. The rest of the form changes with the
-          provider:
+          <strong>Title</strong>. The title is what names the thing DataPipe
+          creates in your storage account — the Drive folder, the Dataverse
+          dataset, or the Zenodo deposition — so pick something you will
+          recognise there. It is set once, at creation: renaming the experiment
+          on its dashboard later changes what DataPipe calls it, not what your
+          storage account calls it.
+        </Text>
+        <Text maxW="70ch">
+          The rest of the form changes with the provider. Every field DataPipe
+          asks for is one the provider needs, and each says underneath it what
+          the provider does with the value:
         </Text>
         <List.Root maxW="70ch" gap={2} ps={6}>
           <List.Item>
@@ -66,17 +75,23 @@ export default function CreatingAnExperimentPage() {
               Dataverse
             </Text>{" "}
             — the <strong>collection alias</strong>, which is the short name
-            from your collection&apos;s URL, plus the author name, contact
-            email, and description that Dataverse requires for every dataset.
-            Subject is optional.
+            from your collection&apos;s URL, plus the <strong>author name</strong>,{" "}
+            <strong>contact email</strong>, and <strong>description</strong>{" "}
+            that Dataverse requires in the citation metadata of every dataset —
+            it refuses to create one without them. The contact email starts
+            filled in from your DataPipe account; change it if the address you
+            want published on the dataset is a different one. Subject is
+            optional, and defaults to Social Sciences.
           </List.Item>
           <List.Item>
             <Text as="span" fontWeight="semibold">
               Zenodo
             </Text>{" "}
-            — the <strong>creator name</strong> and a{" "}
-            <strong>description</strong> for the deposition. Affiliation is
-            optional.
+            — the <strong>author name</strong> and a{" "}
+            <strong>description</strong> for the deposition. Zenodo would accept
+            a draft without these, but it will not let you publish one, so
+            DataPipe asks now rather than leaving you to find out at the end of
+            data collection. Affiliation is optional.
           </List.Item>
         </List.Root>
         <Text maxW="70ch">


### PR DESCRIPTION
Different providers asked different questions on the create form, with nothing explaining why. This audits which asks are actually essential, standardizes how they're presented, and makes it clear what the Title field controls.

## The audit

Every required Dataverse field is one **Dataverse itself** rejects a dataset without — `collectionAlias` is the POST path (`/api/dataverses/{alias}/datasets`, no possible default), and author, contact and description are required fields of the citation metadata block. So the asymmetry between a Drive folder and a Dataverse dataset is real, not accidental.

Zenodo's two required fields are **DataPipe's** requirement, not Zenodo's: `POST /api/deposit/depositions` accepts an incomplete draft, and nothing in the adapter publishes. Kept deliberately — a deposition with no creator or description can't be published, and discovering that at the end of data collection is far worse than typing a sentence at the start. Now documented as our choice.

## What changed

**Unified labels.** Dataverse's `authorName` and Zenodo's `creatorName` are one question asked in two words; both are **"Author name"** now. The wire names still differ because the two APIs do. Zenodo's own term ("creator") moved to helper text.

**Every rendered field explains itself.** `helperText` is declared beside the label in each adapter's `containerInput`, so a new provider can't add a field the form has no way to explain. "Collection alias" was documented only in `/docs/experiments`; optional Subject looked exactly as mandatory as required Description. One `FieldLabel` rule now marks optional fields, replacing the `(optional)` hardcoded into the Drive picker's label string.

**Contact email prefills** from `users/{uid}.contactEmail`, which is already mandatory and gated by `ContactEmailGate`. Seeded once when the user doc arrives, re-seeded on provider switch, typed values always win — a starting value, not a lock, since Dataverse publishes that address on the dataset.

## The title

It names a real folder/dataset/deposition in the researcher's own account, said only "Title", and is **fixed at creation** — no adapter implements a container rename, so renaming an experiment moves DataPipe's title only and the two diverge permanently, with the container's real name never shown anywhere in DataPipe.

The field now says which thing it names, per provider, and that renaming won't follow. The dashboard rename shows the matching caveat while it's being edited (only while editing — it's a footnote about the rename, not a standing fact).

Also closes a whitespace hole: `" "` passed both the client's `length === 0` check and the server's `!title`, creating a container named with a single space that nothing could rename. Both trim now, and the trimmed value is what's stored *and* sent to the provider. Field values are sent trimmed too — a Dataverse author of `"Smith, Jane "` was reaching citation metadata.

## Testing

- `tsc` and `npm run lint` clean.
- `providers-container-input`, `providers-dataverse`, `providers-zenodo`, `provider-config`, `experiment-creation` — 158 passed.
- `create-experiment-emulator` — 15 passed against the emulator, including two new cases: whitespace-only title rejected with nothing created, and a padded title stored trimmed *and* naming the Drive folder with the same trimmed value.
- Two new conformance tests: every non-hidden `containerInput` field declares helper text, and same-meaning fields keep one label across providers.

Not verified: `providers-zenodo-oauth` fails locally (7/10), reaching for real GCP credentials instead of the Firestore emulator. It fails identically before and after this branch, and the only change to `zenodo.ts` here is the `containerInput` array — nothing that suite exercises. Looks like local env setup, flagging rather than claiming green.

## Deliberately out of scope

- **Author name, collection alias and affiliation are still retyped per experiment.** They're per-lab constants with nowhere to live yet; `prefillFor` is shaped to absorb them once a provider connection can store them.
- **No container rename.** The dashboard title and the container's title still diverge after a rename — this warns about it rather than fixing it. A `renameContainer` on the `StorageProvider` interface is what would close it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015sgaqqAebNujGsZ5mKbK52
