### PR TITLE
Saved confirmation: move it out of the layout flow

### DIFF
--- a/components/dashboard/ExperimentActive.js
+++ b/components/dashboard/ExperimentActive.js
@@ -1,11 +1,15 @@
-import { Field, NumberInput } from "@chakra-ui/react";
+import { Field, HStack, NumberInput } from "@chakra-ui/react";
 
 import { useState } from "react";
 
 import { setDoc, doc } from "firebase/firestore";
 
 import { db } from "../../lib/firebase";
-import SettingsRow, { SaveStatus, useTrackedSave } from "../ui/SettingsRow";
+import SettingsRow, {
+  SaveError,
+  SavedFlag,
+  useTrackedSave,
+} from "../ui/SettingsRow";
 import { SwitchTable } from "./SectionPanel";
 
 // Every writer below returns the setDoc promise UNCAUGHT. That is the point of
@@ -85,7 +89,22 @@ export default function ExperimentActive({ data }) {
       >
         {conditionActive && (
           <Field.Root id="n-conditions">
-            <Field.Label>How many conditions?</Field.Label>
+            {/* Label and confirmation share one line, the confirmation right
+                aligned so it lands in the same column as the switches' own.
+                It reserves its width whether or not it is showing, so typing
+                in the field below never makes the label jump. */}
+            <HStack
+              justify="space-between"
+              alignItems="center"
+              w="100%"
+              gap={4}
+            >
+              <Field.Label>How many conditions?</Field.Label>
+              <SavedFlag
+                saved={nConditionsSave.saved}
+                savedLabel="Number of conditions saved"
+              />
+            </HStack>
             <NumberInput.Root
               value={String(nConditions)}
               min={2}
@@ -109,10 +128,7 @@ export default function ExperimentActive({ data }) {
                 <NumberInput.DecrementTrigger />
               </NumberInput.Control>
             </NumberInput.Root>
-            <SaveStatus
-              saved={nConditionsSave.saved}
-              error={nConditionsSave.error}
-            />
+            <SaveError error={nConditionsSave.error} />
           </Field.Root>
         )}
       </SettingsRow>
@@ -127,7 +143,18 @@ export default function ExperimentActive({ data }) {
       >
         {sessionLimitActive && (
           <Field.Root id="session-limit">
-            <Field.Label>How many total sessions?</Field.Label>
+            <HStack
+              justify="space-between"
+              alignItems="center"
+              w="100%"
+              gap={4}
+            >
+              <Field.Label>How many total sessions?</Field.Label>
+              <SavedFlag
+                saved={maxSessionsSave.saved}
+                savedLabel="Session limit saved"
+              />
+            </HStack>
             <NumberInput.Root
               value={String(maxSessions)}
               min={0}
@@ -151,10 +178,7 @@ export default function ExperimentActive({ data }) {
                 <NumberInput.DecrementTrigger />
               </NumberInput.Control>
             </NumberInput.Root>
-            <SaveStatus
-              saved={maxSessionsSave.saved}
-              error={maxSessionsSave.error}
-            />
+            <SaveError error={maxSessionsSave.error} />
           </Field.Root>
         )}
       </SettingsRow>

--- a/components/dashboard/ExperimentValidation.js
+++ b/components/dashboard/ExperimentValidation.js
@@ -1,10 +1,21 @@
-import { Field, Stack, Textarea, Checkbox, CheckboxGroup } from "@chakra-ui/react";
+import {
+  Field,
+  HStack,
+  Stack,
+  Textarea,
+  Checkbox,
+  CheckboxGroup,
+} from "@chakra-ui/react";
 
 import { useEffect, useRef, useState } from "react";
 
 import { doc, setDoc } from "firebase/firestore";
 import { db } from "../../lib/firebase";
-import SettingsRow, { SaveStatus, useTrackedSave } from "../ui/SettingsRow";
+import SettingsRow, {
+  SaveError,
+  SavedFlag,
+  useTrackedSave,
+} from "../ui/SettingsRow";
 import { SwitchTable } from "./SectionPanel";
 
 function writeExperiment(expId, fields) {
@@ -121,29 +132,46 @@ export default function ExperimentValidation({ data }) {
                 checkboxes -- the form would show rules that are not in force
                 while claiming they had been restored, which is the same class
                 of lie the empty catches told. */}
-            <CheckboxGroup
-              value={validationSettings}
-              onValueChange={(values) => {
-                setValidationSettings(values);
-              }}
+            {/* One confirmation for the whole detail block -- the checkboxes
+                and the required-fields box are written by a single effect, so
+                a single flag is the honest granularity. It sits at the top
+                right of the block, holding its width, rather than mounting a
+                line under the textarea and shoving the section below down
+                every time a checkbox is ticked. */}
+            <HStack
+              justify="space-between"
+              alignItems="center"
+              w="100%"
+              gap={4}
             >
-              <Stack gap={6} direction="row">
-                <Checkbox.Root value="json" colorPalette="brandGreen">
-                  <Checkbox.HiddenInput />
-                  <Checkbox.Control>
-                    <Checkbox.Indicator />
-                  </Checkbox.Control>
-                  <Checkbox.Label>Allow JSON</Checkbox.Label>
-                </Checkbox.Root>
-                <Checkbox.Root value="csv" colorPalette="brandGreen">
-                  <Checkbox.HiddenInput />
-                  <Checkbox.Control>
-                    <Checkbox.Indicator />
-                  </Checkbox.Control>
-                  <Checkbox.Label>Allow CSV</Checkbox.Label>
-                </Checkbox.Root>
-              </Stack>
-            </CheckboxGroup>
+              <CheckboxGroup
+                value={validationSettings}
+                onValueChange={(values) => {
+                  setValidationSettings(values);
+                }}
+              >
+                <Stack gap={6} direction="row">
+                  <Checkbox.Root value="json" colorPalette="brandGreen">
+                    <Checkbox.HiddenInput />
+                    <Checkbox.Control>
+                      <Checkbox.Indicator />
+                    </Checkbox.Control>
+                    <Checkbox.Label>Allow JSON</Checkbox.Label>
+                  </Checkbox.Root>
+                  <Checkbox.Root value="csv" colorPalette="brandGreen">
+                    <Checkbox.HiddenInput />
+                    <Checkbox.Control>
+                      <Checkbox.Indicator />
+                    </Checkbox.Control>
+                    <Checkbox.Label>Allow CSV</Checkbox.Label>
+                  </Checkbox.Root>
+                </Stack>
+              </CheckboxGroup>
+              <SavedFlag
+                saved={detailSave.saved}
+                savedLabel="Validation rules saved"
+              />
+            </HStack>
             <Field.Root>
               <Field.Label>Required fields</Field.Label>
               <Textarea
@@ -175,7 +203,7 @@ export default function ExperimentValidation({ data }) {
                 must contain.
               </Field.HelperText>
             </Field.Root>
-            <SaveStatus saved={detailSave.saved} error={detailSave.error} />
+            <SaveError error={detailSave.error} />
           </Stack>
         )}
       </SettingsRow>

--- a/components/dashboard/Title.js
+++ b/components/dashboard/Title.js
@@ -1,12 +1,19 @@
 import { useState } from "react";
-import { Editable, IconButton, Flex, Stack, Text } from "@chakra-ui/react";
+import {
+  Editable,
+  HStack,
+  IconButton,
+  Flex,
+  Stack,
+  Text,
+} from "@chakra-ui/react";
 
 import { Check, X, Pencil } from "lucide-react";
 
 import { db } from "../../lib/firebase";
 import { doc, setDoc } from "firebase/firestore";
 import { STORAGE_PROVIDERS } from "../../lib/provider-config";
-import { SaveStatus, useTrackedSave } from "../ui/SettingsRow";
+import { SaveError, SavedFlag, useTrackedSave } from "../ui/SettingsRow";
 
 export default function ExperimentTitle({ data }) {
   // Remount counter for the Editable. See handleCommit.
@@ -54,56 +61,69 @@ export default function ExperimentTitle({ data }) {
 
   return (
     <Stack gap={0} w="100%">
-      <Editable.Root
-        key={`${data.title}-${resetKey}`}
-        textAlign="left"
-        defaultValue={data.title}
-        fontSize="2xl"
-        fontWeight="bold"
-        color="fg"
-        onValueCommit={(details) => handleCommit(details.value)}
-        onEditChange={(details) => setEditing(details.edit)}
-        as={Flex}
-        align="center"
-      >
-        <Editable.Preview mr={8} />
-        <Editable.Input size="lg" mr={8} />
-        <Editable.Control>
-          <Editable.EditTrigger asChild>
-            {/* All three triggers drop their literal `white` / `green.400` /
-                `red.400` + `whiteAlpha.300` props. The default gray outline
-                recipe is legible in both modes now (border gray.500: 4.50:1
-                light / 3.43:1 dark) and hover uses bg.muted. Cancel-editing
-                was `red.400`, which DESIGN.md §5 reserves for irreversible
-                destruction -- abandoning an edit is neither. Commit stays
-                green because it is the primary action inside this control,
-                and brandGreen is the app's one primary (§5). */}
-            <IconButton aria-label="Rename experiment" variant="outline" size="sm">
-              <Pencil />
-            </IconButton>
-          </Editable.EditTrigger>
-          <Editable.SubmitTrigger asChild>
-            <IconButton
-              aria-label="Save new name"
-              size="sm"
-              variant="outline"
-              colorPalette="brandGreen"
-            >
-              <Check />
-            </IconButton>
-          </Editable.SubmitTrigger>
-          <Editable.CancelTrigger asChild>
-            <IconButton
-              aria-label="Cancel renaming"
-              size="sm"
-              variant="outline"
-              colorPalette="gray"
-            >
-              <X />
-            </IconButton>
-          </Editable.CancelTrigger>
-        </Editable.Control>
-      </Editable.Root>
+      {/* The rename confirmation is the worst offender if it mounts below:
+          it sits under the page's H1, so a successful rename pushed the ENTIRE
+          page down a line and pulled it back up three seconds later. On this
+          row, right aligned, it holds its own width and moves nothing. */}
+      <HStack w="100%" gap={4} align="center">
+        <Editable.Root
+          flex="1"
+          minW={0}
+          key={`${data.title}-${resetKey}`}
+          textAlign="left"
+          defaultValue={data.title}
+          fontSize="2xl"
+          fontWeight="bold"
+          color="fg"
+          onValueCommit={(details) => handleCommit(details.value)}
+          onEditChange={(details) => setEditing(details.edit)}
+          as={Flex}
+          align="center"
+        >
+          <Editable.Preview mr={8} />
+          <Editable.Input size="lg" mr={8} />
+          <Editable.Control>
+            <Editable.EditTrigger asChild>
+              {/* All three triggers drop their literal `white` / `green.400` /
+                  `red.400` + `whiteAlpha.300` props. The default gray outline
+                  recipe is legible in both modes now (border gray.500: 4.50:1
+                  light / 3.43:1 dark) and hover uses bg.muted. Cancel-editing
+                  was `red.400`, which DESIGN.md §5 reserves for irreversible
+                  destruction -- abandoning an edit is neither. Commit stays
+                  green because it is the primary action inside this control,
+                  and brandGreen is the app's one primary (§5). */}
+              <IconButton
+                aria-label="Rename experiment"
+                variant="outline"
+                size="sm"
+              >
+                <Pencil />
+              </IconButton>
+            </Editable.EditTrigger>
+            <Editable.SubmitTrigger asChild>
+              <IconButton
+                aria-label="Save new name"
+                size="sm"
+                variant="outline"
+                colorPalette="brandGreen"
+              >
+                <Check />
+              </IconButton>
+            </Editable.SubmitTrigger>
+            <Editable.CancelTrigger asChild>
+              <IconButton
+                aria-label="Cancel renaming"
+                size="sm"
+                variant="outline"
+                colorPalette="gray"
+              >
+                <X />
+              </IconButton>
+            </Editable.CancelTrigger>
+          </Editable.Control>
+        </Editable.Root>
+        <SavedFlag saved={titleSave.saved} savedLabel="Name saved" />
+      </HStack>
 
       {editing && containerLabel && (
         <Text fontSize="sm" color="fg.muted">
@@ -112,11 +132,7 @@ export default function ExperimentTitle({ data }) {
         </Text>
       )}
 
-      <SaveStatus
-        saved={titleSave.saved}
-        error={titleSave.error}
-        savedLabel="Name saved"
-      />
+      <SaveError error={titleSave.error} />
     </Stack>
   );
 }

--- a/components/ui/SettingsRow.js
+++ b/components/ui/SettingsRow.js
@@ -1,5 +1,12 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Box, Field, HStack, Stack, Switch } from "@chakra-ui/react";
+import {
+  Box,
+  Field,
+  HStack,
+  Stack,
+  Switch,
+  VisuallyHidden,
+} from "@chakra-ui/react";
 import FormErrorAlert from "./FormErrorAlert";
 import GuidanceLine from "./GuidanceLine";
 import StatusIndicator from "./StatusIndicator";
@@ -44,6 +51,35 @@ import StatusIndicator from "./StatusIndicator";
  * cannot tell a saved toggle from an unsaved one at all today -- there is no
  * announcement of any kind.
  *
+ * ---------------------------------------------------------------------------
+ * Why the confirmation does not move the page
+ * ---------------------------------------------------------------------------
+ * The confirmation used to mount as a new block UNDER the row. Flipping the
+ * first switch in a four-row panel grew that row by a line and pushed the
+ * three rows below it down; three seconds later they sprang back. So the
+ * feedback for "your change landed" was the whole panel jumping -- and if the
+ * researcher had already reached for the next switch, the switch they were
+ * aiming at had moved. That is the WCAG 2.2 3.2.5-adjacent failure mode this
+ * split exists to remove, and it hurts most exactly when someone is setting
+ * up an experiment by running down the list of toggles.
+ *
+ * So the two outcomes now render in two different places:
+ *
+ *   SavedFlag  -- success. Sits INLINE in the row, immediately left of the
+ *                 control it is confirming, and is ALWAYS in the layout: the
+ *                 chip is rendered at full size whether or not the write has
+ *                 landed, and only `opacity` changes. Nothing reflows, ever,
+ *                 in either direction. Placing it beside the control also
+ *                 answers "which of these four rows saved?", which a message
+ *                 in the gap between two rows never quite did.
+ *   SaveError  -- failure. Stays a block under the row. It is a full sentence,
+ *                 it is not transient, and it SHOULD claim space and push
+ *                 things down: the researcher has to read it and act.
+ *
+ * A row with dependent controls uses the same pair one level down (the
+ * numeric fields in ExperimentActive, the validation detail block) so the
+ * confirmation always appears at the top right of whatever it saved.
+ *
  * No silent retry. A failed write stays failed and visible until the
  * researcher acts, because a retry that also fails silently is the original
  * bug with extra steps.
@@ -65,6 +101,12 @@ const DEFAULT_FAILURE_MESSAGE =
 // How long the transient "Saved" confirmation stays up. Long enough to be
 // noticed on a glance, short enough that it never reads as permanent state.
 const SAVED_VISIBLE_MS = 3000;
+
+// The visible text of the confirmation chip, on every row. Constant on
+// purpose: it is what makes the reserved width identical everywhere, and it
+// sits next to the control it refers to, so it does not need to name it. The
+// per-call-site `savedLabel` is the SPOKEN version, which does.
+const SAVED_TEXT = "Saved";
 
 /**
  * useTrackedSave
@@ -138,27 +180,73 @@ export function useTrackedSave(failureMessage = DEFAULT_FAILURE_MESSAGE) {
 }
 
 /**
- * SaveStatus
+ * SavedFlag
  *
- * The visible half of `useTrackedSave`. Renders the failure through the app's
- * one error surface (`FormErrorAlert`, which already carries `role="alert"`)
- * and the success through a `StatusIndicator` -- icon plus mandatory visible
- * text, never color alone (DESIGN.md §5).
+ * The success half of `useTrackedSave`: a small confirmation chip that lives
+ * NEXT TO the control it is confirming rather than under it.
  *
- * The wrapper is a `role="status"` `aria-live="polite"` region so a change in
- * either direction is announced without stealing focus.
+ * The chip is always rendered, at full size, and only its `opacity` moves.
+ * That is the whole point -- an element that mounts and unmounts is an element
+ * that reflows its neighbours twice per save (see the header comment). Because
+ * the visible text is the constant `SAVED_TEXT` rather than the caller's
+ * `savedLabel`, the reserved width is the same on every row, so the controls
+ * beside it line up.
+ *
+ * Accessibility: the chip is `aria-hidden`, because at `opacity: 0` it is
+ * still in the accessibility tree and would otherwise announce a stale
+ * "Saved". The announcement comes instead from the visually hidden
+ * `role="status"` live region beside it, which carries the caller's full
+ * `savedLabel` ("Data collection setting saved") -- a screen-reader user is
+ * not looking at which switch the chip is next to, so the announcement has to
+ * name the setting that the sighted layout is naming by position.
+ *
+ * Motion: 150ms `ease-out`, the only durations/easing DESIGN.md §7 allows, and
+ * it is dropped entirely under `prefers-reduced-motion: reduce` -- the chip
+ * still appears and still announces, it just cuts instead of fading.
+ *
+ * @param {boolean} saved - From `useTrackedSave`.
+ * @param {string} [savedLabel="Saved"] - What a screen reader hears. Name the
+ *   setting, not just the outcome.
  */
-export function SaveStatus({ saved, error, savedLabel = "Saved" }) {
-  if (!saved && !error) return null;
-
+export function SavedFlag({ saved, savedLabel = "Saved" }) {
   return (
-    <Box role="status" aria-live="polite" w="100%" mt={2}>
-      {error ? (
-        <FormErrorAlert>{error}</FormErrorAlert>
-      ) : (
-        <StatusIndicator status="ok" label={savedLabel} />
-      )}
+    // `lineHeight="1"` keeps the slot's box tight to the icon and the word,
+    // so a permanently-present but usually-invisible element cannot add
+    // leading to the row it sits in.
+    <Box flexShrink={0} lineHeight="1">
+      <Box
+        aria-hidden="true"
+        opacity={saved ? 1 : 0}
+        transition="opacity 150ms cubic-bezier(0, 0, 0.2, 1)"
+        _motionReduce={{ transition: "none" }}
+      >
+        <StatusIndicator status="ok" label={SAVED_TEXT} />
+      </Box>
+      <VisuallyHidden role="status" aria-live="polite">
+        {saved ? savedLabel : ""}
+      </VisuallyHidden>
     </Box>
+  );
+}
+
+/**
+ * SaveError
+ *
+ * The failure half. A block under the control, through the app's one error
+ * surface (`FormErrorAlert`, which already carries `role="alert"` and already
+ * renders nothing for a falsy message, so call sites need no guard).
+ *
+ * This one is deliberately NOT space-reserving. Reserving a blank slot the
+ * height of an unknown-length sentence would put a permanent hole in every
+ * row, and unlike the confirmation, an error is not transient -- it stays
+ * until the researcher does something about it, so it is allowed to take the
+ * room it needs.
+ */
+export function SaveError({ error }) {
+  return (
+    <FormErrorAlert mt={2} w="100%">
+      {error}
+    </FormErrorAlert>
   );
 }
 
@@ -261,23 +349,30 @@ export default function SettingsRow({
             </Field.Label>
             {badge}
           </HStack>
-          <Switch.Root
-            colorPalette="brandGreen"
-            size="md"
-            checked={value}
-            disabled={disabled}
-            onCheckedChange={(e) => handleChange(e.checked)}
-          >
-            <Switch.HiddenInput />
-            <Switch.Control>
-              <Switch.Thumb />
-            </Switch.Control>
-          </Switch.Root>
+          {/* The confirmation rides in the same group as the switch, on the
+              switch's left, so it reads as belonging to THIS row. It holds
+              its width whether or not it is showing, which is what keeps the
+              switch from sliding sideways when a save lands. */}
+          <HStack gap={3} alignItems="center" flexShrink={0}>
+            <SavedFlag saved={saved} savedLabel={savedLabel} />
+            <Switch.Root
+              colorPalette="brandGreen"
+              size="md"
+              checked={value}
+              disabled={disabled}
+              onCheckedChange={(e) => handleChange(e.checked)}
+            >
+              <Switch.HiddenInput />
+              <Switch.Control>
+                <Switch.Thumb />
+              </Switch.Control>
+            </Switch.Root>
+          </HStack>
         </HStack>
 
         {description && <GuidanceLine mt={2}>{description}</GuidanceLine>}
 
-        <SaveStatus saved={saved} error={error} savedLabel={savedLabel} />
+        <SaveError error={error} />
 
         {children && (
           <Box w="100%" mt={3}>


### PR DESCRIPTION
## The problem

Flipping a switch in `admin/<experiment>` mounted a "Saved" line **under** that row. The row grew, every row below it moved down for three seconds, then sprang back. So the feedback for "your change landed" was the whole panel jumping — and if the researcher had already reached for the next switch, the switch they were aiming at had moved. That hurts most exactly when someone is setting up an experiment by running down the list of toggles.

## The fix

Split the one `SaveStatus` component into the two different things it was doing:

- **`SavedFlag`** — success. Now inline in the row, immediately left of the control it confirms. It is **always** rendered at full size and only its `opacity` changes, so nothing reflows in either direction. Its visible text is a constant `"Saved"`, which keeps the reserved width identical on every row so the switches stay in one column. Placing it beside the control also answers "which of these four rows saved?", which a message in the gap between two rows never quite did.
- **`SaveError`** — failure. Still a block below the row. It is a full sentence, it is not transient, and it *should* claim space and push things down: the researcher has to read it and act.

The dependent controls get the same pair one level down — the two numeric fields in `ExperimentActive`, the validation detail block, and the title rename, whose confirmation sat under the page H1 and moved the entire page.

## Accessibility

Unchanged in substance. The chip is `aria-hidden` (at `opacity: 0` it is still in the accessibility tree and would otherwise announce a stale "Saved"); the announcement moves to a visually hidden `role="status"` region carrying the caller's descriptive `savedLabel` — "Data collection setting saved", "Name saved", plus new ones for the numeric fields and the validation block. Status is still icon + visible text, never colour alone.

Motion is 150ms `ease-out` per DESIGN.md §7, dropped entirely under `prefers-reduced-motion: reduce` — the chip still appears and still announces, it just cuts instead of fading.

## Verification

Rendered the panel in headless Chrome and measured every row's top, height, and switch position before and after a save lands: **identical in both**. Screenshots confirm the chip appears in whitespace that was already there and the switch does not move.

`npm run lint` and `npm run build` are clean. The 5 failing suites in `functions/src/__tests__/` are pre-existing emulator-connection failures, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SHZNijLwUhn26yCbYbn1UN