### PR TITLE
Serialize deploys to each Firebase project

### DIFF
--- a/.github/workflows/firebase-deploy-test.yml
+++ b/.github/workflows/firebase-deploy-test.yml
@@ -8,6 +8,20 @@ on:
     branches: ["test"]
   workflow_dispatch:
 
+# Deploys to one Firebase project must not overlap. Two merges landing within
+# a few minutes of each other used to start two deploys at once; the second
+# one's update of the SSR function was rejected with a 409 ("unable to queue
+# the operation") because the first was still mid-flight, and the site kept
+# serving the previous build. Note that firebase deploy reports that failure
+# as a warning and still exits 0, so the collision does not show up as a red
+# check -- keeping deploys serialized is what prevents it, not the exit code.
+# cancel-in-progress stays false on purpose --
+# a deploy that is already updating functions should be allowed to finish,
+# not killed halfway through. Later runs queue behind it instead.
+concurrency:
+  group: deploy-test
+  cancel-in-progress: false
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   #FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}

--- a/.github/workflows/firebase-deploy.yml
+++ b/.github/workflows/firebase-deploy.yml
@@ -8,6 +8,14 @@ on:
     branches: ["main"]
   workflow_dispatch:
 
+# See the matching block in firebase-deploy-test.yml: concurrent deploys to the
+# same Firebase project collide on the SSR function update and leave the site
+# on the old build. Separate group from the test deploy -- they target
+# different projects and have no reason to queue behind each other.
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   #FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}


### PR DESCRIPTION
## Why

The `test` site spent ~45 minutes serving a stale build behind a green check.

PRs #201 and #202 merged 2.5 minutes apart. Each merge starts a `Deploy to Test` run, so two deploys to the same Firebase project ran at once. The second one tried to update `ssrdatapipetest` while the first still held it:

```
⚠  functions: Request to .../functions/ssrdatapipetest ... HTTP Error: 409, unable to queue the operation
⚠  functions:  failed to update function projects/datapipe-test/locations/us-central1/functions/ssrdatapipetest
```

Static files uploaded, but every Next.js page is rendered by that function, so the site kept serving the pre-#202 bundle — the new `/docs/citation` page 404'd and the old provider copy was still up. Re-running the deploy with nothing else in flight fixed it.

## What

A `concurrency` group on each deploy workflow, so a second run queues rather than racing the first. `cancel-in-progress: false` is deliberate — a deploy already partway through updating functions should be allowed to finish, not killed halfway.

Production has the identical workflow shape and the same latent bug, so it gets its own group. Separate groups: the two target different projects and have no reason to queue behind each other.

The diff is purely additive — the deploy steps themselves are untouched.

## Known gap

`firebase deploy` reports a failed function update as a warning and still exits 0, so a collision of this kind surfaces as a *green* check, not a red one. That is why the original failure went unnoticed until someone spotted that the docs hadn't changed.

Serializing deploys removes the cause we actually hit. It does not make the deploy honest about failures from any other source — those will still go green. Guarding on the warning text was considered and deliberately rejected: a string match against vendor output rots silently on a CLI upgrade, which is the same class of silent failure it would be trying to catch. Noted here so the remaining exposure is on the record rather than assumed handled.

## Checks

Both files parse as valid workflow YAML and the final deploy step in each is unchanged from `test`.

Neither workflow can run before merge — they only trigger on pushes to `test` and `main`. The first pair of closely-spaced merges to `test` after this lands is the real test of the group.

🤖 Generated with [Claude Code](https://claude.com/claude-code)