### PR TITLE
Experiment page: one column, one width

### DIFF
--- a/pages/admin/[experiment_id].js
+++ b/pages/admin/[experiment_id].js
@@ -43,17 +43,6 @@ export async function getServerSideProps() {
 
 const plural = (n, word) => `${n} ${word}${n !== 1 ? "s" : ""}`;
 
-// DESIGN.md §4's settings measure, the same one pages/admin/account.js uses.
-//
-// This page has two measures, and the step between them is the composition.
-// Reference content -- the details strip, the integration snippets -- spans
-// the full 1100px, because it is read across and the code genuinely needs the
-// width. Controls are capped here, because a SettingsRow puts its label at the
-// left edge and its switch at the right edge with the description running the
-// full width underneath: at 1100px that is a 140-character measure and a
-// 1100px journey from a label to the switch it belongs to.
-const CONTROL_MEASURE = "560px";
-
 export default function ExperimentPage() {
   const router = useRouter();
   const { experiment_id } = router.query;
@@ -266,25 +255,36 @@ function ExperimentPageDashboard({ experiment_id }) {
         </Stack>
       )}
 
-      {/* One ordered column, not two piles.
+      {/* One ordered column, one width.
 
           The page used to be `<Flex>` with two `flex="1"` children, which at
-          maxW 1100 and gap 10 gives each column exactly 530px. Two things went
-          wrong with that. The integration snippets need ~920px including the
-          copy button and both sets of padding -- the longest line in
-          CodeHints is 92 rendered characters -- so ~40% of the page's primary
-          copy-paste artefact sat behind a horizontal scrollbar at every
-          viewport width. And the split was by category rather than by
-          measure, so five sections went left and one went right: the left
-          column ran ~1500px and the right ~740px, leaving 750-900px of empty
-          rail beside the settings, the metadata section and the danger zone.
+          maxW 1100 and gap 10 gives each column exactly 530px: ~40% of the
+          integration snippet sat behind a horizontal scrollbar, and the split
+          was by category rather than by measure, so five sections went left
+          and one went right and 750-900px of rail sat empty beside the
+          settings.
 
-          The two columns could never both be satisfied here: 920 for the code
-          plus 560 for the controls plus a gutter is more than the page has.
-          So the columns are gone, and width is allocated per section by what
-          the section is -- full width for reference content, CONTROL_MEASURE
-          for controls. The order is the order of the work: what is this ->
-          how do I wire it up -> how do I configure it -> how do I end it. */}
+          Collapsing that to one column fixed the columns but left two
+          MEASURES -- reference content at the full 1100px, controls capped at
+          DESIGN.md §4's 560px settings measure. Read top to bottom, that is
+          what the eye reports as broken: two wide bordered panels, then four
+          narrow ones, the right-hand 540px going empty from the middle of the
+          page down. A single column gets a single width.
+
+          So every section is `w="100%"` at the page's 1100px and nothing
+          steps in or out. The cost is the one the 560px cap was buying off --
+          a SettingsRow puts its label at the left edge and its switch at the
+          right -- and it is paid knowingly. What that cap was really
+          protecting, the 140-character description measure, is already
+          handled a level down: GuidanceLine carries `maxW="70ch"`
+          (components/ui/GuidanceLine.js), so row descriptions keep a readable
+          measure at any container width. If the switch travel becomes a
+          problem, fix it inside SettingsRow -- cap the label/description
+          column and bring the switch in beside it -- rather than by narrowing
+          the section and reintroducing the step.
+
+          Order is the order of the work: what is this -> how do I configure
+          it -> how do I wire it up -> how do I end it. */}
 
       {/* The ID / storage-link / session rows used to open a column with no
           heading and no container: the first thing on the page after the
@@ -301,21 +301,75 @@ function ExperimentPageDashboard({ experiment_id }) {
         </SectionPanel>
       </SettingsSection>
 
-      {/* Promoted out of the right-hand column to full width, and up to
-          second position.
+      {/* Settings. Four `<Separator borderColor="whiteAlpha.200">` rules used
+          to divide these sections. They composite to 1.26:1 -- not a weak
+          separator, an absent one -- and DESIGN.md §4 bans the value and
+          commits to spacing-only grouping between sections: mt={10} between
+          routine ones, mt={16} before anything irreversible. The five
+          illegible `xs`/uppercase/`gray.500` (3.43:1) eyebrows they sat under
+          are gone with them; SettingsSection renders a real <h2> in sentence
+          case, and every section now carries the one-line description this
+          page has never had.
 
-          Width, because at 1100px the `pre` gets ~964px against the ~770px
-          the longest snippet line needs -- the horizontal scroll is simply
-          gone rather than reduced. Position, because on every experiment that
-          has never run, wiring up the snippet IS the job; it was previously
-          below the fold in the shorter of two columns.
+          What spacing alone could NOT carry is the grouping INSIDE a section
+          -- §4's own escape hatch, "grouping that spacing cannot carry alone
+          gets a bordered container". Each section body is a SectionPanel, and
+          the switches are hairline-separated rows inside one
+          (components/dashboard/SectionPanel.js). */}
+      <Box mt={10} w="100%">
+        <SettingsSection
+          title="Data collection"
+          description="Turn this off to stop accepting new submissions. Data you have already collected is not affected."
+        >
+          <ExperimentActive data={data} />
+        </SettingsSection>
+      </Box>
 
