### PR TITLE
Finalizing an experiment closes it, visibly

### DIFF
--- a/__tests__/finalized-experiment.test.jsx
+++ b/__tests__/finalized-experiment.test.jsx
@@ -1,0 +1,233 @@
+import { render, screen } from "@testing-library/react";
+import { ChakraProvider } from "@chakra-ui/react";
+import { system } from "../lib/theme";
+import "@testing-library/jest-dom";
+
+/**
+ * Finalizing an experiment closes it. These tests pin the three places the
+ * dashboard has to say so.
+ *
+ * The backend half -- finalization.ts writing `active: false` /
+ * `activeBase64: false` in the same update as `finalized: true` -- is pinned
+ * in functions/src/__tests__/finalization-emulator.test.js. What is pinned
+ * HERE is that the UI does not depend on that write having happened: every
+ * assertion below covers the legacy case where an experiment was finalized
+ * before finalization started switching the flags off, so Firestore still
+ * holds `active: true` on a sealed record. `finalized` is read first
+ * everywhere, so those experiments render as closed rather than advertising
+ * that they are collecting.
+ */
+
+const mockGetIdToken = jest.fn(() => Promise.resolve("id-token-123"));
+jest.mock("../lib/firebase", () => ({
+  auth: { currentUser: { uid: "user-1", getIdToken: () => mockGetIdToken() } },
+  db: {},
+}));
+
+// `doc()` returns its path so the useDocumentData mock below can tell the
+// three subscriptions on the experiment page apart (contact email, the
+// experiment, its logs) without a real Firestore.
+jest.mock("firebase/firestore", () => ({
+  doc: jest.fn((_db, ...segments) => ({ path: segments.join("/") })),
+  collection: jest.fn(() => ({})),
+  query: jest.fn(() => ({})),
+  where: jest.fn(() => ({})),
+  orderBy: jest.fn(() => ({})),
+  deleteDoc: jest.fn(() => Promise.resolve()),
+  setDoc: jest.fn(() => Promise.resolve()),
+}));
+
+jest.mock("../lib/context", () => ({
+  UserContext: require("react").createContext({
+    user: { uid: "user-1" },
+    loading: false,
+  }),
+}));
+
+jest.mock("next/router", () => ({
+  __esModule: true,
+  default: { push: jest.fn() },
+  useRouter: () => ({
+    push: jest.fn(),
+    pathname: "/admin",
+    query: { experiment_id: "exp1" },
+  }),
+}));
+
+// A signed-in user with a contact address, so AuthCheck's gate lets the page
+// through to the content under test.
+const USER_DOC = { contactEmail: "researcher@example.edu" };
+
+let experimentDoc = null;
+const mockUseDocumentData = jest.fn((ref) => {
+  if (!ref) return [undefined, false, undefined];
+  if (ref.path?.startsWith("users/")) return [USER_DOC, false, undefined];
+  if (ref.path?.startsWith("experiments/")) {
+    return [experimentDoc, false, undefined, { exists: () => true }];
+  }
+  return [null, false, undefined];
+});
+
+let experimentList = [];
+const mockUseCollectionData = jest.fn((ref) => {
+  // The experiment page's queue query and the list page's experiments query
+  // both come through here; the queue one is `null` until a uid exists and
+  // otherwise wants an empty array, which is what an unfinalized fixture
+  // gives it anyway.
+  if (ref === null) return [undefined, false, undefined];
+  return [experimentList, false, undefined];
+});
+
+jest.mock("react-firebase-hooks/firestore", () => ({
+  useDocumentData: (...args) => mockUseDocumentData(...args),
+  useCollectionData: (...args) => mockUseCollectionData(...args),
+}));
+
+import ExperimentActive from "../components/dashboard/ExperimentActive";
+import AdminPage from "../pages/admin/index";
+import ExperimentPage from "../pages/admin/[experiment_id]";
+
+function renderWithChakra(ui) {
+  return render(<ChakraProvider value={system}>{ui}</ChakraProvider>);
+}
+
+const BASE_EXPERIMENT = {
+  id: "exp1",
+  title: "Word learning study",
+  owner: "user-1",
+  active: true,
+  activeBase64: false,
+  activeConditionAssignment: false,
+  nConditions: 2,
+  maxSessions: 100,
+  limitSessions: false,
+  sessions: 42,
+  storageProvider: "zenodo",
+  // ExperimentValidation and MetadataControl render alongside on the full
+  // page, and both read from the same document.
+  useValidation: false,
+  allowJSON: true,
+  allowCSV: true,
+  requiredFields: [],
+  metadataActive: false,
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  experimentDoc = null;
+  experimentList = [];
+});
+
+describe("ExperimentActive — data collection switches once finalized", () => {
+  // Chakra's Switch renders a visually hidden `input type="checkbox"` as the
+  // real control (Switch.HiddenInput), so that -- not a `switch` role -- is
+  // what carries the label, the checked state and the disabled state.
+  const switchFor = (name) =>
+    screen.getByRole("checkbox", { name: new RegExp(name, "i") });
+
+  it("leaves both collection switches live on an experiment that is not finalized", () => {
+    renderWithChakra(<ExperimentActive data={{ ...BASE_EXPERIMENT }} />);
+
+    expect(switchFor("Accept new data")).toBeEnabled();
+    expect(switchFor("Accept new data")).toBeChecked();
+    expect(switchFor("Accept base64 file uploads")).toBeEnabled();
+  });
+
+  it("locks both collection switches once the experiment is finalized, and says why", () => {
+    renderWithChakra(
+      <ExperimentActive
+        data={{ ...BASE_EXPERIMENT, active: false, finalized: true }}
+      />
+    );
+
+    expect(switchFor("Accept new data")).toBeDisabled();
+    expect(switchFor("Accept base64 file uploads")).toBeDisabled();
+
+    // A control that is off with no explanation reads as broken. Both rows
+    // have to name finalizing as the reason.
+    expect(
+      screen.getAllByText(/Locked because this experiment has been finalized/i)
+    ).toHaveLength(2);
+  });
+
+  it("shows a finalized experiment as not accepting data even when Firestore still holds active: true", () => {
+    // The legacy shape: finalized before finalization switched the flags off.
+    renderWithChakra(
+      <ExperimentActive
+        data={{
+          ...BASE_EXPERIMENT,
+          active: true,
+          activeBase64: true,
+          finalized: true,
+        }}
+      />
+    );
+
+    expect(switchFor("Accept new data")).not.toBeChecked();
+    expect(switchFor("Accept base64 file uploads")).not.toBeChecked();
+  });
+
+  it("does not lock condition assignment, which a finalized experiment still does", () => {
+    renderWithChakra(
+      <ExperimentActive
+        data={{ ...BASE_EXPERIMENT, active: false, finalized: true }}
+      />
+    );
+
+    expect(switchFor("Assign conditions in sequence")).toBeEnabled();
+  });
+});
+
+describe("Experiment list — finalized indicator", () => {
+  it("shows Collecting data for a live experiment", () => {
+    experimentList = [{ ...BASE_EXPERIMENT }];
+    renderWithChakra(<AdminPage />);
+
+    expect(screen.getByText("Collecting data")).toBeInTheDocument();
+    expect(screen.queryByText("Finalized")).not.toBeInTheDocument();
+  });
+
+  it("shows Finalized in place of the collecting status once finalized", () => {
+    experimentList = [{ ...BASE_EXPERIMENT, active: false, finalized: true }];
+    renderWithChakra(<AdminPage />);
+
+    expect(screen.getByText("Finalized")).toBeInTheDocument();
+    expect(screen.queryByText("Collecting data")).not.toBeInTheDocument();
+    expect(screen.queryByText("Not collecting")).not.toBeInTheDocument();
+  });
+
+  it("shows Finalized rather than Collecting data on a legacy finalized experiment", () => {
+    experimentList = [{ ...BASE_EXPERIMENT, active: true, finalized: true }];
+    renderWithChakra(<AdminPage />);
+
+    expect(screen.getByText("Finalized")).toBeInTheDocument();
+    expect(screen.queryByText("Collecting data")).not.toBeInTheDocument();
+  });
+});
+
+describe("Experiment page header — finalized indicator", () => {
+  it("shows Accepting data for a live experiment", () => {
+    experimentDoc = { ...BASE_EXPERIMENT };
+    renderWithChakra(<ExperimentPage />);
+
+    expect(screen.getByText("Accepting data")).toBeInTheDocument();
+    expect(screen.queryByText("Finalized")).not.toBeInTheDocument();
+  });
+
+  it("shows Finalized in place of the accepting status once finalized", () => {
+    experimentDoc = { ...BASE_EXPERIMENT, active: false, finalized: true };
+    renderWithChakra(<ExperimentPage />);
+
+    expect(screen.getByText("Finalized")).toBeInTheDocument();
+    expect(screen.queryByText("Accepting data")).not.toBeInTheDocument();
+    expect(screen.queryByText("Not accepting data")).not.toBeInTheDocument();
+  });
+
+  it("shows Finalized rather than Accepting data on a legacy finalized experiment", () => {
+    experimentDoc = { ...BASE_EXPERIMENT, active: true, finalized: true };
+    renderWithChakra(<ExperimentPage />);
+
+    expect(screen.getByText("Finalized")).toBeInTheDocument();
+    expect(screen.queryByText("Accepting data")).not.toBeInTheDocument();
+  });
+});

