### PR TITLE
Paint the link focus ring on :focus-visible, not :focus

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -279,6 +279,15 @@ cannot carry alone gets a bordered container (see `SettingsSection` danger varia
   interactive element including icon-only and link-styled controls. Default palette
   ring is `brandGreen.focusRing` (3.27:1 worst case light, 5.71:1 dark).
   `focusRing="none"` — currently on four `Navbar` links — is banned.
+  The ring is **keyboard-only**: it paints on `:focus-visible`, never on a bare
+  `:focus`. A mouse click already tells you what you clicked, so a ring that
+  outlives the click is visual noise — on the navbar and the docs sidebar it
+  reads as a stray light box stuck to the last item you touched. Chakra's stock
+  `link` recipe gets this wrong (it ships `focusRing`, which compiles to
+  `&:is(:focus, [data-focus])`, while every other recipe uses
+  `focusVisibleRing`), so `lib/theme.js` re-points the recipe. Suppressing the
+  pointer case is not the banned `focusRing="none"`: keyboard focus still draws
+  the identical ring, which is the whole point of the rule above.
 - **Semantic z-index scale.** `globals.css:54` has the app's only z-index, an
   arbitrary `1000`. Replace with theme tokens and use nothing else:
 

--- a/lib/theme.js
+++ b/lib/theme.js
@@ -2,6 +2,32 @@ import { createSystem, defaultConfig, defineConfig } from "@chakra-ui/react";
 
 const config = defineConfig({
   theme: {
+    recipes: {
+      // Chakra's stock `link` recipe sets `focusRing: "outside"`, and the
+      // plain `focusRing` utility compiles to `&:is(:focus, [data-focus])` --
+      // NOT :focus-visible. A mouse click on a link therefore paints the 2px
+      // ring and leaves it there until focus moves elsewhere, which on the
+      // dark navbar and docs sidebar reads as a stray white box around the
+      // item you just clicked (gray.focusRing is gray.400 in both modes).
+      // Every other interactive recipe Chakra ships -- button included --
+      // uses `focusVisibleRing`, so links were the odd one out.
+      //
+      // The ring itself is not the bug and is not removed: keyboard users
+      // still get the identical 2px outside ring. Only the pointer-driven
+      // case is suppressed, which is what :focus-visible exists for.
+      //
+      // Key order matters. `focusRing: "none"` keeps the key in the position
+      // the stock base declared it, so its `outline: none` rule is emitted
+      // BEFORE the `focusVisibleRing` rule appended after it. Same layer,
+      // same specificity, and a keyboard-focused link matches both selectors
+      // -- the later rule has to be the one that draws.
+      link: {
+        base: {
+          focusRing: "none",
+          focusVisibleRing: "outside",
+        },
+      },
+    },
     slotRecipes: {
       menu: {
         base: {


### PR DESCRIPTION
## The bug

Clicking a link in the navbar or in the docs sidebar leaves a light ring stuck around it until you click somewhere else.

## Why

Chakra's stock `link` recipe declares `focusRing: "outside"`. The bare `focusRing` utility compiles to `&:is(:focus, [data-focus])` — **not** `:focus-visible` — so the 2px ring paints on a mouse click and stays for as long as the anchor holds focus, which after a Next.js client-side navigation is until the next click somewhere else.

Confirmed in the CSS the dev server actually serves for `/docs`:

```css
.css-12mbh7p:is(:focus, [data-focus]) { outline-width: 2px; outline-offset: 2px; outline-style: solid; outline-color: var(--focus-ring-color); }
```

versus the button recipe on the same page:

```css
.css-14jp1p9:is(:focus-visible, [data-focus-visible]) { ... }
```

Links were the only interactive recipe in the app on the bare `:focus` form. The ring's color is `--chakra-colors-gray-focus-ring` → `gray.400` (these links set no `colorPalette`), which over the dark navbar and sidebar reads as a white box.

## The fix

Re-point the recipe once in `lib/theme.js` rather than patching each call site — `Link` is used in the navbar, the docs sidebar, the footer and docs prose, and they all had it:

```js
link: {
  base: {
    focusRing: "none",
    focusVisibleRing: "outside",
  },
},
```

Key order is deliberate. Both selectors match a keyboard-focused link at equal specificity in the same `@layer recipes`, so the `:focus-visible` rule has to be emitted second. `focusRing: "none"` keeps the key in the slot the stock base declared it, which puts its `outline: none` first; `focusVisibleRing` is appended after. Verified in the emitted CSS by byte offset:

```
61925  :focus, [data-focus]                  -> outline:none;
61977  :focus-visible, [data-focus-visible]  -> outline-width:2px; ...
```

**Keyboard focus is unchanged** — same 2px ring, same offset, same color. Only the pointer-driven case is suppressed, which is what `:focus-visible` exists for.

`DESIGN.md`'s focus-ring rule now states the keyboard-only requirement and notes that this is not the `focusRing="none"` it bans.

`Breadcrumb` is the only other stock recipe with the same defect; it isn't used anywhere in the app, so it's left alone.

## Testing

- `npm run lint` — clean.
- 24 frontend suites, 211 tests, all passing (`__tests__`, minus `firestore-rules` which needs the emulator). The `functions/src/__tests__` backend suites also need a running emulator and were not run — they're untouched by a frontend theme change.
- Verified before and after in the CSS served by `npm run dev`. I could not click through it in a real browser: the Chrome extension isn't connected in this session, so the ring's *removal* is confirmed at the CSS level rather than visually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015sgaqqAebNujGsZ5mKbK52