### PR TITLE
Required fields: show the parsed list, don't ask them to imagine it

### DIFF
--- a/__tests__/experiment-validation.test.jsx
+++ b/__tests__/experiment-validation.test.jsx
@@ -1,0 +1,162 @@
+import {
+  act,
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+} from "@testing-library/react";
+import { ChakraProvider } from "@chakra-ui/react";
+import { system } from "../lib/theme";
+import "@testing-library/jest-dom";
+
+import ExperimentValidation from "../components/dashboard/ExperimentValidation";
+
+const setDocMock = jest.fn(() => Promise.resolve());
+jest.mock("firebase/firestore", () => ({
+  setDoc: (...args) => setDocMock(...args),
+  doc: jest.fn(() => ({})),
+}));
+jest.mock("../lib/firebase", () => ({ db: {} }));
+
+function renderWithChakra(ui) {
+  return render(<ChakraProvider value={system}>{ui}</ChakraProvider>);
+}
+
+const experiment = (overrides = {}) => ({
+  id: "exp-1",
+  useValidation: true,
+  allowJSON: true,
+  allowCSV: true,
+  requiredFields: ["trial_type"],
+  ...overrides,
+});
+
+const focusFieldInput = async () => {
+  const input = screen.getByRole("textbox");
+  await act(async () => {
+    input.focus();
+  });
+  return input;
+};
+
+const typeAndCommit = (input, text) => {
+  fireEvent.input(input, {
+    target: { value: text },
+    inputType: "insertText",
+  });
+  fireEvent.keyDown(input, { key: "Enter" });
+};
+
+beforeEach(() => {
+  setDocMock.mockClear();
+});
+
+describe("ExperimentValidation — required fields", () => {
+  it("shows the stored list as pills", () => {
+    renderWithChakra(
+      <ExperimentValidation
+        data={experiment({ requiredFields: ["trial_type", "rt"] })}
+      />
+    );
+    expect(screen.getByText("trial_type")).toBeInTheDocument();
+    expect(screen.getByText("rt")).toBeInTheDocument();
+  });
+
+  it("does not write on mount", async () => {
+    renderWithChakra(<ExperimentValidation data={experiment()} />);
+    await act(async () => {});
+    expect(setDocMock).not.toHaveBeenCalled();
+  });
+
+  it("saves the list when a field is added", async () => {
+    renderWithChakra(<ExperimentValidation data={experiment()} />);
+
+    typeAndCommit(await focusFieldInput(), "rt");
+
+    await waitFor(() => expect(setDocMock).toHaveBeenCalledTimes(1));
+    expect(setDocMock.mock.calls[0][1]).toEqual({
+      allowJSON: true,
+      allowCSV: true,
+      requiredFields: ["trial_type", "rt"],
+    });
+  });
+
+  it("saves the list when a field is removed", async () => {
+    renderWithChakra(
+      <ExperimentValidation
+        data={experiment({ requiredFields: ["trial_type", "rt"] })}
+      />
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /remove field trial_type/i })
+    );
+
+    await waitFor(() => expect(setDocMock).toHaveBeenCalledTimes(1));
+    expect(setDocMock.mock.calls[0][1].requiredFields).toEqual(["rt"]);
+  });
+
+  it("saves the trimmed name, not what was typed", async () => {
+    // The whole point. `" rt "` in the document is a field no submission has,
+    // and the resulting 400 does not say so.
+    renderWithChakra(
+      <ExperimentValidation data={experiment({ requiredFields: [] })} />
+    );
+
+    typeAndCommit(await focusFieldInput(), "  rt  ");
+
+    await waitFor(() => expect(setDocMock).toHaveBeenCalledTimes(1));
+    expect(setDocMock.mock.calls[0][1].requiredFields).toEqual(["rt"]);
+  });
+
+  it("does not write when a duplicate is refused", async () => {
+    renderWithChakra(<ExperimentValidation data={experiment()} />);
+
+    typeAndCommit(await focusFieldInput(), "trial_type");
+    await act(async () => {});
+
+    expect(setDocMock).not.toHaveBeenCalled();
+    expect(screen.getByText(/already in the list/i)).toBeInTheDocument();
+  });
+
+  it("draws no pill for a legacy [\"\"] document", () => {
+    // Documents written by the old textarea can hold a single empty string. An
+    // empty pill has nothing to draw, so it would be a chip the researcher can
+    // neither see nor delete.
+    const { container } = renderWithChakra(
+      <ExperimentValidation data={experiment({ requiredFields: [""] })} />
+    );
+    expect(
+      container.querySelectorAll("[data-part='item-preview']")
+    ).toHaveLength(0);
+  });
+
+  it("reverts the list and explains when the write fails", async () => {
+    setDocMock.mockImplementationOnce(() => Promise.reject(new Error("nope")));
+    const consoleError = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    renderWithChakra(<ExperimentValidation data={experiment()} />);
+
+    typeAndCommit(await focusFieldInput(), "rt");
+
+    await waitFor(() =>
+      expect(screen.getByText(/could not save your validation rules/i))
+        .toBeInTheDocument()
+    );
+    // The pill has to go with the message: a list that still shows `rt` while
+    // Firestore does not hold it is the lie SettingsRow exists to prevent.
+    expect(screen.queryByText("rt")).not.toBeInTheDocument();
+    expect(screen.getByText("trial_type")).toBeInTheDocument();
+
+    consoleError.mockRestore();
+  });
+
+  it("hides the required-fields control when validation is off", () => {
+    renderWithChakra(
+      <ExperimentValidation data={experiment({ useValidation: false })} />
+    );
+    expect(screen.queryByText("Required fields")).not.toBeInTheDocument();
+  });
+});

