### PR TITLE
New experiment: use the providers' real marks

### DIFF
--- a/components/ProviderIcons.js
+++ b/components/ProviderIcons.js
@@ -1,77 +1,47 @@
 // Marks for the storage providers in lib/provider-config.js, keyed by the
 // same registry id, plus OSF (reused from components/OsfIcon.js) for
-// contexts that still reference it (e.g. the OSF-specific sign-in and
-// account-linking surfaces). Kept out of lib/ on purpose, same reasoning as
-// components/AuthProviderIcons.js: lib/ holds plain data so it stays
-// importable from plain unit tests without JSX.
+// contexts that still reference it. Kept out of lib/ on purpose, same
+// reasoning as components/AuthProviderIcons.js: lib/ holds plain data so it
+// stays importable from plain unit tests without JSX.
 //
-// Unlike AuthProviderIcons' federated-sign-in marks, these are hand-authored
-// monochrome glyphs rather than brand reproductions -- DataPipe is a
-// dark-only theme and DESIGN.md forbids stray hues, so there is no "on brand
-// background" surface for a multi-color logo to sit on. Every mark below
-// draws only with `currentColor`, inherits the surrounding text's color, and
-// is deliberately generic (a drive, a stacked dataset, an archive box) rather
-// than a copy of the provider's actual logo.
+// These are the providers' real marks, in the monochrome Simple Icons
+// cut that ships with react-icons (already a dependency). Monochrome, not
+// full-color: DataPipe is a dark-only theme and DESIGN.md forbids stray
+// hues, so a single-color mark that inherits `currentColor` is the only
+// treatment that sits on every surface here. The hand-drawn generic
+// glyphs that preceded these read as "a triangle", not "Google Drive".
+//
+// `aria-hidden` is baked in at the source, the way AuthProviderIcons does
+// it: every mark is decoration beside a text label that carries the
+// accessible name. Size is react-icons' `size` prop (it sets both width and
+// height AFTER spreading props, so width/height props are ignored).
 //
 // Adding a provider means adding an entry here as well as to
 // STORAGE_PROVIDERS in lib/provider-config.js. A missing icon is not fatal --
 // callers guard with `PROVIDER_ICONS[id] &&` the same way AuthProviderButtons
 // guards AUTH_PROVIDER_ICONS.
+import { SiGoogledrive, SiDataverse, SiZenodo } from "react-icons/si";
+
 import { OsfIcon } from "./OsfIcon";
 
 export const GoogleDriveIcon = (props) => (
-  <svg
-    viewBox="0 0 24 24"
-    width="1em"
-    height="1em"
-    fill="currentColor"
-    aria-hidden="true"
-    {...props}
-  >
-    <path d="M12 3.5 3.5 18.5h17z" />
-  </svg>
+  <SiGoogledrive aria-hidden="true" {...props} />
 );
 
 export const DataverseIcon = (props) => (
-  <svg
-    viewBox="0 0 24 24"
-    width="1em"
-    height="1em"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="1.5"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    aria-hidden="true"
-    {...props}
-  >
-    <ellipse cx="12" cy="5.5" rx="7.5" ry="3" />
-    <path d="M4.5 5.5v6c0 1.66 3.36 3 7.5 3s7.5-1.34 7.5-3v-6" />
-    <path d="M4.5 11.5v6c0 1.66 3.36 3 7.5 3s7.5-1.34 7.5-3v-6" />
-  </svg>
+  <SiDataverse aria-hidden="true" {...props} />
 );
 
-export const ZenodoIcon = (props) => (
-  <svg
-    viewBox="0 0 24 24"
-    width="1em"
-    height="1em"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="1.5"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    aria-hidden="true"
-    {...props}
-  >
-    <path d="M3.5 8.5 5.75 4.5h12.5l2.25 4" />
-    <rect x="3.5" y="8.5" width="17" height="11" rx="1.25" />
-    <path d="M9 13h6" />
-  </svg>
+export const ZenodoIcon = (props) => <SiZenodo aria-hidden="true" {...props} />;
+
+// OsfIcon predates react-icons and takes width/height; adapt it to the same
+// `size` prop the other three accept so callers need one calling convention.
+const OsfProviderIcon = ({ size = "1em", ...props }) => (
+  <OsfIcon width={size} height={size} aria-hidden="true" {...props} />
 );
 
 export const PROVIDER_ICONS = {
-  osf: OsfIcon,
+  osf: OsfProviderIcon,
   gdrive: GoogleDriveIcon,
   dataverse: DataverseIcon,
   zenodo: ZenodoIcon,

--- a/pages/admin/new.js
+++ b/pages/admin/new.js
@@ -464,7 +464,7 @@ function NewExperimentForm() {
                         existed. */}
                     <RadioGroup.ItemText>
                       <HStack gap={1.5} display="inline-flex">
-                        {Icon && <Icon width="1.25em" height="1.25em" />}
+                        {Icon && <Icon size="1.25em" />}
                         <Text as="span">{p.name}</Text>
                       </HStack>
                     </RadioGroup.ItemText>


### PR DESCRIPTION
Follow-up to #197. The hand-drawn provider glyphs on `/admin/new` were too generic — the Google Drive one was "just a triangle".

`react-icons` is already a dependency, and its Simple Icons set has monochrome marks for Google Drive, Dataverse and Zenodo. This swaps them in: `currentColor`, `aria-hidden` baked in, same 1.25em rendering beside the radio label, no new dependencies. `OsfIcon` is adapted to the same `size` prop so the `PROVIDER_ICONS` map has one calling convention.

Lint clean, `next build` clean, new-experiment suite 21/21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SHZNijLwUhn26yCbYbn1UN