-          The "No data yet" EmptyState that used to sit above this is folded
-          into the guidance line below. It stated a fact the header already
-          states twice ("0 completed sessions", "Accepting data"), and its
-          body copy told the researcher to "paste the code below" -- true in
-          the two-column layout, false the moment the columns wrapped and the
-          card landed ~1500px underneath the settings stack. */}
+      <Box mt={10} w="100%">
+        <SettingsSection
+          title="Validation"
+          description="Reject submissions that do not match the format you expect, before they reach your storage provider."
+        >
+          <ExperimentValidation data={data} />
+        </SettingsSection>
+      </Box>
+
+      <Box mt={10} w="100%">
+        <SettingsSection title="Metadata">
+          {/* The Psych-DS explanation used to live inside a popover behind
+              an icon-only "?" trigger -- meaning in a tooltip, DESIGN.md
+              §8.3. It is the section's description now, and the link is
+              brandGreen.fg (4.77:1 light / 6.71:1 dark) rather than the
+              retired blue.500 (§5). */}
+          <GuidanceLine
+            mb={4}
+            href="https://psychds-docs.readthedocs.io/en/latest/"
+            linkText="Learn more about Psych-DS"
+            external
+          >
+            DataPipe can describe your data&apos;s columns -- their
+            descriptions, value ranges and levels -- in a standard metadata
+            file, so your dataset is easier for others to read and reuse.
+          </GuidanceLine>
+          <MetadataControl data={data} />
+        </SettingsSection>
+      </Box>
+
+      {/* Below the settings, above the danger zone.
+
+          It sat second, directly under the details strip, on the argument
+          that wiring up the snippet IS the job on an experiment that has
+          never run. It is reference material the rest of the time, and a
+          researcher who comes back to this page comes back to change a
+          setting -- so the settings are what should be in reach, and the
+          snippet is what should be findable. The empty-state case is carried
+          by the guidance line below instead, which changes wording while
+          `sessions` is 0.
+
+          Full width is no longer a special case for this section, but it is
+          still what the section needs: at 1100px the `pre` gets ~964px
+          against the ~900px the longest snippet line takes, so the
+          horizontal scroll is gone rather than reduced. */}
       <Box mt={10} w="100%">
         <SettingsSection title="Integration code">
           <GuidanceLine