--- a/__tests__/tag-list-input.test.jsx
+++ b/__tests__/tag-list-input.test.jsx
@@ -1,0 +1,321 @@
+import {
+  act,
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+} from "@testing-library/react";
+import { ChakraProvider } from "@chakra-ui/react";
+import { useState } from "react";
+import { system } from "../lib/theme";
+import "@testing-library/jest-dom";
+
+import TagListInput, {
+  normalizeTag,
+  normalizeList,
+} from "../components/ui/TagListInput";
+
+// These names are compared with `Array.includes` against JSON keys and CSV
+// header cells (functions/src/validate-*.ts). The comparison is exact, the
+// server trims nothing, and a rejected submission is a bare 400 that does not
+// say which field failed. So every case below is a shape that used to be
+// enterable and would have silently rejected every participant.
+describe("normalizeTag", () => {
+  it("trims surrounding whitespace", () => {
+    expect(normalizeTag("  trial_type  ")).toBe("trial_type");
+  });
+
+  it("keeps whitespace inside a name", () => {
+    // A JSON key may legally contain a space. Collapsing it would break a
+    // list that was correct.
+    expect(normalizeTag("  response time  ")).toBe("response time");
+  });
+
+  it("strips quotes pasted from source code", () => {
+    expect(normalizeTag('"trial_type"')).toBe("trial_type");
+    expect(normalizeTag("'rt'")).toBe("rt");
+    expect(normalizeTag("`rt`")).toBe("rt");
+  });
+
+  it("strips curly quotes pasted from a document", () => {
+    expect(normalizeTag("“trial_type”")).toBe("trial_type");
+    expect(normalizeTag("‘rt’")).toBe("rt");
+  });
+
+  it("strips nested quoting", () => {
+    expect(normalizeTag("'\"rt\"'")).toBe("rt");
+  });
+
+  it("leaves an unbalanced quote alone", () => {
+    // A name that genuinely starts with a quote is absurd, but guessing is
+    // worse than leaving it visible: the pill shows exactly what will be
+    // compared, so the researcher can see it is wrong.
+    expect(normalizeTag('"rt')).toBe('"rt');
+  });
+
+  it("returns empty for whitespace and for non-strings", () => {
+    expect(normalizeTag("   ")).toBe("");
+    expect(normalizeTag("")).toBe("");
+    expect(normalizeTag(undefined)).toBe("");
+    expect(normalizeTag(null)).toBe("");
+    expect(normalizeTag(7)).toBe("");
+  });
+});
+
+describe("normalizeList", () => {
+  it("drops the empty entry a trailing comma leaves behind", () => {
+    // This is the `[""]` that reached live experiment documents and made both
+    // validators reject every submission until they were taught to filter it.
+    expect(normalizeList(["trial_type", ""])).toEqual(["trial_type"]);
+    expect(normalizeList([""])).toEqual([]);
+  });
+
+  it("drops duplicates, keeping first position", () => {
+    expect(normalizeList(["rt", "trial_type", "rt"])).toEqual([
+      "rt",
+      "trial_type",
+    ]);
+  });
+
+  it("treats values that normalize alike as duplicates", () => {
+    expect(normalizeList(["rt", ' "rt" '])).toEqual(["rt"]);
+  });
+
+  it("tolerates a missing list", () => {
+    expect(normalizeList(undefined)).toEqual([]);
+    expect(normalizeList(null)).toEqual([]);
+  });
+});
+
+function Harness({ initial = [], onChange = () => {}, ...rest }) {
+  const [value, setValue] = useState(initial);
+  return (
+    <ChakraProvider value={system}>
+      <TagListInput
+        label="Required fields"
+        itemNoun="field"
+        value={value}
+        onChange={(next) => {
+          setValue(next);
+          onChange(next);
+        }}
+        helperText="Every submission must contain all of these."
+        {...rest}
+      />
+    </ChakraProvider>
+  );
+}
+
+// The machine only handles input and key events while it is in its
+// `focused:input` state, so every interaction focuses the field first, exactly
+// as a researcher's would. Two details this has to get right or every
+// interaction silently does nothing:
+//
+//   `input.focus()`, not `fireEvent.focus` -- React delegates `onFocus` from
+//   the bubbling `focusin`, which a synthetic non-bubbling `focus` never
+//   produces; and
+//
+//   the await -- the machine's FOCUS transition is queued in a microtask, so
+//   anything typed in the same synchronous turn arrives while it is still
+//   `idle` and is dropped.
+const focusInput = async () => {
+  const input = screen.getByRole("textbox");
+  await act(async () => {
+    input.focus();
+  });
+  return input;
+};
+
+// The machine listens on `onInput`, not `onChange`, and reads `inputType` off
+// the native event to tell a paste from a keystroke.
+const typeInto = (input, text, inputType = "insertText") => {
+  fireEvent.input(input, { target: { value: text }, inputType });
+};
+
+const typeAndCommit = (input, text) => {
+  typeInto(input, text);
+  fireEvent.keyDown(input, { key: "Enter" });
+};
+
+// Committing with the delimiter is not a keydown: the machine sees a comma at
+// the END of the input's value and commits whatever it had recorded before it.
+// So the comma has to arrive as its own event, the way a real keystroke does --
+// send "rt," in one go and the machine commits the empty string it still holds.
+const typeWithComma = (input, text) => {
+  typeInto(input, text);
+  typeInto(input, `${text},`);
+};
+
+// A paste is the same `input` event carrying `inputType: "insertFromPaste"`,
+// which is the only thing that tells the machine to split on the delimiter.
+const pasteInto = (input, text) => {
+  typeInto(input, text, "insertFromPaste");
+};
+
+describe("TagListInput", () => {
+  it("renders one pill per committed value", () => {
+    render(<Harness initial={["trial_type", "rt"]} />);
+    expect(screen.getByText("trial_type")).toBeInTheDocument();
+    expect(screen.getByText("rt")).toBeInTheDocument();
+  });
+
+  it("turns a typed name into a pill on Enter", async () => {
+    const onChange = jest.fn();
+    render(<Harness onChange={onChange} />);
+
+    typeAndCommit(await focusInput(), "trial_type");
+
+    await waitFor(() => expect(onChange).toHaveBeenCalledWith(["trial_type"]));
+    expect(screen.getByText("trial_type")).toBeInTheDocument();
+  });
+
+  it("trims before it commits, so the pill is what the server compares", async () => {
+    const onChange = jest.fn();
+    render(<Harness onChange={onChange} />);
+
+    typeAndCommit(await focusInput(), "  trial_type  ");
+
+    await waitFor(() => expect(onChange).toHaveBeenCalledWith(["trial_type"]));
+  });
+
+  it("strips quotes pasted around a name", async () => {
+    const onChange = jest.fn();
+    render(<Harness onChange={onChange} />);
+
+    typeAndCommit(await focusInput(), '"trial_type"');
+
+    await waitFor(() => expect(onChange).toHaveBeenCalledWith(["trial_type"]));
+  });
+
+  it("refuses a duplicate and says which name it was", async () => {
+    const onChange = jest.fn();
+    render(<Harness initial={["trial_type"]} onChange={onChange} />);
+
+    typeAndCommit(await focusInput(), "trial_type");
+
+    await waitFor(() =>
+      expect(screen.getByText(/already in the list/i)).toBeInTheDocument()
+    );
+    // Rejected, not silently swallowed into a no-op write.
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("never commits a whitespace-only entry", async () => {
+    // The `[""]` that reached live documents came in through a trailing comma
+    // in the old textarea. There is no route to it here: the machine refuses
+    // to add from an empty-after-trim input, and `normalizeList` would drop it
+    // even if one got through.
+    const onChange = jest.fn();
+    const { container } = render(<Harness onChange={onChange} />);
+
+    typeAndCommit(await focusInput(), "   ");
+    await act(async () => {});
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(
+      container.querySelectorAll("[data-part='item-preview']")
+    ).toHaveLength(0);
+  });
+
+  it("replaces the helper text with the notice rather than adding a line", async () => {
+    render(<Harness initial={["rt"]} />);
+    expect(
+      screen.getByText("Every submission must contain all of these.")
+    ).toBeInTheDocument();
+
+    typeAndCommit(await focusInput(), "rt");
+
+    await waitFor(() =>
+      expect(screen.getByText(/already in the list/i)).toBeInTheDocument()
+    );
+    expect(
+      screen.queryByText("Every submission must contain all of these.")
+    ).not.toBeInTheDocument();
+  });
+
+  it("commits on comma as well as Enter", async () => {
+    const onChange = jest.fn();
+    render(<Harness onChange={onChange} />);
+
+    typeWithComma(await focusInput(), "rt");
+
+    await waitFor(() => expect(onChange).toHaveBeenCalledWith(["rt"]));
+  });
+
+  it("splits a pasted comma-separated list into separate pills", async () => {
+    const onChange = jest.fn();
+    render(<Harness onChange={onChange} />);
+
+    pasteInto(await focusInput(), "trial_type, rt, subject_id");
+
+    await waitFor(() =>
+      expect(onChange).toHaveBeenCalledWith(["trial_type", "rt", "subject_id"])
+    );
+  });
+
+  it("drops the empty a pasted trailing comma leaves behind", async () => {
+    const onChange = jest.fn();
+    render(<Harness onChange={onChange} />);
+
+    pasteInto(await focusInput(), "trial_type, rt,");
+
+    await waitFor(() =>
+      expect(onChange).toHaveBeenCalledWith(["trial_type", "rt"])
+    );
+    expect(onChange).not.toHaveBeenCalledWith(["trial_type", "rt", ""]);
+  });
+
+  it("commits a half-typed name when the researcher clicks away", async () => {
+    // `blurBehavior="add"`. The old textarea parsed on blur, so a name typed
+    // and abandoned still counted; dropping it here would be a regression, and
+    // a silent one -- the field would simply be missing next time they looked.
+    // The machine takes this from interact-outside, not from the input's own
+    // blur, so the test has to leave the control the way a person does.
+    const onChange = jest.fn();
+    render(
+      <>
+        <Harness onChange={onChange} />
+        <button type="button">elsewhere</button>
+      </>
+    );
+
+    typeInto(await focusInput(), "subject_id");
+    await act(async () => {
+      // `focusin`, not a synthetic pointerdown: interact-outside only treats a
+      // pointerdown as an interaction once the matching `click` arrives, and
+      // it arms its pointer listeners on a timer. Moving focus out is the
+      // route it handles immediately, and it is what Tab does anyway.
+      screen.getByRole("button", { name: "elsewhere" }).focus();
+    });
+
+    await waitFor(() => expect(onChange).toHaveBeenCalledWith(["subject_id"]));
+  });
+
+  it("gives every remove button a name that says what it removes", () => {
+    render(<Harness initial={["trial_type", "rt"]} />);
+    expect(
+      screen.getByRole("button", { name: /remove field trial_type/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /remove field rt/i })
+    ).toBeInTheDocument();
+  });
+
+  it("removes a pill when its button is pressed", async () => {
+    const onChange = jest.fn();
+    render(<Harness initial={["trial_type", "rt"]} onChange={onChange} />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /remove field trial_type/i })
+    );
+
+    await waitFor(() => expect(onChange).toHaveBeenCalledWith(["rt"]));
+  });
+
+  it("normalizes a list handed to it, so a legacy [\"\"] draws no pill", () => {
+    const { container } = render(<Harness initial={["trial_type", ""]} />);
+    expect(
+      container.querySelectorAll("[data-part='item-preview']")
+    ).toHaveLength(1);
+  });
+});