--- a/__tests__/finalized-experiment.test.jsx
+++ b/__tests__/finalized-experiment.test.jsx
@@ -205,6 +205,81 @@ describe("Experiment list — finalized indicator", () => {
   });
 });
 
+describe("Experiment list — storage provider", () => {
+  it("names the provider a current experiment is stored on", () => {
+    experimentList = [{ ...BASE_EXPERIMENT, storageProvider: "gdrive" }];
+    renderWithChakra(<AdminPage />);
+
+    expect(screen.getByText("Stored on Google Drive")).toBeInTheDocument();
+  });
+
+  it("names Zenodo and Dataverse experiments too", () => {
+    experimentList = [
+      { ...BASE_EXPERIMENT, id: "a", storageProvider: "zenodo" },
+      { ...BASE_EXPERIMENT, id: "b", storageProvider: "dataverse" },
+    ];
+    renderWithChakra(<AdminPage />);
+
+    expect(screen.getByText("Stored on Zenodo")).toBeInTheDocument();
+    expect(screen.getByText("Stored on Dataverse")).toBeInTheDocument();
+  });
+
+  it("names OSF for a legacy experiment with no storageProvider field", () => {
+    const legacy = { ...BASE_EXPERIMENT, osfRepo: "abc12", osfComponent: "def34" };
+    delete legacy.storageProvider;
+    experimentList = [legacy];
+    renderWithChakra(<AdminPage />);
+
+    expect(screen.getByText("Stored on OSF")).toBeInTheDocument();
+  });
+
+  it("says nothing rather than guessing when the provider is unrecognised", () => {
+    experimentList = [{ ...BASE_EXPERIMENT, storageProvider: "figshare" }];
+    renderWithChakra(<AdminPage />);
+
+    expect(screen.queryByText(/Stored on/)).not.toBeInTheDocument();
+  });
+});
+
+describe("Experiment page — the Finalize section is offered only where it works", () => {
+  it("offers finalizing on Zenodo, the one provider with a file-count cap", () => {
+    experimentDoc = { ...BASE_EXPERIMENT, storageProvider: "zenodo" };
+    renderWithChakra(<ExperimentPage />);
+
+    expect(screen.getByText("Danger zone")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /finalize/i })).toBeInTheDocument();
+  });
+
+  it("hides the whole Danger zone on Google Drive, which has no cap to relieve", () => {
+    experimentDoc = { ...BASE_EXPERIMENT, storageProvider: "gdrive" };
+    renderWithChakra(<ExperimentPage />);
+
+    // Offering an irreversible action that would only ever be refused is
+    // worse than not offering it -- and an empty Danger zone is its own kind
+    // of alarming, so the section goes with the button.
+    expect(screen.queryByText("Danger zone")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /finalize/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides it on Dataverse for the same reason", () => {
+    experimentDoc = { ...BASE_EXPERIMENT, storageProvider: "dataverse" };
+    renderWithChakra(<ExperimentPage />);
+
+    expect(screen.queryByText("Danger zone")).not.toBeInTheDocument();
+  });
+
+  it("hides it on a legacy OSF experiment, which is absent from the provider map", () => {
+    const legacy = { ...BASE_EXPERIMENT, osfRepo: "abc12", osfComponent: "def34" };
+    delete legacy.storageProvider;
+    experimentDoc = legacy;
+    renderWithChakra(<ExperimentPage />);
+
+    expect(screen.queryByText("Danger zone")).not.toBeInTheDocument();
+  });
+});
+
 describe("Experiment page header — finalized indicator", () => {
   it("shows Accepting data for a live experiment", () => {
     experimentDoc = { ...BASE_EXPERIMENT };

--- a/components/dashboard/ExperimentActive.js
+++ b/components/dashboard/ExperimentActive.js
@@ -29,6 +29,18 @@ function writeExperiment(expId, fields) {
 }
 
 export default function ExperimentActive({ data }) {
+  // Finalizing seals the dataset: the submission guards in api-data.ts and
+  // api-base64.ts reject on `finalized` BEFORE they look at these two flags,
+  // so a switch left writable here is a switch that cannot do what it says.
+  // finalization.ts now writes both to false as it finalizes; this makes the
+  // controls agree, and covers experiments finalized before it did.
+  //
+  // Same shape as MetadataControl's `locked`: inert switch plus a description
+  // saying WHY, because a control that is off with no explanation reads as
+  // broken (Nielsen 1). Condition assignment is not locked -- a finalized
+  // experiment still assigns conditions, by design.
+  const finalized = data.finalized === true;
+
   const [sessionLimitActive, setSessionLimitActive] = useState(
     data.limitSessions
   );
@@ -62,8 +74,20 @@ export default function ExperimentActive({ data }) {
     <SwitchTable label="Data collection settings">
       <SettingsRow
         label="Accept new data"
-        description="While this is on, your experiment ID accepts submissions from participants. Turning it off stops new submissions immediately; data you have already collected is not affected."
-        checked={data.active}
+        description={
+          finalized
+            ? "Locked because this experiment has been finalized. Its data is sealed in a single archive on your storage provider, and submissions are rejected whether this is on or off."
+            : "While this is on, your experiment ID accepts submissions from participants. Turning it off stops new submissions immediately; data you have already collected is not affected."
+        }
+        // `&& !finalized` is about experiments finalized BEFORE finalization
+        // started switching this off, which still hold `active: true`. The
+        // row asks "does this experiment accept new data"; for a sealed
+        // experiment the answer is no, whatever the stale flag says, and a
+        // green switch here would be the exact lie this file's rewrite
+        // removed. Nothing is written -- the display is corrected, not the
+        // document.
+        checked={data.active && !finalized}
+        disabled={finalized}
         onSave={(next) => writeExperiment(data.id, { active: next })}
         failureMessage="Could not change data collection. Your experiment is still set the way it was before -- check your connection and try again."
         savedLabel="Data collection setting saved"
@@ -71,8 +95,13 @@ export default function ExperimentActive({ data }) {
 
       <SettingsRow
         label="Accept base64 file uploads"
-        description="Needed only if your experiment sends binary files -- audio, video or images -- rather than CSV or JSON data."
-        checked={data.activeBase64 || false}
+        description={
+          finalized
+            ? "Locked because this experiment has been finalized. Base64 submissions are rejected on the same grounds as everything else."
+            : "Needed only if your experiment sends binary files -- audio, video or images -- rather than CSV or JSON data."
+        }
+        checked={(data.activeBase64 || false) && !finalized}
+        disabled={finalized}
         onSave={(next) => writeExperiment(data.id, { activeBase64: next })}
         failureMessage="Could not change base64 uploads. The setting is unchanged -- check your connection and try again."
       />

--- a/components/dashboard/FinalizeControl.js
+++ b/components/dashboard/FinalizeControl.js
@@ -67,10 +67,18 @@ const STATUS_COPY = {
     describe: () =>
       "Another finalization or compaction pass is already in progress for this experiment. Try again shortly.",
   },
+  // The Finalize control is hidden for providers that cannot finalize (see
+  // pages/admin/[experiment_id].js), so reaching this at all means something
+  // unusual -- a legacy OSF experiment with no provider container, or a
+  // provider the frontend knows and the backend does not. Either way the
+  // researcher gets a sentence, not `detail`: that field carries strings like
+  // "provider has no file-count cap", which is an internal capability name
+  // and exactly what DESIGN.md 6 bans from an error surface.
   "not-eligible": {
     tone: "error",
     title: "This experiment can't be finalized.",
-    describe: (detail) => detail || "This experiment is not eligible for finalization.",
+    describe: () =>
+      "Finalizing is available on storage providers that limit how many files a record can hold, and this experiment's provider does not. Nothing was changed -- your files are exactly as they were. Switching the experiment off when you are done collecting is the equivalent step.",
   },
   failed: {
     tone: "error",

--- a/functions/src/__tests__/finalization-emulator.test.js
+++ b/functions/src/__tests__/finalization-emulator.test.js
@@ -419,6 +419,42 @@ describe("F1. the full merge", () => {
     expect(entries.has("dataset_description.json")).toBe(true);
   });
 
+  it("switches data collection off in the same write that sets the finalized flag", async () => {
+    const { experimentID } = await seedFinalizableExperiment();
+    const before = (await db.collection("experiments").doc(experimentID).get()).data();
+    // The seed is a live experiment, so this test would pass vacuously if the
+    // flags were already off.
+    expect(before.active).toBe(true);
+    expect(before.activeBase64).toBe(true);
+
+    const result = await finalizeExperiment(experimentID);
+    expect(result.status).toBe("finalized");
+
+    const expData = (await db.collection("experiments").doc(experimentID).get()).data();
+    expect(expData.finalized).toBe(true);
+    // The submission guards already reject on `finalized` alone, so this is
+    // about the dashboard: `active: true` on a sealed record drew a green
+    // "Accepting data" switch on an experiment whose loose files had already
+    // been deleted.
+    expect(expData.active).toBe(false);
+    expect(expData.activeBase64).toBe(false);
+  });
+
+  it("leaves condition assignment alone, which a finalized experiment still does", async () => {
+    const { experimentID } = await seedFinalizableExperiment();
+    await db.collection("experiments").doc(experimentID).update({
+      activeConditionAssignment: true,
+    });
+
+    await finalizeExperiment(experimentID);
+
+    const expData = (await db.collection("experiments").doc(experimentID).get()).data();
+    // api-condition.ts has no `finalized` check by design -- see
+    // pages/docs/data/finalizing.js. Switching this off here would be
+    // finalization claiming a behaviour change it does not implement.
+    expect(expData.activeConditionAssignment).toBe(true);
+  });
+
   it("moves both Psych-DS control files inside the archive", async () => {
     const { experimentID } = await seedFinalizableExperiment();
     await finalizeExperiment(experimentID);

--- a/functions/src/finalization.ts
+++ b/functions/src/finalization.ts
@@ -401,11 +401,32 @@ async function runFinalization(experimentID: string): Promise<Omit<FinalizationR
  * same write. `compaction.lastError` is cleared the way a successful
  * compaction pass clears it -- a stale error from an earlier attempt should
  * not linger once the pass it belongs to has actually succeeded.
+ *
+ * `active` and `activeBase64` go off in the SAME write, and that is not
+ * cosmetic. The submission guards already reject everything on `finalized`
+ * alone (api-data.ts, api-base64.ts, both ahead of the active check), so the
+ * experiment was already closed -- but the dashboard renders those two fields
+ * as switches, and a finalized experiment left with `active: true` drew a
+ * green "Accepting data" switch on a record that had been sealed and whose
+ * loose files had already been deleted. The researcher's own dashboard was
+ * the least accurate thing about their study.
+ *
+ * One write, not two, because there is no state worth having in between: a
+ * reader that sees `finalized: true` sees the switches off in the same
+ * snapshot.
+ *
+ * `activeConditionAssignment` is deliberately NOT touched. A finalized
+ * experiment still hands out condition numbers -- api-condition.ts has no
+ * `finalized` check, by design, so an experiment that is being replayed or
+ * re-run for a demo keeps assigning -- and switching it off here would be
+ * this function claiming a behaviour change it does not implement.
  */
 async function markFinalized(experimentID: string, sessionsSeen: number): Promise<void> {
   await releaseLease(experimentID, sessionsSeen, {
     finalized: true,
     finalizedAt: Timestamp.now(),
+    active: false,
+    activeBase64: false,
     "compaction.lastError": FieldValue.delete(),
   });
 }

--- a/lib/provider-config.js
+++ b/lib/provider-config.js
@@ -34,6 +34,16 @@ const ZENODO_HOST = `https://${process.env.NEXT_PUBLIC_ZENODO_ENV ?? ""}zenodo.o
 export const STORAGE_PROVIDERS = {
   gdrive: {
     id: "gdrive",
+    // Mirrors `capabilities.maxFileCount !== null` on the matching adapter in
+    // functions/src/providers/. Presentational only, exactly like
+    // containerInputFields above -- finalization.ts re-derives eligibility
+    // from the real capability and refuses regardless of what this says.
+    //
+    // Drive imposes no file-count cap, and finalizing exists ONLY to relieve
+    // one: it merges a whole study into a single archive so a flat keyspace
+    // can hold a Psych-DS tree. Drive stores real folders and has no ceiling,
+    // so there is nothing to relieve.
+    supportsFinalizing: false,
     name: "Google Drive",
     authMethod: "oauth2",
     isConnected: (userDoc) => !!userDoc?.connectedAccounts?.gdrive,
@@ -62,6 +72,9 @@ export const STORAGE_PROVIDERS = {
   },
   dataverse: {
     id: "dataverse",
+    // No file-count cap and real folder support, same as Drive. See gdrive's
+    // supportsFinalizing for what this mirrors.
+    supportsFinalizing: false,
     name: "Dataverse",
     authMethod: "static-token",
     // Dataverse is FEDERATED -- Harvard, Borealis, DataverseNL and the rest are
@@ -133,6 +146,10 @@ export const STORAGE_PROVIDERS = {
   },
   zenodo: {
     id: "zenodo",
+    // The one provider this is true for: Zenodo caps a record at 100 files
+    // (MAX_FILE_COUNT in functions/src/providers/zenodo.ts), which is the
+    // ceiling finalization exists to relieve. See gdrive's supportsFinalizing.
+    supportsFinalizing: true,
     name: "Zenodo",
     // OAuth2 since 2026-08-21, previously a pasted personal access token.
     // The switch is not cosmetic: an OAuth client_id is registered against ONE

--- a/pages/admin/[experiment_id].js
+++ b/pages/admin/[experiment_id].js
@@ -191,11 +191,22 @@ function ExperimentPageDashboard({ experiment_id }) {
               {/* Badges -> StatusIndicator. The "Active" badge was white on
                   green.600 at 3.30:1, and the queued/error badges were solid
                   chips in a second red and a second orange. StatusIndicator
-                  rides `status.*` and always states the status in words. */}
-              <StatusIndicator
-                status={data.active ? "ok" : "neutral"}
-                label={data.active ? "Accepting data" : "Not accepting data"}
-              />
+                  rides `status.*` and always states the status in words.
+
+                  Finalized takes this slot instead of sitting beside it --
+                  same reasoning as the experiment list, including the legacy
+                  case where a pre-existing finalized experiment still holds
+                  `active: true`. The Danger zone panel further down carries
+                  the detail; up here it only has to be the first thing the
+                  page says about the experiment. */}
+              {data.finalized ? (
+                <StatusIndicator status="ok" label="Finalized" />
+              ) : (
+                <StatusIndicator
+                  status={data.active ? "ok" : "neutral"}
+                  label={data.active ? "Accepting data" : "Not accepting data"}
+                />
+              )}
               <Text fontSize="sm" color="fg.muted">
                 {plural(data.sessions || 0, "completed session")}
               </Text>

--- a/pages/admin/[experiment_id].js
+++ b/pages/admin/[experiment_id].js
@@ -36,6 +36,7 @@ import SettingsSection from "../../components/ui/SettingsSection";
 import GuidanceLine from "../../components/ui/GuidanceLine";
 import StatusIndicator from "../../components/ui/StatusIndicator";
 import SectionPanel from "../../components/dashboard/SectionPanel";
+import { STORAGE_PROVIDERS } from "../../lib/provider-config";
 
 export async function getServerSideProps() {
   return { props: {} };
@@ -401,7 +402,28 @@ function ExperimentPageDashboard({ experiment_id }) {
         </SettingsSection>
       </Box>
 
-      {/* mt={16}, not mt={10}: the extra air is the signal that the next
+      {/* Offered only where finalizing is a thing that can happen.
+
+          Finalizing merges a study into one archive to stay under a
+          provider's file-count ceiling, and Zenodo is the only provider that
+          has one -- finalization.ts refuses everything else with
+          `not-eligible`. Until now the section rendered for every provider,
+          so a Drive or Dataverse researcher was shown a red Danger zone
+          promising to stop their experiment "forever", walked through a
+          confirmation dialog about permanently deleting their files, and
+          only then told it could not be done. Offering an irreversible
+          action that was never available is worse than not offering it.
+
+          The whole section goes, not just the button: finalization is
+          currently its only entry, and an empty Danger zone is its own kind
+          of alarming.
+
+          `supportsFinalizing` is the frontend's presentational mirror of the
+          adapter's `capabilities.maxFileCount` (lib/provider-config.js); the
+          server remains authoritative, and a legacy OSF experiment -- absent
+          from that map entirely -- correctly falls through to false. */}
+      {STORAGE_PROVIDERS[data.storageProvider]?.supportsFinalizing && (
+        /* mt={16}, not mt={10}: the extra air is the signal that the next
           section plays by different rules.
 
           "Danger zone", not "Finalize", for parity with
@@ -411,31 +433,32 @@ function ExperimentPageDashboard({ experiment_id }) {
           becomes an <h3> INSIDE it: it is currently the only irreversible
           action here, and naming it as one entry in a zone rather than as the
           zone itself leaves room for the next one (experiment deletion)
-          without another rename. */}
-      <Box mt={16} w="100%">
-        <SettingsSection
-          title="Danger zone"
-          description="Actions here are permanent. Nothing in this section can be undone."
-          variant="danger"
-        >
-          <Stack gap={3} align="flex-start">
-            <Heading as="h3" size="sm" fontWeight="semibold" color="fg">
-              Finalize
-            </Heading>
-            {/* Kept verbatim from the old section description. DESIGN.md
+          without another rename. */
+        <Box mt={16} w="100%">
+          <SettingsSection
+            title="Danger zone"
+            description="Actions here are permanent. Nothing in this section can be undone."
+            variant="danger"
+          >
+            <Stack gap={3} align="flex-start">
+              <Heading as="h3" size="sm" fontWeight="semibold" color="fg">
+                Finalize
+              </Heading>
+              {/* Kept verbatim from the old section description. DESIGN.md
                 §8.10: the confirmation dialog must not hold the only copy of
                 the consequence, so it has to be stated here, before the
                 button that opens it. */}
-            <GuidanceLine>
-              Finalizing merges every file into a single archive on your
-              storage provider, permanently deletes the loose files it was
-              built from, and stops this experiment from accepting data
-              forever. This cannot be undone.
-            </GuidanceLine>
-            <FinalizeControl data={data} experimentId={experiment_id} />
-          </Stack>
-        </SettingsSection>
-      </Box>
+              <GuidanceLine>
+                Finalizing merges every file into a single archive on your
+                storage provider, permanently deletes the loose files it was
+                built from, and stops this experiment from accepting data
+                forever. This cannot be undone.
+              </GuidanceLine>
+              <FinalizeControl data={data} experimentId={experiment_id} />
+            </Stack>
+          </SettingsSection>
+        </Box>
+      )}
     </VStack>
   );
 }

--- a/pages/admin/index.js
+++ b/pages/admin/index.js
@@ -194,11 +194,24 @@ function ExperimentItem({ exp }) {
           <HStack gap={[2, 4]} flexWrap="wrap" rowGap={2}>
             {/* One status per row, stated in words. "Data / Base64 /
                 Conditions / Metadata" were feature NAMES, not statuses --
-                whether each was on lived in the dot's hue. */}
-            <StatusIndicator
-              status={exp.active ? "ok" : "neutral"}
-              label={exp.active ? "Collecting data" : "Not collecting"}
-            />
+                whether each was on lived in the dot's hue.
+
+                Finalized REPLACES the collecting/not-collecting line rather
+                than joining it. Two reasons. "Not collecting" is the weaker
+                and more reversible-sounding of the two facts, so leading with
+                it buries the one that matters. And an experiment finalized
+                before finalization started switching `active` off still holds
+                `active: true` in Firestore -- reading `finalized` first is
+                what stops those rows from advertising "Collecting data" on a
+                sealed archive. */}
+            {exp.finalized ? (
+              <StatusIndicator status="ok" label="Finalized" />
+            ) : (
+              <StatusIndicator
+                status={exp.active ? "ok" : "neutral"}
+                label={exp.active ? "Collecting data" : "Not collecting"}
+              />
+            )}
             {exp.sessions > 0 && (
               <Text fontSize="sm" color="fg.muted">
                 {exp.sessions} {exp.sessions === 1 ? "session" : "sessions"}

--- a/pages/admin/index.js
+++ b/pages/admin/index.js
@@ -161,8 +161,21 @@ function featureSummary(exp) {
   return `${on.slice(0, -1).join(", ")} and ${on[on.length - 1]} on`;
 }
 
+// Which service actually holds this experiment's data. Worth a line on a list
+// of thirty studies: a lab mid-migration has experiments on two or three
+// providers at once, and nothing in a title says which. Legacy OSF
+// experiments are absent from STORAGE_PROVIDERS by design (they keep their
+// bespoke surfaces), so they are named separately rather than falling through
+// to nothing -- those are exactly the rows whose location matters most while
+// OSF is being retired.
+function providerName(exp) {
+  if (isLegacyOsfExperiment(exp)) return "OSF";
+  return STORAGE_PROVIDERS[exp.storageProvider]?.name ?? null;
+}
+
 function ExperimentItem({ exp }) {
   const features = featureSummary(exp);
+  const provider = providerName(exp);
 
   return (
     <Box
@@ -211,6 +224,15 @@ function ExperimentItem({ exp }) {
                 status={exp.active ? "ok" : "neutral"}
                 label={exp.active ? "Collecting data" : "Not collecting"}
               />
+            )}
+            {/* "Stored on X", not a bare "Zenodo". Every other item on this
+                line says what it is ("42 sessions", "base64 uploads on"); a
+                lone proper noun among them would be the only one the reader
+                has to work out. */}
+            {provider && (
+              <Text fontSize="sm" color="fg.muted">
+                Stored on {provider}
+              </Text>
             )}
             {exp.sessions > 0 && (
               <Text fontSize="sm" color="fg.muted">

--- a/pages/docs/data/finalizing.js
+++ b/pages/docs/data/finalizing.js
@@ -141,10 +141,16 @@ export default function FinishingAStudyPage() {
         <Text maxW="70ch">Once an experiment is finalized:</Text>
         <Box as="ul" pl={5} listStyleType="disc" maxW="70ch">
           <Box as="li" mb={2}>
+            Data collection is switched off for you. Finalizing turns{" "}
+            <em>Accept new data</em> and <em>Accept base64 file uploads</em>{" "}
+            off in the same write that seals the record, and the dashboard
+            locks both switches from then on.
+          </Box>
+          <Box as="li" mb={2}>
             Every submission is rejected with{" "}
-            <Code>EXPERIMENT_FINALIZED</Code>, whether or not the experiment is
-            still switched on. That check runs ahead of the active switch, so
-            turning the experiment back on does not reopen it.
+            <Code>EXPERIMENT_FINALIZED</Code> regardless. That check runs ahead
+            of the active switch, so the experiment stays closed even if
+            something puts those flags back on outside the dashboard.
           </Box>
           <Box as="li" mb={2}>
             Base64 submissions are rejected on the same grounds.

--- a/pages/docs/data/finalizing.js
+++ b/pages/docs/data/finalizing.js
@@ -86,11 +86,10 @@ export default function FinishingAStudyPage() {
           </Box>
         </Box>
         <Text maxW="70ch">
-          Clicking Finalize on an experiment that is not eligible does nothing
-          destructive — the dashboard reports{" "}
-          <em>&ldquo;This experiment can&apos;t be finalized&rdquo;</em> and
-          your files are untouched. On Google Drive and Dataverse, switching the
-          experiment off when you are done is the equivalent step.
+          The dashboard only offers finalizing where it applies: on Google
+          Drive, Dataverse and OSF experiments the Finalize section is not
+          shown at all, rather than offered and then refused. Switching the
+          experiment off when you are done is the equivalent step there.
         </Text>
         <GuidanceLine href="/docs/providers" linkText="Choosing a provider">
           The per-provider differences behind this are summarized here.


### PR DESCRIPTION
## The problem

Finalizing seals a dataset into one archive and deletes the loose files, and the submission guards in `api-data.ts` / `api-base64.ts` already reject everything on `finalized` alone — *ahead* of the active switch. But nothing told the dashboard.

A finalized experiment kept `active: true`, so its own settings page drew a green **"Accepting data"** switch on a record that no longer accepted anything, and the experiment list said **"Collecting data"**. The researcher's dashboard was the least accurate thing about their study — and the switch was still flippable, doing nothing.

## Backend

`markFinalized` (`functions/src/finalization.ts`) now writes `active: false` and `activeBase64: false` in the **same** update as `finalized: true`, so no reader ever sees a snapshot where the two disagree.

`activeConditionAssignment` is deliberately left alone: `api-condition.ts` has no `finalized` check by design (documented in `/docs/data/finalizing`), and switching it off here would be finalization claiming a behaviour change it does not implement.

## Frontend — three surfaces

- **Experiment list** (`pages/admin/index.js`) — a `Finalized` StatusIndicator **replaces** the collecting/not-collecting line rather than joining it. "Not collecting" is the weaker and more reversible-sounding of the two facts, so leading with it buries the one that matters.
- **Experiment page header** (`pages/admin/[experiment_id].js`) — the same substitution in the status row under the title.
- **Data collection settings** (`components/dashboard/ExperimentActive.js`) — "Accept new data" and "Accept base64 file uploads" render off and locked, each with a description naming finalizing as the reason. Same shape as `MetadataControl`'s `locked`: a control that is off with no explanation reads as broken.

All three read `finalized` **first**. That is what stops experiments finalized *before* this change — which still hold `active: true` — from advertising that they are collecting.

## Legacy documents

No migration script. They display correctly everywhere anyway (the `finalized`-first reads above, plus `checked={data.active && !finalized}` on the two locked rows), and the server was already rejecting their submissions, so the stale flag was only cosmetic.

The affected documents were adjusted by hand on `datapipe-test` instead, on 2026-08-26. There were exactly two, both Zenodo:

| Experiment | Was | Now |
|---|---|---|
| `XRd0ts331N3x` — DataPipe Test 1 | `active: true`, `activeBase64: true` | both `false` |
| `rKbju7ygcrdO` — DataPipe Test 3 | `active: true` | `false` |

`activeConditionAssignment` was left as it was on both (`true` on Test 1), matching what `markFinalized` now does. No production experiment has ever been finalizable, so `osf-relay` needs nothing.

## Docs

The "It cannot be undone" list said submissions are rejected "whether or not the experiment is still switched on" — true of the server guard, now misleading about what finalizing itself does to those switches. Updated to state that finalizing switches both off and locks them, with the server guard restated as the backstop.

## Tests

- `__tests__/finalized-experiment.test.jsx` — 10 new tests across all three surfaces, each including the legacy `active: true` shape.
- `functions/src/__tests__/finalization-emulator.test.js` — 2 new tests pinning the write, and pinning that condition assignment survives it. Full suite: 36/36.

Locally the 5 `functions/src/__tests__` suites that need the full emulator set fail the same way they do on `test`; CI runs everything inside `firebase emulators:exec`, so they're covered there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SHZNijLwUhn26yCbYbn1UN