@@ -336,98 +390,40 @@ function ExperimentPageDashboard({ experiment_id }) {
         </SettingsSection>
       </Box>
 
-      {/* Controls, at the settings measure. Everything from here down is
-          something the researcher can change, which is why the measure
-          changes with it.
+      {/* mt={16}, not mt={10}: the extra air is the signal that the next
+          section plays by different rules.
 
-          Four `<Separator borderColor="whiteAlpha.200">` rules used to divide
-          these sections. They composite to 1.26:1 -- not a weak separator, an
-          absent one -- and DESIGN.md §4 bans the value and commits to
-          spacing-only grouping between sections: mt={10} between routine
-          ones, mt={16} before anything irreversible. The five illegible
-          `xs`/uppercase/`gray.500` (3.43:1) eyebrows they sat under are gone
-          with them; SettingsSection renders a real <h2> in sentence case, and
-          every section now carries the one-line description this page has
-          never had.
-
-          What spacing alone could NOT carry is the grouping INSIDE a section
-          -- §4's own escape hatch, "grouping that spacing cannot carry alone
-          gets a bordered container". Each section body is a SectionPanel, and
-          the switches are hairline-separated rows inside one
-          (components/dashboard/SectionPanel.js). */}
-      <Box mt={10} w="100%" maxW={CONTROL_MEASURE}>
+          "Danger zone", not "Finalize", for parity with
+          pages/admin/account.js -- the same title, the same variant="danger"
+          container, so the one section on either page that cannot be undone
+          is recognisable as the same thing in both places. Finalization
+          becomes an <h3> INSIDE it: it is currently the only irreversible
+          action here, and naming it as one entry in a zone rather than as the
+          zone itself leaves room for the next one (experiment deletion)
+          without another rename. */}
+      <Box mt={16} w="100%">
         <SettingsSection
-          title="Data collection"
-          description="Turn this off to stop accepting new submissions. Data you have already collected is not affected."
+          title="Danger zone"
+          description="Actions here are permanent. Nothing in this section can be undone."
+          variant="danger"
         >
-          <ExperimentActive data={data} />
-        </SettingsSection>
-
-        <Box mt={10}>
-          <SettingsSection
-            title="Validation"
-            description="Reject submissions that do not match the format you expect, before they reach your storage provider."
-          >
-            <ExperimentValidation data={data} />
-          </SettingsSection>
-        </Box>
-
-        <Box mt={10}>
-          <SettingsSection title="Metadata">
-            {/* The Psych-DS explanation used to live inside a popover behind
-                an icon-only "?" trigger -- meaning in a tooltip, DESIGN.md
-                §8.3. It is the section's description now, and the link is
-                brandGreen.fg (4.77:1 light / 6.71:1 dark) rather than the
-                retired blue.500 (§5). */}
-            <GuidanceLine
-              mb={4}
-              href="https://psychds-docs.readthedocs.io/en/latest/"
-              linkText="Learn more about Psych-DS"
-              external
-            >
-              DataPipe can describe your data&apos;s columns -- their
-              descriptions, value ranges and levels -- in a standard metadata
-              file, so your dataset is easier for others to read and reuse.
+          <Stack gap={3} align="flex-start">
+            <Heading as="h3" size="sm" fontWeight="semibold" color="fg">
+              Finalize
+            </Heading>
+            {/* Kept verbatim from the old section description. DESIGN.md
+                §8.10: the confirmation dialog must not hold the only copy of
+                the consequence, so it has to be stated here, before the
+                button that opens it. */}
+            <GuidanceLine>
+              Finalizing merges every file into a single archive on your
+              storage provider, permanently deletes the loose files it was
+              built from, and stops this experiment from accepting data
+              forever. This cannot be undone.
             </GuidanceLine>
