### PR TITLE
Zenodo test OAuth app: move to the datapipe@jspsych.org registration

### DIFF
--- a/functions/.env.datapipe-test
+++ b/functions/.env.datapipe-test
@@ -35,7 +35,9 @@ TOKEN_ENCRYPTION_KEY=abababababababababababababababababababababababababababababa
 # `firebase deploy` from the git-ignored functions/.env.
 ZENODO_ENV=sandbox.
 ZENODO_REDIRECT_URI=https://datapipe-test.web.app/oauth2/connect
-# TODO: fill in from the OAuth application registered at
-# https://sandbox.zenodo.org/account/settings/applications/ -- connecting a
-# Zenodo account fails until this is set.
-ZENODO_CLIENT_ID=b7FnwoIGfECAs3UCSuJNQqHvXizQG9TYargM52Vu
+# From the OAuth application registered at
+# https://sandbox.zenodo.org/account/settings/applications/ under the
+# datapipe@jspsych.org account (2026-08-24), replacing one registered to a
+# personal account. The id and the TEST_ZENODO_CLIENT_SECRET GitHub secret
+# come from that one registration and have to be rotated together.
+ZENODO_CLIENT_ID=i8LEvZPTBwO8ipksP6MmujspHM8QOh7FTrgSa1v9


### PR DESCRIPTION
Points the test site's Zenodo connection at an OAuth application registered under `datapipe@jspsych.org` rather than a personal Zenodo account, so the credential doesn't depend on one person's account staying around.

One line of real change (`ZENODO_CLIENT_ID` in `functions/.env.datapipe-test`), plus a comment that had gone stale.

### Already done outside this PR

- The sandbox application is registered with redirect URI `https://datapipe-test.web.app/oauth2/connect` — the exact value `ZENODO_REDIRECT_URI` sends, which Invenio matches exactly.
- `TEST_ZENODO_CLIENT_SECRET` has been rotated to this registration's secret. The id here and that secret come from a single application and cannot be updated independently, so merging this without that rotation (or vice versa) yields `invalid_client` at token exchange.
- `functions/.env` (git-ignored, local `firebase deploy` path) updated to match.

### After merge

Pushing to `test` runs **Deploy to Test**, which bakes the new secret into `functions/.env` and puts the new client live.

Sandbox accounts connected under the old client will then fail on their next upload rather than at connect time — invenio-oauth2server scopes tokens to `(client_id, user_id)`, so stored refresh tokens no longer belong to an application this deployment identifies as. Reconnecting from the account page fixes it. The same will be true of production when that app is swapped over.

`ZENODO_ENV=sandbox.` is unchanged and still correct: this is a sandbox client, and it could not complete a flow on zenodo.org.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SHZNijLwUhn26yCbYbn1UN