--- a/components/dashboard/ExperimentValidation.js
+++ b/components/dashboard/ExperimentValidation.js
@@ -1,11 +1,4 @@
-import {
-  Field,
-  HStack,
-  Stack,
-  Textarea,
-  Checkbox,
-  CheckboxGroup,
-} from "@chakra-ui/react";
+import { HStack, Stack, Checkbox, CheckboxGroup } from "@chakra-ui/react";
 
 import { useEffect, useRef, useState } from "react";
 
@@ -16,6 +9,7 @@ import SettingsRow, {
   SavedFlag,
   useTrackedSave,
 } from "../ui/SettingsRow";
+import TagListInput, { normalizeList } from "../ui/TagListInput";
 import { SwitchTable } from "./SectionPanel";
 
 function writeExperiment(expId, fields) {
@@ -27,13 +21,18 @@ export default function ExperimentValidation({ data }) {
   if (data.allowCSV) validationOptionsArray.push("csv");
   if (data.allowJSON) validationOptionsArray.push("json");
 
-  const requiredFieldsText = data.requiredFields.join(", ");
+  // Normalized on the way in as well as on the way out. Live documents can
+  // hold `[""]` -- the textarea this replaced stored an empty box that way
+  // before it learned to filter, and both validators still carry a filter for
+  // it (functions/src/validate-json.ts). An empty pill has nothing to draw, so
+  // rendering the raw array would produce an invisible chip the researcher
+  // could neither see nor delete.
+  const initialFields = normalizeList(data.requiredFields);
 
   const [validationSettings, setValidationSettings] = useState(
     validationOptionsArray
   );
-  const [requiredFields, setRequiredFields] = useState(requiredFieldsText);
-  const [fieldsArray, setFieldsArray] = useState(data.requiredFields);
+  const [fieldsArray, setFieldsArray] = useState(initialFields);
   // Mirrors the switch so the dependent controls appear the instant it is
   // flipped rather than after the Firestore round trip. SettingsRow calls
   // this again with the previous value if the write fails, so the revealed
@@ -53,7 +52,7 @@ export default function ExperimentValidation({ data }) {
   // in force. Seeded from the document and updated only after a write lands.
   const committed = useRef({
     validationSettings: validationOptionsArray,
-    fieldsArray: data.requiredFields,
+    fieldsArray: initialFields,
   });
 
   // The old version of this effect had two defects. It listed `data` in its
@@ -102,7 +101,6 @@ export default function ExperimentValidation({ data }) {
       () => {
         setValidationSettings(previous.validationSettings);
         setFieldsArray(previous.fieldsArray);
-        setRequiredFields(previous.fieldsArray.join(", "));
       }
     );
     // detailSave.save is stable (useCallback over a constant message), and
@@ -172,37 +170,29 @@ export default function ExperimentValidation({ data }) {
                 savedLabel="Validation rules saved"
               />
             </HStack>
-            <Field.Root>
-              <Field.Label>Required fields</Field.Label>
-              <Textarea
-                value={requiredFields}
-                onChange={(e) => {
-                  setRequiredFields(e.target.value);
-                }}
-                onBlur={() => {
-                  const parsed = requiredFields
-                    .split(",")
-                    .map((field) => field.trim())
-                    .filter(Boolean);
-                  // Only commit a genuinely different list. `split` returns a
-                  // fresh array every blur, and the save effect is keyed to
-                  // `fieldsArray` by identity -- so without this, tabbing
-                  // through the field without editing it wrote to Firestore.
-                  if (parsed.join(",") !== fieldsArray.join(",")) {
-                    setFieldsArray(parsed);
-                  }
-                }}
-              />
-              {/* `color="gray"` here was the CSS named color #808080, which
-                  measures 4.19:1 on the dark page -- below the 4.5:1 body
-                  floor, and a raw literal besides (DESIGN.md §8.5). Dropping
-                  the prop lets the Field recipe's own fg.muted apply: 8.30:1
-                  light / 9.14:1 dark. */}
-              <Field.HelperText>
-                A comma-separated list of column names that every submission
-                must contain.
-              </Field.HelperText>
-            </Field.Root>
+            {/* The old control was a Textarea holding a comma-separated
+                string, parsed on blur. Two things were wrong with it, and only
+                one was cosmetic. The cosmetic one: `color="gray"` on the
+                helper text resolved to the CSS named color #808080 (4.19:1 on
+                the dark page, and a raw literal besides -- DESIGN.md §8.5).
+                The real one: the researcher could not see what the parse had
+                produced. These names are compared exactly against JSON keys
+                and CSV headers, a mismatch is an unexplained 400, and a
+                trailing comma or a pasted quote is invisible in a textarea.
+                TagListInput shows the parsed result instead of asking the
+                researcher to imagine it. */}
+            <TagListInput
+              label="Required fields"
+              itemNoun="field"
+              value={fieldsArray}
+              onChange={setFieldsArray}
+              placeholder="trial_type"
+              helperText={
+                fieldsArray.length === 0
+                  ? "No required fields: DataPipe will check only that a submission is well-formed. Type a column name and press Enter or comma to require one."
+                  : "Every submission must contain all of these. Type a column name and press Enter or comma to add another."
+              }
+            />
             <SaveError error={detailSave.error} />
           </Stack>
         )}

--- a/components/ui/TagListInput.js
+++ b/components/ui/TagListInput.js
@@ -1,0 +1,380 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { TagsInput, Text } from "@chakra-ui/react";
+import { X } from "lucide-react";
+
+/**
+ * TagListInput
+ *
+ * A short list of exact string values, entered one at a time and rendered as
+ * pills. Replaces the "type a comma-separated list into a textarea" pattern.
+ *
+ * ---------------------------------------------------------------------------
+ * Why a pill, and not a textarea
+ * ---------------------------------------------------------------------------
+ * The list this was built for is `requiredFields` on an experiment: names that
+ * are compared with `includes` against JSON keys and CSV header cells
+ * (`functions/src/validate-json.ts`, `validate-csv.ts`). The comparison is
+ * exact. There is no fuzzy match, no trim on the server, and no error message
+ * that names the field that failed -- a rejected submission is a bare 400
+ * `INVALID_DATA` (pages/docs/experiments/validation.js). So a stray space, a
+ * pasted quote, or a trailing comma does not produce a warning; it produces an
+ * experiment that silently rejects every participant.
+ *
+ * A textarea cannot show that. `trial_type , rt` and `trial_type,rt` look the
+ * same at a glance, and the empty string that a trailing comma leaves behind
+ * is invisible by definition -- that one shipped, and `[""]` in a live
+ * experiment document is why both validators now carry a filter for it.
+ *
+ * A pill is the fix because it is a *receipt*. The moment a name becomes a
+ * pill, the researcher can see exactly what will be compared: its boundaries
+ * are drawn, its whitespace is gone, and an empty entry has nothing to draw so
+ * it cannot appear at all. Text that has not yet become a pill is still in the
+ * input, visibly pending. Nothing is ambiguous.
+ *
+ * ---------------------------------------------------------------------------
+ * Normalization happens on the way OUT, not on the way in
+ * ---------------------------------------------------------------------------
+ * There are four routes a value can take into the list -- typed + Enter, typed
+ * + comma, pasted (split on commas), and edited in place on an existing pill --
+ * and Chakra's underlying machine treats them as four different code paths.
+ * Guarding them one by one is how you end up guarding three of them.
+ *
+ * So `normalizeList` runs on every committed value, whatever produced it, and
+ * the caller only ever receives a list that is trimmed, unquoted, non-empty
+ * and de-duplicated. `validate` below is *not* where correctness lives; it
+ * exists only so that a rejected keystroke can say why, instead of the pill
+ * quietly failing to appear.
+ *
+ * ---------------------------------------------------------------------------
+ * The message slot does not move the page
+ * ---------------------------------------------------------------------------
+ * Same rule SettingsRow's SavedFlag follows: feedback that appears and
+ * disappears must not reflow its neighbours. There is one line under the
+ * control, and the rejection notice *replaces* the helper text in it rather
+ * than mounting below it, then restores itself. Nothing below the field moves.
+ *
+ * ---------------------------------------------------------------------------
+ * Deviations from Chakra's stock `tagsInput` recipe, and why
+ * ---------------------------------------------------------------------------
+ * - `itemDeleteTrigger` ships `opacity: 0.4` at rest. A 40%-opacity glyph on a
+ *   tinted fill is nowhere near the 3:1 WCAG 1.4.11 floor, and it is the
+ *   control that removes a rule from a live experiment. Full opacity,
+ *   `fg.muted`.
+ * - That same trigger ships no focus ring at all (the recipe gives one to
+ *   `clearTrigger` and forgets the per-item one). DESIGN.md §5 requires a ring
+ *   on *every* interactive element including icon-only ones; §8.8 bans going
+ *   without. Added.
+ * - `itemPreview` fills with `colorPalette.subtle` and no border. On the light
+ *   page that is `gray.100` inside a `bg` control -- 1.17:1, an edge that is
+ *   not there. DESIGN.md §1 settles this for panels ("must carry a border --
+ *   never rely on the fill alone") and a pill boundary is load-bearing in
+ *   exactly the same way: it is what separates one exact string from the next.
+ *   `bg.muted` + 1px `border`.
+ * - Focus on the control is Chakra's 1px outline; DESIGN.md §5 specifies 2px.
+ *
+ * @param {string} label - Required. The field's visible label.
+ * @param {string[]} value - The committed list. Controlled.
+ * @param {(next: string[]) => void} onChange - Called with a normalized list
+ *   whenever it changes. Never called with an unchanged list.
+ * @param {string} [helperText] - The steady-state line under the control.
+ * @param {string} [placeholder]
+ * @param {string} [itemNoun="item"] - Singular noun used in the accessible
+ *   announcements and the rejection notices ("field", "column", "tag").
+ * @param {boolean} [disabled=false]
+ * @param {boolean} [editable=true] - Allow editing a pill in place (Enter on a
+ *   highlighted pill, or double-click).
+ */
+
+// How long a rejection notice holds the message slot before the helper text
+// comes back. Matches SettingsRow's SAVED_VISIBLE_MS -- the two pieces of
+// transient feedback on this page should not linger for different durations.
+const NOTICE_VISIBLE_MS = 3000;
+
+// Quote characters a researcher can plausibly paste around a field name:
+// straight pairs from source code, curly pairs from a document or a chat
+// client, and backticks from a Markdown span. `"trial_type"` copied out of a
+// jsPsych example is a different string from `trial_type` as far as
+// `Array.includes` is concerned, and nothing downstream would ever tell them.
+const QUOTE_PAIRS = [
+  ['"', '"'],
+  ["'", "'"],
+  ["`", "`"],
+  ["“", "”"],
+  ["‘", "’"],
+];
+
+/**
+ * One value: trimmed, unwrapped, trimmed again. Returns "" for anything that
+ * is not a usable name, which is how empties are dropped downstream.
+ */
+export function normalizeTag(raw) {
+  if (typeof raw !== "string") return "";
+  let out = raw.trim();
+  // Loop rather than a single pass: `'"rt"'` is a real paste (a quoted string
+  // inside a quoted list) and one pass would leave the inner quotes on.
+  let stripped = true;
+  while (stripped && out.length >= 2) {
+    stripped = false;
+    for (const [open, close] of QUOTE_PAIRS) {
+      if (out.startsWith(open) && out.endsWith(close)) {
+        out = out.slice(1, -1).trim();
+        stripped = true;
+        break;
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * A whole list: every value normalized, empties dropped, duplicates dropped
+ * keeping first position. This is the only shape a caller ever sees.
+ */
+export function normalizeList(list) {
+  const seen = new Set();
+  const out = [];
+  for (const raw of list ?? []) {
+    const clean = normalizeTag(raw);
+    if (!clean || seen.has(clean)) continue;
+    seen.add(clean);
+    out.push(clean);
+  }
+  return out;
+}
+
+const sameList = (a, b) =>
+  a.length === b.length && a.every((item, i) => item === b[i]);
+
+export default function TagListInput({
+  label,
+  value,
+  onChange,
+  helperText,
+  placeholder,
+  itemNoun = "item",
+  disabled = false,
+  editable = true,
+}) {
+  if (process.env.NODE_ENV !== "production") {
+    if (!label) console.error("TagListInput: `label` is required.");
+    if (!onChange) console.error("TagListInput: `onChange` is required.");
+  }
+
+  const [notice, setNotice] = useState(null);
+
+  // The rejection notice is transient. Keyed on a counter rather than the
+  // message text so that the same rejection twice in a row restarts the timer
+  // instead of letting the first one's timeout clear the second one early.
+  const [noticeKey, setNoticeKey] = useState(0);
+  const mounted = useRef(true);
+  useEffect(() => {
+    mounted.current = true;
+    return () => {
+      mounted.current = false;
+    };
+  }, []);
+  useEffect(() => {
+    if (!notice) return undefined;
+    const timer = setTimeout(() => {
+      if (mounted.current) setNotice(null);
+    }, NOTICE_VISIBLE_MS);
+    return () => clearTimeout(timer);
+  }, [notice, noticeKey]);
+
+  const say = useCallback((message) => {
+    setNotice(message);
+    setNoticeKey((k) => k + 1);
+  }, []);
+
+  const committed = normalizeList(value);
+
+  const handleValueChange = useCallback(
+    (details) => {
+      const next = normalizeList(details.value);
+      // The machine hands back its own raw list, which may normalize to
+      // something identical to what the caller already holds -- pasting
+      // "rt," adds nothing once the empty is dropped. Writing in that case
+      // would be a Firestore round trip for no change.
+      if (sameList(next, committed)) return;
+      setNotice(null);
+      onChange(next);
+    },
+    [committed, onChange]
+  );
+
+  /**
+   * Runs before a value is accepted. Correctness does not depend on it --
+   * `handleValueChange` normalizes regardless -- but a pill that simply fails
+   * to appear is the silent failure this component exists to remove, so every
+   * rejection says why.
+   *
+   * `inputValue` is the whole pending string, and on the paste path it still
+   * contains the delimiters (the machine validates first and splits after), so
+   * this has to split for itself.
+   */
+  const validate = useCallback(
+    (details) => {
+      const pieces = normalizeList(details.inputValue.split(","));
+      if (pieces.length === 0) {
+        say(`That is not a ${itemNoun} name.`);
+        return false;
+      }
+      const existing = new Set(normalizeList(details.value));
+      const fresh = pieces.filter((piece) => !existing.has(piece));
+      if (fresh.length === 0) {
+        say(
+          pieces.length === 1
+            ? `"${pieces[0]}" is already in the list.`
+            : `Those ${itemNoun}s are already in the list.`
+        );
+        return false;
+      }
+      return true;
+    },
+    [itemNoun, say]
+  );
+
+  return (
+    <TagsInput.Root
+      value={committed}
+      onValueChange={handleValueChange}
+      validate={validate}
+      disabled={disabled}
+      editable={editable}
+      // Off by default in the machine, which would drop a pasted
+      // "trial_type, rt, subject_id" in as ONE pill containing commas -- a
+      // name no submission can ever have. Pasting a list is the single most
+      // likely way this field gets filled.
+      addOnPaste
+      // A half-typed name left in the input when focus leaves is a name the
+      // researcher meant to add; committing it is what the textarea did (it
+      // parsed on blur) and dropping it now would be a regression.
+      blurBehavior="add"
+      // The machine's stock strings say "tag", which means nothing here. These
+      // are what a screen-reader user hears from its live region, so they name
+      // the thing the researcher named it.
+      translations={{
+        clearTriggerLabel: `Remove all ${itemNoun}s`,
+        deleteTagTriggerLabel: (tag) => `Remove ${itemNoun} ${tag}`,
+        tagAdded: (tag) => `Added ${itemNoun} ${tag}`,
+        tagsPasted: (tags) => `Added ${tags.length} ${itemNoun}s`,
+        tagEdited: (tag) =>
+          `Editing ${itemNoun} ${tag}. Press enter to save or escape to cancel.`,
+        tagUpdated: (tag) => `${itemNoun} changed to ${tag}`,
+        tagDeleted: (tag) => `Removed ${itemNoun} ${tag}`,
+        tagSelected: (tag) =>
+          `${tag} selected. Press enter to edit, or backspace to remove.`,
+      }}
+    >
+      <TagsInput.Label
+        fontWeight="normal"
+        fontSize="md"
+        color="fg"
+        mb={1}
+        _disabled={{ opacity: 1, color: "fg.subtle" }}
+      >
+        {label}
+      </TagsInput.Label>
+
+      <TagsInput.Control
+        borderColor="border"
+        bg="bg"
+        // DESIGN.md §5: 2px ring. Chakra's recipe emits a 1px outline here and
+        // no offset. The control is not itself the focus target -- the input
+        // inside it is -- so the ring is driven by `_focusWithin`, which is
+        // what makes the whole pill box read as one field.
+        _focusWithin={{
+          borderColor: "brandGreen.focusRing",
+          outline: "2px solid",
+          outlineColor: "brandGreen.focusRing",
+          outlineOffset: "2px",
+        }}
+        // Chakra's `_disabled` on this slot is `opacity: 0.5`, which takes the
+        // pill text with it and drops it under the contrast floor. Grey the
+        // surface instead and leave the names readable -- a locked list still
+        // has to be legible, or the researcher cannot tell what it locked.
+        _disabled={{ opacity: 1, bg: "bg.subtle", cursor: "not-allowed" }}
+        py={2}
+        px={2}
+        gap={2}
+        // A one-pill row measures 44px (28px pill + 8px of padding either
+        // side) while the recipe's empty height is 40px, so the field grew by
+        // 4px the instant the first pill landed and shrank again when the last
+        // one went -- and it is the FIRST pill, the one you are looking at,
+        // that moves the page. Reserve the row height instead.
+        minH={11}
+      >
+        <TagsInput.Context>
+          {(api) =>
+            api.value.map((item, index) => (
+              <TagsInput.Item key={`${item}-${index}`} index={index} value={item}>
+                <TagsInput.ItemPreview
+                  bg="bg.muted"
+                  color="fg"
+                  borderWidth="1px"
+                  borderColor="border"
+                  rounded="md"
+                  gap={1}
+                  ps={2}
+                  pe={1}
+                  _highlighted={{
+                    borderColor: "brandGreen.focusRing",
+                    bg: "bg.subtle",
+                  }}
+                >
+                  <TagsInput.ItemText fontSize="sm">{item}</TagsInput.ItemText>
+                  <TagsInput.ItemDeleteTrigger
+                    opacity={1}
+                    color="fg.muted"
+                    rounded="sm"
+                    // Chakra sizes this at `item-height / 1.5` -- 18.7px at
+                    // size md -- and then pulls it back over the pill's own
+                    // trailing padding with a negative margin. 24px square and
+                    // no negative margin: WCAG 2.2 2.5.8 wants 24x24, and
+                    // these pills sit 8px apart, so the spacing exception does
+                    // not rescue an 18px target either.
+                    boxSize="24px"
+                    me={0}
+                    _hover={{ color: "fg", bg: "bg.subtle" }}
+                    _focusVisible={{
+                      outline: "2px solid",
+                      outlineColor: "brandGreen.focusRing",
+                      outlineOffset: "1px",
+                      color: "fg",
+                    }}
+                  >
+                    <X size={14} aria-hidden="true" />
+                  </TagsInput.ItemDeleteTrigger>
+                </TagsInput.ItemPreview>
+                <TagsInput.ItemInput fontSize="sm" />
+              </TagsInput.Item>
+            ))
+          }
+        </TagsInput.Context>
+        <TagsInput.Input
+          placeholder={committed.length === 0 ? placeholder : undefined}
+          fontSize="sm"
+          _placeholder={{ color: "fg.subtle" }}
+        />
+        <TagsInput.HiddenInput />
+      </TagsInput.Control>
+
+      {/* ONE line, always exactly one line's worth of box, whether it is
+          holding guidance or a rejection. See the header note: this used to be
+          a message that mounted underneath and pushed the save-error block and
+          everything below it down a row on every duplicate keystroke. */}
+      <Text
+        mt={2}
+        fontSize="sm"
+        maxW="70ch"
+        color={notice ? "brandOrange.fg" : "fg.muted"}
+        // `aria-live` rather than `role="alert"`: the machine already owns an
+        // assertive live region for additions and removals, and two regions
+        // interrupting each other is worse than either alone.
+        aria-live="polite"
+      >
+        {notice || helperText}
+      </Text>
+    </TagsInput.Root>
+  );
+}

--- a/pages/docs/experiments/validation.js
+++ b/pages/docs/experiments/validation.js
@@ -99,8 +99,11 @@ export default function ValidationAndSessionLimitsPage() {
           </List.Item>
         </List.Root>
         <Text maxW="70ch">
-          The dashboard takes the list as comma-separated names. Empty it and
-          DataPipe checks only that the file is well-formed.
+          On the dashboard, type a name and press Enter or comma to add it, or
+          paste a comma-separated list in one go. Each name becomes a chip
+          showing exactly the text that will be matched, so a stray space or a
+          pasted quote is visible before it costs you a session. Remove every
+          chip and DataPipe checks only that the file is well-formed.
         </Text>
       </DocsSection>
 


### PR DESCRIPTION
Replaces the comma-separated textarea on `/admin/<experiment_id>` with a pill field.

## Why

`requiredFields` is compared with `Array.includes` against JSON keys and CSV header cells (`functions/src/validate-json.ts`, `validate-csv.ts`). The match is exact, the server trims nothing, and a rejection is a bare `400 INVALID_DATA` that does not say which field failed. So a stray space, a pasted quote, or a trailing comma does not produce a warning — it produces an experiment that silently rejects every participant.

A textarea cannot show that. `trial_type , rt` and `trial_type,rt` look the same at a glance, and the empty string a trailing comma leaves behind is invisible by definition — that one shipped, and `[""]` in a live experiment document is why both validators now carry a filter for it.

A pill is the fix because it is a **receipt**. The moment a name becomes a pill the researcher can see exactly what will be compared: its boundaries are drawn, its whitespace is gone, and an empty entry has nothing to draw so it cannot appear at all. Text that has not yet been committed is still in the input, visibly pending.

## What's here

**`components/ui/TagListInput.js`** — a new shared primitive, built on Chakra v3's `TagsInput` (Ark/zag) rather than hand-rolled. The machine already ships keyboard navigation between pills, in-place editing, a live region, and delimiter/paste splitting; re-implementing those would have meant re-implementing them badly.

Normalization runs on the way **out**, in one place. There are four routes a value can take in — typed + Enter, typed + comma, pasted, edited in place on an existing pill — and the machine treats them as four separate code paths. Guarding them one at a time is how you end up guarding three of them. `normalizeList` trims, strips pasted quotes (straight, curly, backtick — `"trial_type"` copied out of a jsPsych example is a different string), drops empties and de-duplicates, so the caller only ever receives a clean list. `validate` is not where correctness lives; it exists so a rejected keystroke can say *why* instead of the pill quietly failing to appear.

### Deviations from Chakra's stock recipe

Four, each a real defect rather than taste:

- `itemDeleteTrigger` ships `opacity: 0.4` at rest — nowhere near the 3:1 non-text floor, on the control that removes a rule from a live experiment.
- That same trigger ships **no focus ring**; the recipe gives one to `clearTrigger` and forgets the per-item one. DESIGN.md §5 requires one on every interactive element, §8.8 bans going without.
- It is sized `item-height / 1.5` = 18.7px and pulled back over the pill's own trailing padding by a negative margin. Now 24×24 per WCAG 2.2 2.5.8 — pills sit 8px apart, so the spacing exception does not rescue an 18px target either.
- `itemPreview` fills with `colorPalette.subtle` and carries no border. On the light page that is 1.17:1 against the control — an edge that is not there. DESIGN.md §1 settles this for panels ("must carry a border — never rely on the fill alone") and a pill boundary is load-bearing in exactly the same way. Now `bg.muted` + 1px `border`.

Two existing house rules carried over: the control reserves the one-pill row height so the first pill does not grow the field, and a rejection notice **replaces** the helper line rather than mounting under it — the same no-reflow principle as `SavedFlag`.

### Also

- `ExperimentValidation.js` wired to it. Legacy `[""]` documents now draw no phantom pill — an empty chip is one the researcher can neither see nor delete.
- `pages/docs/experiments/validation.js` — the "takes the list as comma-separated names" sentence was about to be wrong.

## Testing

34 new tests across `__tests__/tag-list-input.test.jsx` and `__tests__/experiment-validation.test.jsx`, covering the normalization contract, every commit route, and the failure path: a rejected write reverts the pills, so the list can never show a rule Firestore does not hold.

`292 passed` across the root suite; lint clean. Rendered and inspected in the real theme via headless Chrome — populated, empty, wrapping, disabled, and the focus-within ring — against the dark-only palette the app actually ships.

The two `validate-csv` / `validate-json` failures seen locally are an uncompiled `functions/lib` in a fresh worktree, not related to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016iV4rd2rgXxCYS6CMGRzN5