-            <MetadataControl data={data} />
-          </SettingsSection>
-        </Box>
-
-        {/* mt={16}, not mt={10}: the extra air is the signal that the next
-            section plays by different rules.
-
-            "Danger zone", not "Finalize", for parity with
-            pages/admin/account.js -- the same title, the same
-            variant="danger" container, so the one section on either page that
-            cannot be undone is recognisable as the same thing in both places.
-            Finalization becomes an <h3> INSIDE it: it is currently the only
-            irreversible action here, and naming it as one entry in a zone
-            rather than as the zone itself leaves room for the next one
-            (experiment deletion) without another rename. */}
-        <Box mt={16}>
-          <SettingsSection
-            title="Danger zone"
-            description="Actions here are permanent. Nothing in this section can be undone."
-            variant="danger"
-          >
-            <Stack gap={3} align="flex-start">
-              <Heading as="h3" size="sm" fontWeight="semibold" color="fg">
-                Finalize
-              </Heading>
-              {/* Kept verbatim from the old section description. DESIGN.md
-                  §8.10: the confirmation dialog must not hold the only copy
-                  of the consequence, so it has to be stated here, before the
-                  button that opens it. */}
-              <GuidanceLine>
-                Finalizing merges every file into a single archive on your
-                storage provider, permanently deletes the loose files it was
-                built from, and stops this experiment from accepting data
-                forever. This cannot be undone.
-              </GuidanceLine>
-              <FinalizeControl data={data} experimentId={experiment_id} />
-            </Stack>
-          </SettingsSection>
-        </Box>
+            <FinalizeControl data={data} experimentId={experiment_id} />
+          </Stack>
+        </SettingsSection>
       </Box>
     </VStack>
   );


### PR DESCRIPTION
Follow-up to #201. That PR collapsed `/admin/[experiment_id]` from two columns
to one ordered column; this one gives that column a single width and reorders
the last two sections.

## The problem

#201 left the page with one column but **two measures**: reference content (the
details strip, the integration snippets) at the full 1100px, and controls capped
at DESIGN.md §4's 560px settings measure. Read top to bottom, that is what the
eye reports as broken — two wide bordered panels, then four narrow ones, with
the right-hand ~540px going empty from the middle of the page down.

## The change

Every section is now `w="100%"` at the page's 1100px. `CONTROL_MEASURE` and its
wrapper `<Box>` are gone; nothing steps in or out.

Integration code also moves **below** the settings. It sat second on the argument
that wiring up the snippet *is* the job on an experiment that has never run, but
it is reference material the rest of the time, and a researcher who comes back to
this page comes back to change a setting. Section order is now the order of the
work:

| | Before (#201) | After |
|---|---|---|
| 1 | Experiment details (1100px) | Experiment details |
| 2 | Integration code (1100px) | Data collection |
| 3 | Data collection (560px) | Validation |
| 4 | Validation (560px) | Metadata |
| 5 | Metadata (560px) | Integration code |
| 6 | Danger zone (560px) | Danger zone |

## The tradeoff, stated

Going wide costs the thing the 560px cap was buying off: a `SettingsRow` puts its
label at the left edge and its switch at the right, so the eye travels the full
measure between a label and the control it belongs to.

What that cap was *really* protecting — a 140-character description measure — is
already handled a level down. `GuidanceLine` carries `maxW="70ch"`
(`components/ui/GuidanceLine.js`), so row descriptions stay readable at any
container width; only the switch moves. This is called out in a comment on the
layout block: if the switch travel turns out to be a problem in use, the fix
belongs inside `SettingsRow` (cap the label/description column, bring the switch
in beside it) rather than re-narrowing the section and reintroducing the step.

## Note on measures

`pages/admin/account.js` stays on the 560px settings measure — it is a pure
settings page. This page is now unambiguously on the 1100px dashboard measure.
That is a deliberate split rather than an inconsistency, but it does mean the two
admin pages render at different widths; happy to bring account.js along if you'd
rather they match.

## Testing

- `npm run lint` — clean
- `npm run build` — compiles successfully
- One file changed, no component APIs touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SHZNijLwUhn26yCbYbn1UN