### PR TITLE
Plainer provider copy, a citation page, and quieter footer links

### DIFF
--- a/__tests__/citation-page.test.jsx
+++ b/__tests__/citation-page.test.jsx
@@ -1,0 +1,115 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { ChakraProvider } from "@chakra-ui/react";
+import { system } from "../lib/theme";
+import "@testing-library/jest-dom";
+
+// The page imports DocsLayout for its getLayout, and DocsLayout imports the
+// Navbar -- so the module graph reaches firebase, the fonts and the user
+// context even though none of them render here. Same three mocks as
+// index.test.jsx, for the same reason: a missing export is a module-load
+// crash, not a failing assertion.
+jest.mock("../lib/firebase", () => ({
+  auth: { currentUser: null },
+  db: {},
+}));
+
+jest.mock("next/font/google", () => ({
+  Rubik: () => ({ className: "mock-rubik" }),
+  Space_Grotesk: () => ({ className: "mock-space-grotesk" }),
+}));
+
+jest.mock("../lib/context", () => ({
+  UserContext: require("react").createContext({ user: null, loading: false }),
+}));
+
+import CitationPage from "../pages/docs/citation";
+import { CITATION, CITATION_APA, CITATION_BIBTEX } from "../lib/citation";
+
+// The page component only, without its DocsLayout getLayout wrapper -- the
+// same scope 404.test.jsx uses. The layout brings the sidebar and a router,
+// and neither is what this page's behavior lives in.
+function renderCitationPage() {
+  return render(
+    <ChakraProvider value={system}>
+      <CitationPage />
+    </ChakraProvider>
+  );
+}
+
+// jsdom has no clipboard. `navigator.clipboard` is not configurable in every
+// jsdom version, so it is defined rather than assigned.
+function mockClipboard(writeText) {
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText },
+    configurable: true,
+    writable: true,
+  });
+}
+
+describe("CitationPage", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("shows the reference in APA and BibTeX", () => {
+    renderCitationPage();
+
+    expect(screen.getByRole("heading", { name: "APA" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "BibTeX" })).toBeInTheDocument();
+    // The rendered APA reference is assembled from fields rather than from
+    // CITATION_APA, so this checks the two agree on the part most likely to
+    // drift if someone edits one of them.
+    expect(screen.getByText(/2499–2506/)).toBeInTheDocument();
+    expect(screen.getByText(/@article\{deleeuw2024datapipe/)).toBeInTheDocument();
+  });
+
+  it("copies the plain-text APA reference", async () => {
+    const writeText = jest.fn().mockResolvedValue(undefined);
+    mockClipboard(writeText);
+
+    renderCitationPage();
+    fireEvent.click(screen.getByRole("button", { name: /copy apa citation/i }));
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith(CITATION_APA));
+    // Confirmation is a visible label, not only the icon swap.
+    await waitFor(() => expect(screen.getByText("Copied")).toBeInTheDocument());
+  });
+
+  it("copies the BibTeX entry", async () => {
+    const writeText = jest.fn().mockResolvedValue(undefined);
+    mockClipboard(writeText);
+
+    renderCitationPage();
+    fireEvent.click(screen.getByRole("button", { name: /copy code/i }));
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith(CITATION_BIBTEX));
+  });
+
+  it("says what to do instead when the clipboard rejects", async () => {
+    // Insecure origin, or clipboard permission denied. The old unawaited
+    // write reported success here; the button must not.
+    const writeText = jest.fn().mockRejectedValue(new Error("denied"));
+    mockClipboard(writeText);
+    jest.spyOn(console, "error").mockImplementation(() => {});
+
+    renderCitationPage();
+    fireEvent.click(screen.getByRole("button", { name: /copy apa citation/i }));
+
+    await waitFor(() =>
+      expect(screen.getByText(/could not copy/i)).toBeInTheDocument()
+    );
+    expect(screen.queryByText("Copied")).not.toBeInTheDocument();
+  });
+
+  it("builds the BibTeX entry from the same fields as the APA reference", () => {
+    // Not a rendering test: the point of lib/citation.js is that one paper
+    // cannot be two papers. A page range typed twice is exactly how that
+    // fails, so both formats are checked against the single field.
+    expect(CITATION_APA).toContain(CITATION.pages);
+    expect(CITATION_BIBTEX).toContain(CITATION.pages.replace("–", "--"));
+    expect(CITATION_APA).toContain(CITATION.journal);
+    expect(CITATION_BIBTEX).toContain(CITATION.journal);
+    expect(CITATION_APA).toContain(CITATION.doi);
+    expect(CITATION_BIBTEX).toContain(CITATION.doi);
+  });
+});

--- a/components/CopyButton.js
+++ b/components/CopyButton.js
@@ -1,6 +1,6 @@
 import { Box, HStack, IconButton, Text } from "@chakra-ui/react";
 import { Check, Copy } from "lucide-react";
-import { useState } from "react";
+import useCopyToClipboard from "../lib/use-copy-to-clipboard";
 
 /**
  * CopyButton
@@ -17,29 +17,14 @@ import { useState } from "react";
  *   code.border gray.500 on #111111 ->  3.30:1 (outline; 3:1 floor, WCAG 1.4.11)
  *   code.bg.active gray.800         -> hover fill
  *
- * Two behavioral fixes alongside the color:
- *
- * - `navigator.clipboard.writeText` was called unawaited with no catch. It
- *   rejects on insecure origins and when clipboard permission is denied, so
- *   the button showed a checkmark for a copy that never happened.
- * - The only success signal was an icon swap. There is now a visible "Copied"
- *   label in an `aria-live="polite"` region, so the confirmation reaches
- *   people who are not watching a 16px glyph -- and a failure says what to do
- *   instead, rather than nothing.
+ * The behavior -- awaited write, a real error state, and a visible label in an
+ * `aria-live` region rather than a 16px glyph swap as the only confirmation --
+ * now lives in lib/use-copy-to-clipboard.js, shared with the citation page's
+ * page-surface copy button. The reasoning behind each of those three is in
+ * that file.
  */
 export default function CopyButton({ code }) {
-  const [state, setState] = useState("idle"); // idle | copied | error
-
-  const onCopy = async () => {
-    try {
-      await navigator.clipboard.writeText(code);
-      setState("copied");
-      setTimeout(() => setState("idle"), 2000);
-    } catch (err) {
-      console.error("Copy failed:", err);
-      setState("error");
-    }
-  };
+  const { state, copy } = useCopyToClipboard();
 
   return (
     <HStack gap={2} align="center" flexShrink={0}>
@@ -62,7 +47,7 @@ export default function CopyButton({ code }) {
         color="code.fg"
         borderColor="code.border"
         _hover={{ bg: "code.bg.active", color: "code.fg.strong" }}
-        onClick={onCopy}
+        onClick={() => copy(code)}
       >
         {state === "copied" ? <Check /> : <Copy />}
       </IconButton>

--- a/components/Footer.js
+++ b/components/Footer.js
@@ -1,6 +1,7 @@
 import {
   Box,
   Container,
+  HStack,
   Link,
   Stack,
   Text,
@@ -10,6 +11,45 @@ import {
 import { OpenCollectiveIcon } from "./OpenCollectiveIcon";
 import { JsPsychIcon } from "./JsPsychIcon";
 import NextLink from "next/link";
+
+// The footer row is navigation, not prose: four standalone destinations in a
+// labelled cluster, with no body text around them for a link to hide inside.
+// That is the case DESIGN.md §5's persistent underline is written for -- "no
+// green/body text pair reaches the 3:1 color-difference floor, so color alone
+// can never mark a link" -- and it is why the Navbar's links are bare
+// `color="fg"` too. Four permanently underlined green fragments spread across
+// the band read as leftover markup rather than as a menu.
+//
+// So: `fg` against the band's `fg.muted` body text, which makes the links the
+// one bright thing in the row, and an underline on hover, where it confirms
+// what is under the cursor. Keyboard users get the theme's focus-visible ring
+// (lib/theme.js re-points the link recipe for exactly this), so there is no
+// `_focusVisible` underline to add here.
+function FooterLink({ href, external, children }) {
+  const style = {
+    color: "fg",
+    _hover: {
+      color: "brandGreen.fg",
+      textDecoration: "underline",
+      textUnderlineOffset: "3px",
+    },
+  };
+
+  if (external) {
+    return (
+      <Link {...style} href={href} target="_blank" rel="noopener noreferrer">
+        {children}
+        <VisuallyHidden> (opens in a new tab)</VisuallyHidden>
+      </Link>
+    );
+  }
+
+  return (
+    <Link {...style} asChild>
+      <NextLink href={href}>{children}</NextLink>
+    </Link>
+  );
+}
 
 export default function Footer() {
   return (
@@ -61,43 +101,23 @@ export default function Footer() {
             Created by the developers of jsPsych{" "}
             <JsPsychIcon width="2em" height="2em" style={{ display: "inline" }} />
           </Text>
-          <Text>
-            <Link
-              color="brandGreen.fg"
-              textDecoration="underline"
-              href={"https://github.com/jspsych/datapipe/issues/new"}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
+          {/* One cluster, not four items spaced out across the band by the
+              parent's space-between. The grouping is what makes these read as
+              a menu -- and, with the <nav> label, what makes "navigation, not
+              prose" structural rather than a styling assertion. */}
+          <HStack as="nav" aria-label="Footer" gap={{ base: 4, md: 6 }} flexWrap="wrap">
+            <FooterLink external href="https://github.com/jspsych/datapipe/issues/new">
               Report an Issue
-              <VisuallyHidden> (opens in a new tab)</VisuallyHidden>
-            </Link>
-          </Text>
-          <Text>
-            <Link
-              color="brandGreen.fg"
-              textDecoration="underline"
-              href={"https://github.com/jspsych/datapipe"}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
+            </FooterLink>
+            <FooterLink external href="https://github.com/jspsych/datapipe">
               GitHub
-              <VisuallyHidden> (opens in a new tab)</VisuallyHidden>
-            </Link>
-          </Text>
-          <Text>
-            <Link color="brandGreen.fg" textDecoration="underline" asChild>
-              <NextLink href="/contact">Contact Us</NextLink>
-            </Link>
-          </Text>
-          {/* Researchers are sent here by an IRB or an institutional security
-              reviewer, i.e. by someone who is not already inside the docs. The
-              footer is where that reader looks for it. */}
-          <Text>
-            <Link color="brandGreen.fg" textDecoration="underline" asChild>
-              <NextLink href="/docs/privacy">Privacy</NextLink>
-            </Link>
-          </Text>
+            </FooterLink>
+            <FooterLink href="/contact">Contact Us</FooterLink>
+            {/* Researchers are sent here by an IRB or an institutional security
+                reviewer, i.e. by someone who is not already inside the docs.
+                The footer is where that reader looks for it. */}
+            <FooterLink href="/docs/privacy">Privacy</FooterLink>
+          </HStack>
           <Stack align={"flex-start"}>
             <Button
               asChild

--- a/lib/citation.js
+++ b/lib/citation.js
@@ -1,0 +1,48 @@
+// The DataPipe paper, as fields rather than as two hand-written strings.
+//
+// The citation page renders it three ways -- APA prose with an italic journal
+// title, a plain-text APA string for the clipboard, and a BibTeX entry -- and
+// a reader who copies one and reads another has to get the same paper. Typing
+// the reference out once per format is how a volume number ends up correct in
+// the block you can see and wrong in the block you actually pasted, with
+// nothing to catch it. Everything below is derived from these fields.
+export const CITATION = {
+  // APA gives initials; BibTeX wants the name it can format itself, so the
+  // author appears twice on purpose rather than being split at a period.
+  authors: "de Leeuw, J. R.",
+  authorsBibtex: "de Leeuw, Joshua R.",
+  year: 2024,
+  title: "DataPipe: Born-open data collection for online experiments",
+  journal: "Behavior Research Methods",
+  volume: 56,
+  issue: 3,
+  // En dash, per APA. The BibTeX entry converts it below.
+  pages: "2499–2506",
+  doi: "10.3758/s13428-023-02161-x",
+};
+
+export const CITATION_DOI_URL = `https://doi.org/${CITATION.doi}`;
+
+// What the APA copy button puts on the clipboard. The rendered version on the
+// page italicises the journal and links the DOI; neither survives a plain-text
+// copy, so this is the same reference with that formatting dropped -- not a
+// different one.
+export const CITATION_APA = `${CITATION.authors} (${CITATION.year}). ${CITATION.title}. ${CITATION.journal}, ${CITATION.volume}(${CITATION.issue}), ${CITATION.pages}. ${CITATION_DOI_URL}`;
+
+// Two BibTeX conventions applied to the fields above:
+//
+// - The title is wrapped in a second pair of braces. BibTeX lowercases title
+//   words under most styles, and "Datapipe" in a reference list is a bug
+//   report waiting to happen.
+// - Page ranges take a double hyphen, which TeX renders as the en dash APA
+//   already uses above.
+export const CITATION_BIBTEX = `@article{deleeuw${CITATION.year}datapipe,
+  title = {{${CITATION.title}}},
+  author = {${CITATION.authorsBibtex}},
+  journal = {${CITATION.journal}},
+  year = {${CITATION.year}},
+  volume = {${CITATION.volume}},
+  number = {${CITATION.issue}},
+  pages = {${CITATION.pages.replace(/[–—]/g, "--")}},
+  doi = {${CITATION.doi}}
+}`;

--- a/lib/docs-nav.js
+++ b/lib/docs-nav.js
@@ -227,8 +227,10 @@ export const DOCS_NAV = [
   },
   {
     // Ungrouped, last -- docs IA plan §2.3: "About DataPipe ... (ungrouped, last)".
-    // `group: null` tells DocsSidebar to render this page's link without a
-    // group heading above it.
+    // `group: null` tells DocsSidebar to render these pages' links without a
+    // group heading above them. Both pages sit in this one entry rather than
+    // in two `group: null` entries, which the sidebar would render as two
+    // ungrouped blocks with a 24px gap and nothing to explain it.
     group: null,
     pages: [
       {
@@ -239,7 +241,19 @@ export const DOCS_NAV = [
           { id: "funding", label: "Funding" },
           { id: "risks", label: "Risks" },
           { id: "support", label: "Support" },
-          { id: "citing", label: "Citing DataPipe" },
+        ],
+      },
+      {
+        // Was the `citing` section of About DataPipe. It is one thing a
+        // reader arrives looking for -- usually at the end of a project, not
+        // while reading about cost and funding -- and it now carries two
+        // formats and two copy buttons, which is a page rather than a
+        // paragraph.
+        href: "/docs/citation",
+        label: "Citing DataPipe",
+        sections: [
+          { id: "apa", label: "APA" },
+          { id: "bibtex", label: "BibTeX" },
         ],
       },
     ],

--- a/lib/use-copy-to-clipboard.js
+++ b/lib/use-copy-to-clipboard.js
@@ -1,0 +1,49 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+/**
+ * useCopyToClipboard
+ *
+ * The copy-button state machine, extracted from components/CopyButton.js so
+ * the code specimen's icon button and the citation page's labelled button
+ * share one implementation rather than two that can drift.
+ *
+ * Three states, and the two non-idle ones are what the button has to say out
+ * loud (see CopyButton's own notes): `writeText` rejects on insecure origins
+ * and when clipboard permission is denied, so an unawaited call reports a
+ * success that never happened. It is awaited here, and a rejection lands in
+ * `error` rather than in `copied`.
+ *
+ * `copied` reverts after `resetAfterMs`; `error` does not. A failure carries
+ * an instruction -- select it and copy manually -- and clearing that after two
+ * seconds would take the instruction away from exactly the reader who needs
+ * it. It clears on the next successful copy instead.
+ *
+ * The timeout is cleared on unmount, and before each new copy, so a reader who
+ * navigates away inside the two-second window doesn't leave a setState aimed
+ * at a component that is gone.
+ */
+export default function useCopyToClipboard({ resetAfterMs = 2000 } = {}) {
+  const [state, setState] = useState("idle"); // idle | copied | error
+  const timeoutRef = useRef(null);
+
+  useEffect(() => {
+    return () => clearTimeout(timeoutRef.current);
+  }, []);
+
+  const copy = useCallback(
+    async (text) => {
+      clearTimeout(timeoutRef.current);
+      try {
+        await navigator.clipboard.writeText(text);
+        setState("copied");
+        timeoutRef.current = setTimeout(() => setState("idle"), resetAfterMs);
+      } catch (err) {
+        console.error("Copy failed:", err);
+        setState("error");
+      }
+    },
+    [resetAfterMs]
+  );
+
+  return { state, copy };
+}

--- a/pages/admin/new.js
+++ b/pages/admin/new.js
@@ -27,12 +27,15 @@ import PageHeader from "../../components/ui/PageHeader";
 import GuidanceLine from "../../components/ui/GuidanceLine";
 import FormErrorAlert from "../../components/ui/FormErrorAlert";
 
-// The title survives the round trip to account settings and back.
+// The title survives leaving this page and coming back.
 //
-// A new signup cannot create an experiment until a storage provider is
-// connected, so the most common path through this form is: type a title, be
-// told to connect a provider, leave, come back. Before this, the typed title
-// was simply gone, and the researcher had no sign they had been mid-task.
+// This was written for the connect round trip -- type a title, be told to
+// connect a provider, leave, come back -- but that path does not exist: the
+// title field is inside the `providerConnected` branch below, so a researcher
+// without a provider never has a title to lose. What it still covers is the
+// connected case: type a title, go look something up, return to a form that
+// has not thrown the work away.
+//
 // sessionStorage (not localStorage) so it is scoped to the tab and the visit.
 const DRAFT_TITLE_KEY = "datapipe:new-experiment-title";
 
@@ -474,18 +477,15 @@ function NewExperimentForm() {
           {!providerConnected && (
             <VStack gap={3} mt={4} align="flex-start">
               <GuidanceLine>
-                You cannot create an experiment until DataPipe has somewhere to
-                put its data. Connecting your{" "}
-                {STORAGE_PROVIDERS[provider]?.name} account takes a minute, and
-                the title you have typed here will still be waiting when you
-                come back.
+                Connect a {STORAGE_PROVIDERS[provider]?.name} account to create
+                an experiment.
               </GuidanceLine>
               <Button asChild variant="solid" colorPalette="brandGreen" size="md">
-                {/* `next` is a forward-compatible hint for account settings to
-                    offer a "return to creating your experiment" affordance.
-                    It is inert until that page reads it; the sessionStorage
-                    draft above is what actually saves the researcher's work
-                    today. */}
+                {/* `next` is a forward-compatible hint for account settings
+                    to offer a "return to creating your experiment" affordance.
+                    It is inert until that page reads it. Nothing is being
+                    preserved across this particular trip -- there is no title
+                    field on screen in this branch to preserve. */}
                 <Link href="/admin/account?next=/admin/new">
                   Connect {STORAGE_PROVIDERS[provider]?.name}
                 </Link>

--- a/pages/docs/about.js
+++ b/pages/docs/about.js
@@ -1,4 +1,4 @@
-import { Box, Link as ChakraLink, List, Text } from "@chakra-ui/react";
+import { Link as ChakraLink, List, Text } from "@chakra-ui/react";
 import NextLink from "next/link";
 import PageHeader from "../../components/ui/PageHeader";
 import DocsLayout from "../../components/docs/DocsLayout";
@@ -33,7 +33,7 @@ export default function AboutDataPipePage() {
     <>
       <PageHeader
         title="About DataPipe"
-        purpose="What DataPipe costs, how it's funded, the risks of using it, and how to cite it."
+        purpose="What DataPipe costs, how it's funded, the risks of using it, and where to get help."
       />
 
       <DocsSection id="cost" title="Cost">
@@ -124,29 +124,10 @@ export default function AboutDataPipePage() {
           <ProseLink href="/contact">contact page</ProseLink> has an email
           address.
         </Text>
-      </DocsSection>
-
-      <DocsSection id="citing" title="Citing DataPipe">
         <Text maxW="70ch">
-          If you use DataPipe to collect data, please cite the following paper:
+          If what you need is the reference for the DataPipe paper, that moved
+          to <ProseLink href="/docs/citation">Citing DataPipe</ProseLink>.
         </Text>
-        <Box
-          maxW="70ch"
-          bg="bg.subtle"
-          borderWidth="1px"
-          borderColor="border.subtle"
-          p={4}
-          borderRadius="md"
-        >
-          <Text fontSize="sm">
-            de Leeuw, J. R. (2024). DataPipe: Born-open data collection for
-            online experiments. <em>Behavior Research Methods</em>, 56(3),
-            2499–2506.{" "}
-            <ProseLink href="https://doi.org/10.3758/s13428-023-02161-x" external>
-              https://doi.org/10.3758/s13428-023-02161-x
-            </ProseLink>
-          </Text>
-        </Box>
       </DocsSection>
     </>
   );

--- a/pages/docs/citation.js
+++ b/pages/docs/citation.js
@@ -1,0 +1,146 @@
+import { Box, Button, Link as ChakraLink, HStack, Text } from "@chakra-ui/react";
+import { Check, Copy } from "lucide-react";
+import NextLink from "next/link";
+import PageHeader from "../../components/ui/PageHeader";
+import DocsLayout from "../../components/docs/DocsLayout";
+import DocsSection from "../../components/docs/DocsSection";
+import CodeBlock from "../../components/CodeBlock";
+import useCopyToClipboard from "../../lib/use-copy-to-clipboard";
+import {
+  CITATION,
+  CITATION_APA,
+  CITATION_BIBTEX,
+  CITATION_DOI_URL,
+} from "../../lib/citation";
+
+// Prose link, per DESIGN.md §5: brandGreen.fg with a persistent underline, so
+// a link is never signalled by color alone.
+function ProseLink({ href, external, children }) {
+  const style = {
+    color: "brandGreen.fg",
+    textDecoration: "underline",
+    textUnderlineOffset: "2px",
+  };
+
+  if (external) {
+    return (
+      <ChakraLink href={href} target="_blank" rel="noopener noreferrer" {...style}>
+        {children}
+      </ChakraLink>
+    );
+  }
+
+  return (
+    <ChakraLink asChild {...style}>
+      <NextLink href={href}>{children}</NextLink>
+    </ChakraLink>
+  );
+}
+
+// The APA reference and its copy button, on the page surface.
+//
+// The BibTeX entry below uses CodeBlock -- the mode-invariant #111111 code
+// specimen with its own icon-only CopyButton -- because a BibTeX entry is
+// code: it goes into a .bib file verbatim, and DESIGN.md §1 gives code
+// surfaces that ground in both modes. An APA reference is not code. It goes
+// into a manuscript as prose, with a real italic journal title that a
+// monospace specimen would flatten, so it stays on `bg.subtle` and the button
+// is the app's neutral outline (DESIGN.md §5: one primary per screen, every
+// other action outline or ghost on gray).
+//
+// The button carries a visible "Copy" label rather than an icon alone. The
+// specimen's icon button sits inside an object that is obviously code with an
+// obvious corner affordance; a lone glyph floating over a paragraph of prose
+// is not the same affordance, and this page's whole job is that one action.
+function CitationPanel({ label, text, children }) {
+  const { state, copy } = useCopyToClipboard();
+
+  return (
+    <Box
+      maxW="70ch"
+      bg="bg.subtle"
+      borderWidth="1px"
+      borderColor="border.subtle"
+      p={4}
+      borderRadius="md"
+    >
+      {children}
+      <HStack gap={3} mt={3} align="center" flexWrap="wrap">
+        <Button
+          size="sm"
+          variant="outline"
+          color="fg"
+          borderColor="border"
+          _hover={{ bg: "bg.muted" }}
+          onClick={() => copy(text)}
+        >
+          {state === "copied" ? <Check /> : <Copy />}
+          Copy {label}
+        </Button>
+        {/* Always rendered, never conditionally mounted: a live region that
+            appears at the same moment its text does is announced
+            inconsistently across screen readers. */}
+        <Box aria-live="polite" role="status">
+          {state === "copied" && (
+            <Text fontSize="sm" color="fg.muted">
+              Copied
+            </Text>
+          )}
+          {state === "error" && (
+            <Text fontSize="sm" color="fg.muted">
+              Could not copy. Select the text and copy it manually.
+            </Text>
+          )}
+        </Box>
+      </HStack>
+    </Box>
+  );
+}
+
+export default function CitationPage() {
+  return (
+    <>
+      <PageHeader
+        title="Citing DataPipe"
+        purpose="The paper to cite if you collected data with DataPipe, in APA and BibTeX."
+      />
+
+      <DocsSection id="apa" title="APA">
+        <Text maxW="70ch">
+          If you use DataPipe to collect data, please cite the paper describing
+          it. The article is open access.
+        </Text>
+        <CitationPanel label="APA citation" text={CITATION_APA}>
+          {/* Rendered from the same fields the clipboard string is built
+              from (lib/citation.js), so the reference you read and the one
+              you paste cannot disagree. */}
+          <Text fontSize="sm">
+            {CITATION.authors} ({CITATION.year}). {CITATION.title}.{" "}
+            <em>{CITATION.journal}</em>, {CITATION.volume}({CITATION.issue}),{" "}
+            {CITATION.pages}.{" "}
+            <ProseLink href={CITATION_DOI_URL} external>
+              {CITATION_DOI_URL}
+            </ProseLink>
+          </Text>
+        </CitationPanel>
+      </DocsSection>
+
+      <DocsSection id="bibtex" title="BibTeX">
+        <Text maxW="70ch">
+          The same reference as a BibTeX entry, for a{" "}
+          <Text as="span" fontFamily="mono">
+            .bib
+          </Text>{" "}
+          file.
+        </Text>
+        <Box maxW="70ch">
+          <CodeBlock language="bibtex">{CITATION_BIBTEX}</CodeBlock>
+        </Box>
+      </DocsSection>
+    </>
+  );
+}
+
+CitationPage.getLayout = function getLayout(page) {
+  return <DocsLayout>{page}</DocsLayout>;
+};

--- a/pages/docs/providers/index.js
+++ b/pages/docs/providers/index.js
@@ -35,42 +35,31 @@ function ProseLink({ href, external, children }) {
   );
 }
 
-// One storage provider, in the terms a researcher choosing between them
-// actually needs: whether it is the right fit, where the data physically ends
-// up, how they connect, and the limit that will eventually matter. Moved from
-// pages/getting-started.js, with its raw palette steps replaced by semantic
-// tokens. The decision sentence leads because that is the only line someone
-// skimming for "which one do I pick" needs to read. Plain rows rather than a
-// comparison table so it stays readable on a phone.
-function ProviderOption({ name, summary, landsIn, connect, limits }) {
+// One storage provider: what it is, where the files land, and the limit that
+// will eventually matter. Deliberately no "choose this if" steer -- which
+// trade-off matters is the researcher's call, and the limits are the only
+// part of it they cannot work out for themselves. Same list, same wording as
+// pages/getting-started.js; keep the two in step. Everything else a provider
+// does mid-study is #provider-specific-behavior below, so these rows stay
+// short enough to compare at a glance on a phone.
+function ProviderOption({ name, description, limits }) {
   return (
-    <Box borderWidth="1px" borderColor="border" borderRadius={8} p={4}>
-      <Text fontWeight="semibold" color="fg" mb={1}>
-        {name}
-      </Text>
-      <Text fontSize="sm" mb={3}>
-        {summary}
-      </Text>
-      <Stack gap={1}>
-        <Text fontSize="sm" color="fg.muted">
-          <Text as="span" fontWeight="semibold">
-            Data lands in:
-          </Text>{" "}
-          {landsIn}
+    <Box maxW="70ch">
+      <Text>
+        <Text as="span" fontWeight="semibold" color="fg">
+          {name}
         </Text>
-        <Text fontSize="sm" color="fg.muted">
-          <Text as="span" fontWeight="semibold">
-            Connect with:
-          </Text>{" "}
-          {connect}
-        </Text>
-        <Text fontSize="sm" color="fg.muted">
+        {" — "}
+        {description}
+      </Text>
+      {limits && (
+        <Text fontSize="sm" color="fg.muted" mt={1}>
           <Text as="span" fontWeight="semibold">
             Limits:
           </Text>{" "}
           {limits}
         </Text>
-      </Stack>
+      )}
     </Box>
   );
 }
@@ -106,23 +95,17 @@ export default function ChoosingAProviderPage() {
         <Stack gap={3} maxW="70ch">
           <ProviderOption
             name="Google Drive"
-            summary="Your own Google Drive. Choose this if you want the fewest steps and do not need a citable dataset."
-            landsIn="a folder in My Drive/DataPipe, or in a parent folder you pick."
-            connect="your Google account, in one click."
+            description="your own Google Drive. Data lands in a folder in My Drive/DataPipe, or in a parent folder you pick."
             limits="free Google accounts share 15 GB across Drive, Gmail, and Photos. Uploads stop once that is full."
           />
           <ProviderOption
             name="Dataverse"
-            summary="Institutional repositories run by universities and consortia — Harvard Dataverse, Borealis, DataverseNL, and others. Choose this if your institution or funder expects data to live there."
-            landsIn="a draft dataset, in a collection you name."
-            connect="an API token from your institution's installation."
+            description="institutional repositories run by universities and consortia — Harvard Dataverse, Borealis, DataverseNL, and others. Data lands in a draft dataset, in a collection you name."
             limits="your installation sets its own file size and storage limits. API tokens expire, often yearly, and DataPipe cannot renew them — data stops arriving until you reconnect."
           />
           <ProviderOption
             name="Zenodo"
-            summary="An open repository run by CERN that issues a DOI for every published record. Choose this if you want your data citable without an institutional repository."
-            landsIn="a deposition that stays private until you publish it."
-            connect="your Zenodo account, in one click."
+            description="an open repository run by CERN. Data lands in a deposition that stays private until you publish it, and publishing issues a DOI."
             limits="100 files and 50 GB per record. DataPipe merges completed sessions into archives so a long study stays under the file limit."
           />
         </Stack>

--- a/pages/faq.js
+++ b/pages/faq.js
@@ -35,7 +35,7 @@ export const FAQ_REDIRECTS = {
   "item-10": "/docs/experiments/conditions",
   "item-11": "/docs/experiments/metadata",
   "item-12": "/docs/providers/connecting#how-permission-works",
-  "item-13": "/docs/about#citing",
+  "item-13": "/docs/citation",
 };
 
 export default function FAQRedirect() {

--- a/pages/getting-started.js
+++ b/pages/getting-started.js
@@ -130,35 +130,24 @@ function FeatureItem({ name, children }) {
   );
 }
 
-// One storage provider, in the terms a researcher choosing between them
-// actually needs: whether it is the right fit, where the data physically ends
-// up, how they connect, and the limit that will eventually matter. The
-// decision sentence leads because that is the only line someone skimming for
-// "which one do I pick" needs to read. Plain rows rather than a comparison
-// table so it stays readable on a phone.
-function ProviderOption({ name, summary, landsIn, connect, limits }) {
+// One storage provider: what it is, where the files land, and the limit that
+// will eventually matter. Deliberately no "choose this if" steer -- which
+// trade-off matters is the researcher's call, and the limits are the only
+// part of it they cannot work out for themselves. Same shape as FeatureItem
+// above, so step 1 and step 4 read as one page; the bordered card this
+// replaced nested a boundary inside the StepCard's own for three short rows.
+function ProviderOption({ name, description, limits }) {
   return (
-    // Sole visual boundary of the row (WCAG 1.4.11 "panel edge"), so this
-    // uses `border` (gray.500, 4.50 light / 3.43 dark) rather than
-    // `border.subtle`, which DESIGN.md bans as a lone grouping device.
-    <Box borderWidth="1px" borderColor="border" borderRadius={8} p={4}>
-      <Text fontWeight="semibold" color="brandOrange.fg" mb={2}>
-        {name}
+    <Box>
+      <Text>
+        <Text as="span" fontWeight="semibold" color="brandOrange.fg">{name}</Text>
+        {" — "}{description}
       </Text>
-      <Text fontSize="sm" mb={3}>
-        {summary}
-      </Text>
-      <Stack gap={2}>
-        <Text fontSize="sm" color="fg.muted">
-          <Text as="span" fontWeight="semibold">Data lands in:</Text> {landsIn}
-        </Text>
-        <Text fontSize="sm" color="fg.muted">
-          <Text as="span" fontWeight="semibold">Connect with:</Text> {connect}
-        </Text>
-        <Text fontSize="sm" color="fg.muted">
+      {limits && (
+        <Text fontSize="sm" color="fg.muted" mt={1}>
           <Text as="span" fontWeight="semibold">Limits:</Text> {limits}
         </Text>
-      </Stack>
+      )}
     </Box>
   );
 }
@@ -204,23 +193,17 @@ export default function GettingStarted() {
         <Stack gap={3}>
           <ProviderOption
             name="Google Drive"
-            summary="Your own Google Drive. Choose this if you want the fewest steps and do not need a citable dataset."
-            landsIn="a folder in My Drive/DataPipe, or in a parent folder you pick."
-            connect="your Google account, in one click."
+            description="your own Google Drive. Data lands in a folder in My Drive/DataPipe, or in a parent folder you pick."
             limits="free Google accounts share 15 GB across Drive, Gmail, and Photos. Uploads stop once that is full."
           />
           <ProviderOption
             name="Dataverse"
-            summary="Institutional repositories run by universities and consortia — Harvard Dataverse, Borealis, DataverseNL, and others. Choose this if your institution or funder expects data to live there."
-            landsIn="a draft dataset, in a collection you name."
-            connect="an API token from your institution's installation."
+            description="institutional repositories run by universities and consortia — Harvard Dataverse, Borealis, DataverseNL, and others. Data lands in a draft dataset, in a collection you name."
             limits="your installation sets its own file size and storage limits. API tokens expire, often yearly, and DataPipe cannot renew them — data stops arriving until you reconnect."
           />
           <ProviderOption
             name="Zenodo"
-            summary="An open repository run by CERN that issues a DOI for every published record. Choose this if you want your data citable without an institutional repository."
-            landsIn="a deposition that stays private until you publish it."
-            connect="your Zenodo account, in one click."
+            description="an open repository run by CERN. Data lands in a deposition that stays private until you publish it, and publishing issues a DOI."
             limits="100 files and 50 GB per record. DataPipe merges completed sessions into archives so a long study stays under the file limit."
           />
         </Stack>


### PR DESCRIPTION
Four small fixes, all copy or surface.

## The connect-account message on /admin/new

It said "the title you have typed here will still be waiting when you come back" — next to a form with no title field. The title input lives inside the `providerConnected` branch, so a researcher without a provider never has a title to lose. Now:

> Connect a **{provider}** account to create an experiment.

The button directly below already says "Connect {provider}", so the "takes a minute" filler went too.

While there: the `sessionStorage` title draft's comments described that same impossible round trip. They now describe what the mechanism actually covers — a *connected* researcher who leaves the page and comes back. **The mechanism's original purpose is unreachable; worth deciding separately whether it earns its keep.**

## Provider descriptions

On both `/getting-started` and `/docs/providers`, the opinionated "Choose this if you want the fewest steps…" summaries are gone, along with the `Connect with:` row that `/docs/providers/connecting` already owns. Each provider is now a plain row — name, what it is and where files land, then a `Limits:` note:

> **Zenodo** — an open repository run by CERN. Data lands in a deposition that stays private until you publish it, and publishing issues a DOI.
> *Limits:* 100 files and 50 GB per record. DataPipe merges completed sessions into archives so a long study stays under the file limit.

Which trade-off matters is the researcher's call; the limits are the only part they can't work out for themselves. The docs page's deeper "Provider-specific behavior" section is untouched, so the top list can stay short enough to compare at a glance.

## Citing DataPipe → its own page

New `/docs/citation`, with two sections:

- **APA** — the reference as prose (italic journal, linked DOI) on `bg.subtle`, with a neutral-outline **Copy APA citation** button.
- **BibTeX** — the entry in the existing `CodeBlock` specimen, which brings its own copy button. BibTeX is code you paste into a `.bib` file; an APA reference is prose a monospace block would flatten. (Prism has no `bibtex` grammar installed — its `highlightElement` renders unhighlighted text rather than throwing, which is the wanted outcome.)

`lib/citation.js` holds the paper as fields; both formats and the rendered prose derive from it. A volume number typed once per format is how the block you read and the block you pasted end up disagreeing — a test asserts the two agree on pages, journal, and DOI.

`CopyButton`'s state machine moved to `lib/use-copy-to-clipboard.js` so the specimen's icon button and the page's labelled button are one implementation. The extracted version also clears its reset timeout on unmount, which the inline one didn't.

Wiring follows from `lib/docs-nav.js`: sidebar, `/docs` overview, and the prev/next pager all pick the page up. `pages/faq.js`'s `item-13` redirect now points at it.

⚠️ **One judgment call:** raw `/docs/about#citing` links now land at the top of About rather than on the citation. The only known consumer was the FAQ redirect map, which is updated, and the sidebar shows "Citing DataPipe" directly below About. Say the word and I'll leave a stub section on About to keep the anchor alive.

## Footer links

The permanent underline is gone. DESIGN.md §5 mandates it for *prose*, where no green/body-text pair clears the 3:1 color-difference floor — a labelled `<nav>` cluster isn't prose, which is why the Navbar's links are bare `color="fg"` today. Links now sit at `fg` (a step brighter than the band's `fg.muted`) and underline in `brandGreen.fg` on hover; keyboard focus still draws the theme's focus-visible ring.

The four links are also one `HStack` instead of four `<Text>` items the parent's `space-between` scattered evenly across the band — that spread was doing as much of the awkwardness as the underline.

## Testing

- 199 tests pass across 23 suites, 5 of them new (`__tests__/citation-page.test.jsx`: both formats render, both copy buttons write the right string, a rejected clipboard says what to do instead, and the two formats agree field-for-field).
- ESLint clean.
- Verified on a dev server: footer CSS emits no static underline and the right hover rule; the citation page's sidebar entry, `aria-current`, pager, and overview listing all resolve.
- Two pre-existing failures are unrelated — `validate-csv` and `validate-json` import `functions/lib/*.js`, which doesn't exist until the functions TypeScript is compiled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R5dh3MB9EjCCU6ayEfgyyk
