### PR TITLE
Experiment logs: make them readable, bounded, and queryable

### DIFF
--- a/components/dashboard/ErrorPanel.js
+++ b/components/dashboard/ErrorPanel.js
@@ -1,10 +1,47 @@
 import { Box, Accordion, Alert, Table, Text } from "@chakra-ui/react";
 
-// How many rows to render. `logs/{id}.errors` grows by `arrayUnion` and is
-// never trimmed, so a broken integration during piloting can produce thousands
-// of entries -- which this component used to render, all of them, unpaginated.
-// The recent ones are the only ones a researcher can act on.
+// How many rows to render. `logs/{id}.errors` is now capped at 50 by
+// write-log.ts (MAX_ERROR_ENTRIES), but the recent ones are still the only
+// ones a researcher can act on, and documents written before the cap landed
+// can hold thousands of entries that will not rotate out until fifty new ones
+// arrive.
 const MAX_ROWS = 20;
+
+/**
+ * `time` on an error entry comes in two shapes and both are live at once:
+ *
+ *  - A Firestore Timestamp, on everything written since write-log.ts started
+ *    storing a real one. Through the client SDK this arrives as a Timestamp
+ *    instance with .toDate(); through anything that serialized it in between
+ *    it can arrive as a plain `{seconds, nanoseconds}`.
+ *  - A preformatted en-GB string, on entries that were already in the array.
+ *    Those are displayed verbatim -- reparsing a formatted string to reformat
+ *    it would be guesswork.
+ *
+ * Returns null rather than throwing on anything else, because a malformed
+ * timestamp must not be the thing that white-screens the experiment page.
+ */
+function formatErrorTime(time) {
+  if (typeof time === "string") return time;
+  if (!time) return null;
+
+  let date = null;
+  if (typeof time.toDate === "function") {
+    date = time.toDate();
+  } else if (typeof time.seconds === "number") {
+    date = new Date(time.seconds * 1000);
+  } else if (time instanceof Date) {
+    date = time;
+  }
+  if (!date || Number.isNaN(date.getTime())) return null;
+
+  // Matches the format the old string entries were written in, so a table
+  // holding both does not read as two different kinds of record.
+  return new Intl.DateTimeFormat("en-GB", {
+    dateStyle: "short",
+    timeStyle: "long",
+  }).format(date);
+}
 
 /**
  * ErrorPanel — the record of submissions the API rejected for this experiment.
@@ -12,16 +49,16 @@ const MAX_ROWS = 20;
  * Three things were wrong with the previous version, all of them frontend:
  *
  * 1. IT COULD WHITE-SCREEN THE PAGE. It called `errors.map(...)` with no
- *    guard, while `functions/src/write-log.ts` writes `logError` (an
+ *    guard, while `functions/src/write-log.ts` wrote `logError` (an
  *    increment) and the `errors` array in TWO SEPARATE, NON-ATOMIC `set`
  *    calls. Between those two writes -- or permanently, if the second one
- *    fails -- the document has `logError > 0` and no `errors` field, and the
+ *    failed -- the document had `logError > 0` and no `errors` field, and the
  *    parent page renders this panel on `logError` alone. `undefined.map` then
  *    takes down the whole experiment page, including the integration code and
- *    the queued-upload recovery panel. The backend race is real and is filed
- *    separately; this component simply must not be the thing that breaks when
- *    it happens. Every read below is defensive: missing array, missing fields,
- *    non-object entries.
+ *    the queued-upload recovery panel. The backend race is fixed (both are
+ *    one transactional write now), but a document that reached the split
+ *    state before the fix still exists, so every read below stays defensive:
+ *    missing array, missing fields, non-object entries.
  *
  * 2. IT SHOWED MACHINE CODES. It rendered `error.error` -- literally the
  *    string "EXPERIMENT_NOT_FOUND" -- while `error.message` ("The experiment
@@ -47,10 +84,15 @@ const MAX_ROWS = 20;
  * roughly 3.5:1. brandRed is also DESIGN.md §5's irreversible-destruction hue,
  * which fits: these are submissions that were refused and are not coming back.
  *
- * @param {Array<object>|undefined} errors - The `logs/{id}.errors` array.
- *   Tolerates undefined, null, empty, and malformed entries.
+ * @param {Array<object>|undefined} errors - The `logs/{id}.errors` array, now
+ *   capped at the 50 most recent by the backend. Tolerates undefined, null,
+ *   empty, and malformed entries.
+ * @param {number|undefined} totalCount - `logs/{id}.logError`, the true
+ *   lifetime count. The `errors` array is capped, so its length understates
+ *   the total on any experiment that has been rejected more than fifty times.
+ *   Falls back to the array length when absent.
  */
-export default function ErrorPanel({ errors }) {
+export default function ErrorPanel({ errors, totalCount }) {
   // The guard that stops the non-atomic backend write from white-screening
   // the page. `logError > 0` with no `errors` array is a state the backend
   // can genuinely produce, and the honest render for it is nothing at all --
@@ -58,21 +100,26 @@ export default function ErrorPanel({ errors }) {
   const all = Array.isArray(errors) ? errors.filter(Boolean) : [];
   if (all.length === 0) return null;
 
-  // arrayUnion appends, so the tail is the most recent. `time` is written as
-  // a preformatted en-GB string by write-log.ts, not a Timestamp, so it is
-  // displayed rather than parsed -- reordering by it would be guesswork.
+  // Entries are appended, so the tail is the most recent. The array is not
+  // re-sorted by `time`: entries written before the Timestamp change carry a
+  // formatted string instead, and a mixed-type sort would scramble the order
+  // that insertion already gets right.
   const recent = all.slice(-MAX_ROWS).reverse();
-  const latest = recent[0];
-  const latestTime = typeof latest?.time === "string" ? latest.time : null;
+  const latestTime = formatErrorTime(recent[0]?.time);
+
+  // The headline counts every rejection ever recorded, which is `logError` --
+  // NOT the length of a capped array. Getting this wrong would tell a
+  // researcher with 300 rejections that they had 50.
+  const total = typeof totalCount === "number" && totalCount > 0 ? totalCount : all.length;
 
   return (
     <Alert.Root status="error" colorPalette="brandRed" variant="subtle">
       <Alert.Indicator />
       <Box flex="1" minW={0}>
         <Alert.Title mb={2}>
-          {all.length === 1
+          {total === 1
             ? "One submission to this experiment was rejected."
-            : `${all.length} submissions to this experiment were rejected.`}
+            : `${total} submissions to this experiment were rejected.`}
         </Alert.Title>
         <Text fontSize="sm" mb={4}>
           {latestTime
@@ -83,8 +130,8 @@ export default function ErrorPanel({ errors }) {
           <Accordion.Item value="error-logs">
             <Accordion.ItemTrigger>
               <Box as="span" flex="1" textAlign="left" fontSize="sm">
-                {all.length > MAX_ROWS
-                  ? `Show the ${MAX_ROWS} most recent of ${all.length}`
+                {total > MAX_ROWS
+                  ? `Show the ${MAX_ROWS} most recent of ${total}`
                   : "Show what was rejected"}
               </Box>
               <Accordion.ItemIndicator />
@@ -134,7 +181,7 @@ export default function ErrorPanel({ errors }) {
                         </Table.Cell>
                         <Table.Cell>
                           <Text fontSize="xs" color="fg.muted">
-                            {error?.time || "—"}
+                            {formatErrorTime(error?.time) || "—"}
                           </Text>
                         </Table.Cell>
                       </Table.Row>

--- a/functions/scripts/backfill-log-owner.mjs
+++ b/functions/scripts/backfill-log-owner.mjs
@@ -1,0 +1,129 @@
+// Give every existing logs/{experimentID} document the `owner` and
+// `storageProvider` fields it should always have had.
+//
+// WHY THIS EXISTS
+//
+// firestore.rules gates log reads on:
+//
+//     allow read: if request.auth.uid != null && resource.data.owner == request.auth.uid;
+//
+// but functions/src/write-log.ts never wrote an `owner` field -- not in any
+// revision, from the day the rule was added. The rule therefore could not
+// pass for any document in the collection, the dashboard's logs/{id}
+// subscription failed silently, and components/dashboard/ErrorPanel.js never
+// rendered for anyone. Researchers have never been able to see their own
+// rejected submissions.
+//
+// write-log.ts now writes `owner` (and `storageProvider`) on every log write,
+// and create-experiment.ts seeds both when an experiment is created. That
+// fixes every experiment that receives another request. It does NOT fix an
+// experiment that is finished, paused, or simply idle -- its log document sits
+// there with counters and errors that its owner still cannot read. This script
+// is for those. It should need to be run once per project.
+//
+// Usage:
+//   node functions/scripts/backfill-log-owner.mjs             # dry run, changes nothing
+//   node functions/scripts/backfill-log-owner.mjs --apply     # actually writes
+//
+// Env:
+//   GOOGLE_APPLICATION_CREDENTIALS  service-account key with Firebase Admin access
+//   FIREBASE_PROJECT_ID             (optional) overrides the credential's project
+//
+// SAFETY: the owner is taken from experiments/{id}.owner -- the same field the
+// rest of the codebase treats as authoritative -- and written with a merge, so
+// nothing else in the document is touched. A log document whose experiment no
+// longer exists is reported as `orphaned` and left alone: there is no owner to
+// infer, and inventing one would hand somebody else's uid a document. A log
+// document that already has an owner is skipped rather than overwritten, so
+// re-running this is a no-op.
+
+import { initializeApp, applicationDefault } from "firebase-admin/app";
+import { getFirestore } from "firebase-admin/firestore";
+
+const apply = process.argv.includes("--apply");
+
+const projectId = process.env.FIREBASE_PROJECT_ID;
+initializeApp({
+  credential: applicationDefault(),
+  ...(projectId ? { projectId } : {}),
+});
+
+const db = getFirestore();
+
+// Firestore caps a batch at 500 operations.
+const BATCH_LIMIT = 500;
+
+async function main() {
+  console.log(apply ? "MODE: apply (writes)" : "MODE: dry run (no writes)");
+
+  const logsSnap = await db.collection("logs").get();
+  console.log(`logs documents: ${logsSnap.size}`);
+
+  const pending = [];
+  const counts = { alreadyOwned: 0, orphaned: 0, providerOnly: 0, toFix: 0 };
+
+  for (const logDoc of logsSnap.docs) {
+    const log = logDoc.data() || {};
+
+    const expSnap = await db.collection("experiments").doc(logDoc.id).get();
+    if (!expSnap.exists) {
+      counts.orphaned += 1;
+      console.log(`  orphaned: logs/${logDoc.id} (no matching experiment)`);
+      continue;
+    }
+    const exp = expSnap.data() || {};
+
+    // Both fields are considered independently: an experiment created before
+    // the provider migration has no storageProvider to copy, and a log
+    // document written by the new write-log.ts already has an owner but may
+    // predate the provider field on its experiment.
+    const update = {};
+    if (!log.owner && exp.owner) update.owner = exp.owner;
+    if (!log.storageProvider && exp.storageProvider) {
+      update.storageProvider = exp.storageProvider;
+    }
+
+    if (Object.keys(update).length === 0) {
+      counts.alreadyOwned += 1;
+      continue;
+    }
+    if (!update.owner) counts.providerOnly += 1;
+
+    counts.toFix += 1;
+    pending.push({ ref: logDoc.ref, update });
+    console.log(`  fix: logs/${logDoc.id} <- ${JSON.stringify(update)}`);
+  }
+
+  console.log("");
+  console.log(`already complete: ${counts.alreadyOwned}`);
+  console.log(`orphaned (skipped): ${counts.orphaned}`);
+  console.log(`to update: ${counts.toFix} (of which provider-only: ${counts.providerOnly})`);
+
+  if (!apply) {
+    console.log("");
+    console.log("Dry run. Re-run with --apply to write these changes.");
+    return;
+  }
+
+  let written = 0;
+  for (let i = 0; i < pending.length; i += BATCH_LIMIT) {
+    const batch = db.batch();
+    for (const { ref, update } of pending.slice(i, i + BATCH_LIMIT)) {
+      batch.set(ref, update, { merge: true });
+    }
+    await batch.commit();
+    written += Math.min(BATCH_LIMIT, pending.length - i);
+    console.log(`committed ${written}/${pending.length}`);
+  }
+
+  console.log("");
+  console.log(`done: ${written} log documents updated`);
+}
+
+main().then(
+  () => process.exit(0),
+  (e) => {
+    console.error(e);
+    process.exit(1);
+  }
+);

--- a/functions/src/__tests__/base64data-emulator.test.js
+++ b/functions/src/__tests__/base64data-emulator.test.js
@@ -58,6 +58,14 @@ beforeAll(async () => {
     activeBase64: true,
     owner: "testuser",
   });
+  // api-base64.ts counts the attempt AFTER confirming the experiment exists
+  // (see write-log.ts), so the experiment this test counts against has to be
+  // seeded rather than left absent.
+  await db.collection("experiments").doc("base64-testlog").set({
+    activeBase64: false,
+    owner: "testuser",
+    storageProvider: "osf",
+  });
 });
 
 describe("apiData", () => {
@@ -89,6 +97,8 @@ describe("apiData", () => {
     });
     let doc = await waitForLog(db, "base64-testlog", "saveBase64Data", 1);
     expect(doc.data().saveBase64Data).toBe(1);
+    expect(doc.data().owner).toBe("testuser");
+    expect(doc.data().storageProvider).toBe("osf");
 
     await saveData({
       experimentID: "base64-testlog",

--- a/functions/src/__tests__/create-experiment-emulator.test.js
+++ b/functions/src/__tests__/create-experiment-emulator.test.js
@@ -288,6 +288,22 @@ describe("5. createExperiment happy path (gdrive)", () => {
 
     const userDoc = await db.collection("users").doc(uid).get();
     expect(userDoc.data().experiments).toContain(body.experimentID);
+
+    // logs/{id} is seeded in the same batch. `owner` is the field
+    // firestore.rules checks on every read of this document -- it was never
+    // written by any code path, so the rule could not pass and the dashboard's
+    // error panel never rendered for anyone. Seeding it here covers the
+    // experiment that has not received a request yet; write-log.ts covers the
+    // rest.
+    const logDoc = await db.collection("logs").doc(body.experimentID).get();
+    expect(logDoc.exists).toBe(true);
+    expect(logDoc.data().owner).toBe(uid);
+    expect(logDoc.data().storageProvider).toBe("gdrive");
+    expect(logDoc.data().createdAt).toBeTruthy();
+    // Zeroed rather than absent, so a log document is never a half-populated
+    // shape.
+    expect(logDoc.data().saveData).toBe(0);
+    expect(logDoc.data().logError).toBe(0);
   });
 });
 

--- a/functions/src/__tests__/data-emulator.test.js
+++ b/functions/src/__tests__/data-emulator.test.js
@@ -46,6 +46,16 @@ beforeAll(async () => {
     active: true,
     owner: "testuser",
   });
+  // `testlog` used to be deliberately absent: the request counter was
+  // incremented before api-data.ts checked that the experiment existed, so a
+  // log document appeared for any ID at all. It is counted after the check
+  // now (see write-log.ts), so the experiment this test counts against has to
+  // actually exist.
+  await db.collection("experiments").doc("testlog").set({
+    active: false,
+    owner: "testuser",
+    storageProvider: "osf",
+  });
 });
 
 describe("apiData", () => {
@@ -79,6 +89,11 @@ describe("apiData", () => {
     let doc = await db.collection("logs").doc("testlog").get();
     expect(doc.exists).toBe(true);
     expect(doc.data().saveData).toBe(1);
+    // The two fields that make this document readable by its owner
+    // (firestore.rules) and groupable by provider.
+    expect(doc.data().owner).toBe("testuser");
+    expect(doc.data().storageProvider).toBe("osf");
+    expect(doc.data().lastRequestAt).toBeTruthy();
 
     await saveData({
       experimentID: "testlog",
@@ -125,6 +140,99 @@ describe("apiData", () => {
     doc = await db.collection("logs").doc("data-testexp").get();
     expect(doc.data().logError).toBe(2);
 
+  });
+
+  it("should not count a request against an experiment that does not exist", async () => {
+    const db = getFirestore();
+    const bogusID = `does-not-exist-${Date.now()}`;
+
+    await saveData({ experimentID: bogusID, data: "test", filename: "test" });
+    await new Promise((resolve) => setTimeout(resolve, 500));
+
+    // The error is still recorded -- but `saveData`, the attempt counter, is
+    // not touched, because there is no experiment for the attempt to be an
+    // attempt AT. Counting it inflated the request totals and let any POST
+    // create an unreadable, ownerless document.
+    const doc = await db.collection("logs").doc(bogusID).get();
+    expect(doc.data()?.saveData).toBeUndefined();
+    expect(doc.data()?.owner).toBeUndefined();
+
+    await db.collection("logs").doc(bogusID).delete();
+  });
+
+  it("should tally errors by code and stamp each entry with a real Timestamp", async () => {
+    const db = getFirestore();
+    await db.collection("logs").doc("data-testexp-bycode").delete();
+    await db.collection("experiments").doc("data-testexp-bycode").set({
+      active: false,
+      owner: "testuser",
+      storageProvider: "osf",
+    });
+
+    // Two of the same code, so the tally has to count rather than merely
+    // record that the code was seen.
+    await saveData({ experimentID: "data-testexp-bycode", data: "test", filename: "test" });
+    await saveData({ experimentID: "data-testexp-bycode", data: "test", filename: "test" });
+    await new Promise((resolve) => setTimeout(resolve, 700));
+
+    const doc = await db.collection("logs").doc("data-testexp-bycode").get();
+    const data = doc.data();
+
+    expect(data.logError).toBe(2);
+    expect(data.errorsByCode.DATA_COLLECTION_NOT_ACTIVE).toBe(2);
+
+    // A real Timestamp, not the preformatted en-GB string it used to be --
+    // the whole point is that this is sortable and filterable.
+    expect(data.errors).toHaveLength(2);
+    expect(typeof data.errors[0].time.toDate).toBe("function");
+    expect(data.errors[0].time.toDate()).toBeInstanceOf(Date);
+
+    // Both halves of what used to be two non-atomic writes land together.
+    expect(data.owner).toBe("testuser");
+    expect(data.storageProvider).toBe("osf");
+  });
+
+  it("should cap the stored errors array while the counter keeps climbing", async () => {
+    const db = getFirestore();
+    const experimentID = "data-testexp-cap";
+    await db.collection("logs").doc(experimentID).delete();
+    await db.collection("experiments").doc(experimentID).set({
+      active: false,
+      owner: "testuser",
+      storageProvider: "osf",
+    });
+
+    // Seed the array one short of the cap with entries that are individually
+    // identifiable, so the trim can be shown to drop the OLDEST rather than
+    // some arbitrary slice. Driving 50 real requests through the emulator
+    // would make this test minutes long for no extra coverage.
+    const seeded = Array.from({ length: 49 }, (_, i) => ({
+      error: "SEEDED",
+      message: `seeded ${i}`,
+      time: new Date(2020, 0, 1, 0, 0, i),
+    }));
+    await db.collection("logs").doc(experimentID).set({ errors: seeded }, { merge: true });
+
+    // Two more real errors: the first fills the cap, the second must evict.
+    await saveData({ experimentID, data: "test", filename: "test" });
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    let data = (await db.collection("logs").doc(experimentID).get()).data();
+    expect(data.errors).toHaveLength(50);
+    expect(data.errors[0].message).toBe("seeded 0");
+
+    await saveData({ experimentID, data: "test", filename: "test" });
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    data = (await db.collection("logs").doc(experimentID).get()).data();
+
+    // Still 50 -- the array does not grow past the cap ...
+    expect(data.errors).toHaveLength(50);
+    // ... the oldest entry is the one that went ...
+    expect(data.errors[0].message).toBe("seeded 1");
+    // ... the newest is at the tail, where the dashboard looks for it ...
+    expect(data.errors[49].error).toBe("DATA_COLLECTION_NOT_ACTIVE");
+    // ... and the true total is the counter, which is NOT capped. This is why
+    // ErrorPanel is passed logError instead of errors.length.
+    expect(data.logError).toBe(2);
   });
 
   it("should return error message when the experimentID does not match an experiment", async () => {

--- a/functions/src/__tests__/get-condition-emulator.test.js
+++ b/functions/src/__tests__/get-condition-emulator.test.js
@@ -48,7 +48,7 @@ beforeAll(async () => {
   await db
     .collection("experiments")
     .doc("testexp")
-    .set({ activeConditionAssignment: false });
+    .set({ activeConditionAssignment: false, owner: "testuser", storageProvider: "osf" });
   await db
     .collection("experiments")
     .doc("testexp-active")
@@ -81,6 +81,8 @@ describe("getCondition", () => {
     await getCondition({ experimentID: "testexp" });
     let doc = await waitForLog(db, "testexp", "logError", 1);
     expect(doc.data().logError).toBe(1);
+    expect(doc.data().errorsByCode.CONDITION_ASSIGNMENT_NOT_ACTIVE).toBe(1);
+    expect(doc.data().owner).toBe("testuser");
 
     await getCondition({ experimentID: "testexp" });
     doc = await waitForLog(db, "testexp", "logError", 2);

--- a/functions/src/api-base64.ts
+++ b/functions/src/api-base64.ts
@@ -22,8 +22,6 @@ export const apiBase64 = onRequest({ cors: true, memory: "512MiB", concurrency: 
     return;
   }
 
-  await writeLog(experimentID, "saveBase64Data");
-
   const exp_doc_ref: DocumentReference<DocumentData> = db.collection("experiments").doc(experimentID);
   const exp_doc: DocumentSnapshot = await exp_doc_ref.get();
 
@@ -41,24 +39,31 @@ export const apiBase64 = onRequest({ cors: true, memory: "512MiB", concurrency: 
     return;
   }
 
+  // Identity for every log write below, and the reason the attempt is counted
+  // here rather than at the top of the handler -- see the matching comment in
+  // api-data.ts and the header of write-log.ts.
+  const logContext = { owner: exp_data.owner, storageProvider: exp_data.storageProvider };
+
+  await writeLog(experimentID, "saveBase64Data", undefined, logContext);
+
   // Finalization is permanent (docs/finalization-spec.md) -- see the matching
   // comment in api-data.ts for why this is checked ahead of, and independent
   // from, the ordinary activeBase64 flag.
   if (exp_data.finalized) {
     res.status(400).json(MESSAGES.EXPERIMENT_FINALIZED);
-    await writeLog(experimentID, "logError", MESSAGES.EXPERIMENT_FINALIZED);
+    await writeLog(experimentID, "logError", MESSAGES.EXPERIMENT_FINALIZED, logContext);
     return;
   }
 
   if (!exp_data.activeBase64) {
     res.status(400).json(MESSAGES.BASE64DATA_COLLECTION_NOT_ACTIVE);
-    await writeLog(experimentID, "logError", MESSAGES.BASE64DATA_COLLECTION_NOT_ACTIVE);
+    await writeLog(experimentID, "logError", MESSAGES.BASE64DATA_COLLECTION_NOT_ACTIVE, logContext);
     return;
   }
 
   if (!isBase64(data, {allowMime: true})) {
     res.status(400).json(MESSAGES.INVALID_BASE64_DATA);
-    await writeLog(experimentID, "logError", MESSAGES.INVALID_BASE64_DATA);
+    await writeLog(experimentID, "logError", MESSAGES.INVALID_BASE64_DATA, logContext);
     return;
   }
 
@@ -74,7 +79,7 @@ export const apiBase64 = onRequest({ cors: true, memory: "512MiB", concurrency: 
     }
   } catch (e) {
     res.status(400).json(MESSAGES.INVALID_BASE64_DATA);
-    await writeLog(experimentID, "logError", MESSAGES.INVALID_BASE64_DATA);
+    await writeLog(experimentID, "logError", MESSAGES.INVALID_BASE64_DATA, logContext);
     return;
   }
 
@@ -87,14 +92,14 @@ export const apiBase64 = onRequest({ cors: true, memory: "512MiB", concurrency: 
   } catch (e) {
     const detail = e instanceof Error ? e.message : "Unknown error";
     res.status(500).json(MESSAGES.DATA_PERSIST_ERROR);
-    await writeLog(experimentID, "logError", {...MESSAGES.DATA_PERSIST_ERROR, detail});
+    await writeLog(experimentID, "logError", {...MESSAGES.DATA_PERSIST_ERROR, detail}, logContext);
     return;
   }
 
   const user_doc = await db.doc(`users/${exp_data.owner}`).get();
   if (!user_doc.exists) {
     res.status(400).json(MESSAGES.INVALID_OWNER);
-    await writeLog(experimentID, "logError", MESSAGES.INVALID_OWNER);
+    await writeLog(experimentID, "logError", MESSAGES.INVALID_OWNER, logContext);
     return;
   }
 
@@ -102,7 +107,7 @@ export const apiBase64 = onRequest({ cors: true, memory: "512MiB", concurrency: 
 
   if (!user_data) {
     res.status(400).json(MESSAGES.USER_DATA_NOT_FOUND);
-    await writeLog(experimentID, "logError", MESSAGES.USER_DATA_NOT_FOUND);
+    await writeLog(experimentID, "logError", MESSAGES.USER_DATA_NOT_FOUND, logContext);
     return;
   }
 
@@ -112,14 +117,14 @@ export const apiBase64 = onRequest({ cors: true, memory: "512MiB", concurrency: 
   } catch (e) {
     const detail = e instanceof Error ? e.message : "Unknown error";
     res.status(500).json(MESSAGES.TOKEN_RESOLUTION_ERROR);
-    await writeLog(experimentID, "logError", {...MESSAGES.TOKEN_RESOLUTION_ERROR, detail});
+    await writeLog(experimentID, "logError", {...MESSAGES.TOKEN_RESOLUTION_ERROR, detail}, logContext);
     return;
   }
 
   if (!tokenResult.success) {
     const errorMessage = MESSAGES[tokenResult.error as keyof typeof MESSAGES] || MESSAGES.TOKEN_RESOLUTION_ERROR;
     res.status(400).json(errorMessage);
-    await writeLog(experimentID, "logError", {...errorMessage, detail: tokenResult.detail});
+    await writeLog(experimentID, "logError", {...errorMessage, detail: tokenResult.detail}, logContext);
     return;
   }
 
@@ -157,11 +162,14 @@ export const apiBase64 = onRequest({ cors: true, memory: "512MiB", concurrency: 
         });
         await cleanupPending(pendingPath); // queue-upload has its own copy
         res.status(202).json(MESSAGES.OSF_UPLOAD_QUEUED);
-        await writeLog(experimentID, "logError", {...MESSAGES.OSF_UPLOAD_EXCEPTION, detail: `Collision cache rehydration failed: ${detail}`});
+        // Held for retry, not stored and not refused -- see the matching
+        // comment in api-data.ts and the header of write-log.ts.
+        await writeLog(experimentID, "saveBase64DataQueued", undefined, logContext);
+        await writeLog(experimentID, "logError", {...MESSAGES.OSF_UPLOAD_EXCEPTION, detail: `Collision cache rehydration failed: ${detail}`}, logContext);
         return;
       } catch {
         res.status(500).json(MESSAGES.OSF_UPLOAD_EXCEPTION);
-        await writeLog(experimentID, "logError", {...MESSAGES.OSF_UPLOAD_EXCEPTION, detail});
+        await writeLog(experimentID, "logError", {...MESSAGES.OSF_UPLOAD_EXCEPTION, detail}, logContext);
         return;
       }
     }
@@ -172,7 +180,7 @@ export const apiBase64 = onRequest({ cors: true, memory: "512MiB", concurrency: 
     if (claimResult.reason === "duplicate") {
       await cleanupPending(pendingPath);
       res.status(400).json(MESSAGES.OSF_FILE_EXISTS);
-      await writeLog(experimentID, "logError", MESSAGES.OSF_FILE_EXISTS);
+      await writeLog(experimentID, "logError", MESSAGES.OSF_FILE_EXISTS, logContext);
       return;
     }
 
@@ -189,11 +197,12 @@ export const apiBase64 = onRequest({ cors: true, memory: "512MiB", concurrency: 
       });
       await cleanupPending(pendingPath); // queue-upload has its own copy
       res.status(202).json(MESSAGES.OSF_UPLOAD_QUEUED);
-      await writeLog(experimentID, "logError", {...MESSAGES.OSF_UPLOAD_EXCEPTION, detail: "Collision cache rehydrating"});
+      await writeLog(experimentID, "saveBase64DataQueued", undefined, logContext);
+      await writeLog(experimentID, "logError", {...MESSAGES.OSF_UPLOAD_EXCEPTION, detail: "Collision cache rehydrating"}, logContext);
       return;
     } catch {
       res.status(500).json(MESSAGES.OSF_UPLOAD_EXCEPTION);
-      await writeLog(experimentID, "logError", {...MESSAGES.OSF_UPLOAD_EXCEPTION, detail: "Collision cache rehydrating"});
+      await writeLog(experimentID, "logError", {...MESSAGES.OSF_UPLOAD_EXCEPTION, detail: "Collision cache rehydrating"}, logContext);
       return;
     }
   }
@@ -219,6 +228,7 @@ export const apiBase64 = onRequest({ cors: true, memory: "512MiB", concurrency: 
       });
       await cleanupPending(pendingPath); // queue-upload has its own copy
       res.status(202).json(MESSAGES.OSF_UPLOAD_QUEUED);
+      await writeLog(experimentID, "saveBase64DataQueued", undefined, logContext);
       return;
     } catch {
       res.status(500).json(MESSAGES.OSF_UPLOAD_EXCEPTION);
@@ -251,11 +261,12 @@ export const apiBase64 = onRequest({ cors: true, memory: "512MiB", concurrency: 
       });
       await cleanupPending(pendingPath); // queue-upload has its own copy
       res.status(202).json(MESSAGES.OSF_UPLOAD_QUEUED);
-      await writeLog(experimentID, "logError", {...MESSAGES.OSF_UPLOAD_EXCEPTION, detail});
+      await writeLog(experimentID, "saveBase64DataQueued", undefined, logContext);
+      await writeLog(experimentID, "logError", {...MESSAGES.OSF_UPLOAD_EXCEPTION, detail}, logContext);
       return;
     } catch {
       res.status(500).json(MESSAGES.OSF_UPLOAD_EXCEPTION);
-      await writeLog(experimentID, "logError", {...MESSAGES.OSF_UPLOAD_EXCEPTION, detail});
+      await writeLog(experimentID, "logError", {...MESSAGES.OSF_UPLOAD_EXCEPTION, detail}, logContext);
       return;
     }
   }
@@ -268,11 +279,14 @@ export const apiBase64 = onRequest({ cors: true, memory: "512MiB", concurrency: 
       await confirmClaim(experimentID, claimName, claimToken);
       // Logs before response — see the matching comment in api-data.ts:
       // responding first races observers of the log against the write.
-      await writeLog(experimentID, "logError", MESSAGES.OSF_FILE_EXISTS);
+      await writeLog(experimentID, "logError", MESSAGES.OSF_FILE_EXISTS, logContext);
       await writeLog(experimentID, "logError", {
+        // See the matching comment in api-data.ts for why this entry carries
+        // an `error` code of its own.
+        error: "COLLISION_CACHE_DISAGREEMENT",
         collisionCacheDisagreement: true,
         direction: "cache-free-provider-conflict",
-      });
+      }, logContext);
       await cleanupPending(pendingPath);
       res.status(400).json(MESSAGES.OSF_FILE_EXISTS);
       return;
@@ -290,11 +304,12 @@ export const apiBase64 = onRequest({ cors: true, memory: "512MiB", concurrency: 
       });
       await cleanupPending(pendingPath); // queue-upload has its own copy
       res.status(202).json(MESSAGES.OSF_UPLOAD_QUEUED);
-      await writeLog(experimentID, "logError", {...MESSAGES.OSF_UPLOAD_ERROR, osfStatus: result.providerStatus, osfStatusText: result.providerMessage});
+      await writeLog(experimentID, "saveBase64DataQueued", undefined, logContext);
+      await writeLog(experimentID, "logError", {...MESSAGES.OSF_UPLOAD_ERROR, osfStatus: result.providerStatus, osfStatusText: result.providerMessage}, logContext);
       return;
     } catch {
       res.status(400).json(MESSAGES.OSF_UPLOAD_ERROR);
-      await writeLog(experimentID, "logError", {...MESSAGES.OSF_UPLOAD_ERROR, osfStatus: result.providerStatus, osfStatusText: result.providerMessage});
+      await writeLog(experimentID, "logError", {...MESSAGES.OSF_UPLOAD_ERROR, osfStatus: result.providerStatus, osfStatusText: result.providerMessage}, logContext);
       return;
     }
   }
@@ -302,6 +317,10 @@ export const apiBase64 = onRequest({ cors: true, memory: "512MiB", concurrency: 
   // Successful write — confirm the claim (best-effort; a confirm failure
   // must not fail a request that already succeeded against the provider).
   await confirmClaim(experimentID, claimName, claimToken);
+
+  // The file is in the researcher's storage. This is the only place in this
+  // handler that is true.
+  await writeLog(experimentID, "saveBase64DataSucceeded", undefined, logContext);
 
   // Data successfully uploaded to OSF — clean up the pending copy.
   await cleanupPending(pendingPath);

--- a/functions/src/api-condition.ts
+++ b/functions/src/api-condition.ts
@@ -14,8 +14,6 @@ export const apiCondition = onRequest({ cors: true }, async (req, res) => {
     return;
   }
 
-  await writeLog(experimentID, "getCondition");
-
   const exp_doc_ref: DocumentReference<DocumentData> = db.collection("experiments").doc(experimentID);
   const exp_doc: DocumentSnapshot = await exp_doc_ref.get();
 
@@ -33,9 +31,16 @@ export const apiCondition = onRequest({ cors: true }, async (req, res) => {
     return;
   }
 
+  // Counted here, not before the read above: an experiment that does not
+  // exist has no owner, so a log document keyed by a garbage ID is one no
+  // researcher can ever read -- it only inflates the request count and hands
+  // anyone who can POST a way to create documents. See write-log.ts.
+  const logContext = { owner: exp_data.owner, storageProvider: exp_data.storageProvider };
+  await writeLog(experimentID, "getCondition", undefined, logContext);
+
   if (!exp_data.activeConditionAssignment) {
     res.status(400).json(MESSAGES.CONDITION_ASSIGNMENT_NOT_ACTIVE);
-    await writeLog(experimentID, "logError", MESSAGES.CONDITION_ASSIGNMENT_NOT_ACTIVE);
+    await writeLog(experimentID, "logError", MESSAGES.CONDITION_ASSIGNMENT_NOT_ACTIVE, logContext);
     return;
   }
 
@@ -59,7 +64,7 @@ export const apiCondition = onRequest({ cors: true }, async (req, res) => {
     });
   } catch (error) {
     res.status(400).json(MESSAGES.UNKNOWN_ERROR_GETTING_CONDITION);
-    await writeLog(experimentID, "logError", MESSAGES.UNKNOWN_ERROR_GETTING_CONDITION);
+    await writeLog(experimentID, "logError", MESSAGES.UNKNOWN_ERROR_GETTING_CONDITION, logContext);
     return;
   }
 

--- a/functions/src/api-data.ts
+++ b/functions/src/api-data.ts
@@ -26,8 +26,6 @@ export const apiData = onRequest({ cors: true, memory: "512MiB", concurrency: 1 
     return;
   }
 
-  await writeLog(experimentID, "saveData");
-
   const exp_doc_ref: DocumentReference<DocumentData> = db.collection("experiments").doc(experimentID);
   const exp_doc: DocumentSnapshot = await exp_doc_ref.get();
 
@@ -46,6 +44,18 @@ export const apiData = onRequest({ cors: true, memory: "512MiB", concurrency: 1 
     return;
   }
 
+  // Identity for every log write below. Reading it costs nothing extra --
+  // exp_doc is already in hand -- and it is what makes logs/{id} readable by
+  // its owner at all (firestore.rules) and groupable by provider.
+  const logContext = { owner: exp_data.owner, storageProvider: exp_data.storageProvider };
+
+  // The attempt is counted HERE, after the experiment is known to exist,
+  // rather than at the top of the handler. Counting first meant every request
+  // carrying a mistyped or invented experiment ID created a log document that
+  // has no owner -- unreadable by anyone, and unbounded in number. See
+  // write-log.ts.
+  await writeLog(experimentID, "saveData", undefined, logContext);
+
   // Finalization is permanent (docs/finalization-spec.md): once an experiment
   // is finalized, every remaining file has been merged into one archive and
   // the originals deleted. A session accepted after that would sit outside
@@ -55,20 +65,20 @@ export const apiData = onRequest({ cors: true, memory: "512MiB", concurrency: 1 
   // off, and this message is the one that should surface either way.
   if (exp_data.finalized) {
     res.status(400).json(MESSAGES.EXPERIMENT_FINALIZED);
-    await writeLog(experimentID, "logError", MESSAGES.EXPERIMENT_FINALIZED);
+    await writeLog(experimentID, "logError", MESSAGES.EXPERIMENT_FINALIZED, logContext);
     return;
   }
 
   if (!exp_data.active) {
     res.status(400).json(MESSAGES.DATA_COLLECTION_NOT_ACTIVE);
-    await writeLog(experimentID, "logError", MESSAGES.DATA_COLLECTION_NOT_ACTIVE);
+    await writeLog(experimentID, "logError", MESSAGES.DATA_COLLECTION_NOT_ACTIVE, logContext);
     return;
   }
 
   if (exp_data.limitSessions) {
     if (exp_data.sessions >= exp_data.maxSessions) {
       res.status(400).json(MESSAGES.SESSION_LIMIT_REACHED);
-      await writeLog(experimentID, "logError", MESSAGES.SESSION_LIMIT_REACHED);
+      await writeLog(experimentID, "logError", MESSAGES.SESSION_LIMIT_REACHED, logContext);
       return;
     }
   }
@@ -89,7 +99,7 @@ export const apiData = onRequest({ cors: true, memory: "512MiB", concurrency: 1 
     }
     if (!valid) {
       res.status(400).json(MESSAGES.INVALID_DATA);
-      await writeLog(experimentID, "logError", MESSAGES.INVALID_DATA);
+      await writeLog(experimentID, "logError", MESSAGES.INVALID_DATA, logContext);
       return;
     }
   }
@@ -103,7 +113,7 @@ export const apiData = onRequest({ cors: true, memory: "512MiB", concurrency: 1 
   } catch (e) {
     const detail = e instanceof Error ? e.message : "Unknown error";
     res.status(500).json(MESSAGES.DATA_PERSIST_ERROR);
-    await writeLog(experimentID, "logError", {...MESSAGES.DATA_PERSIST_ERROR, detail});
+    await writeLog(experimentID, "logError", {...MESSAGES.DATA_PERSIST_ERROR, detail}, logContext);
     return;
   }
 
@@ -111,7 +121,7 @@ export const apiData = onRequest({ cors: true, memory: "512MiB", concurrency: 1 
 
   if (!user_doc.exists) {
     res.status(400).json(MESSAGES.INVALID_OWNER);
-    await writeLog(experimentID, "logError", MESSAGES.INVALID_OWNER);
+    await writeLog(experimentID, "logError", MESSAGES.INVALID_OWNER, logContext);
     return;
   }
 
@@ -119,7 +129,7 @@ export const apiData = onRequest({ cors: true, memory: "512MiB", concurrency: 1 
 
   if (!user_data) {
     res.status(400).json(MESSAGES.USER_DATA_NOT_FOUND);
-    await writeLog(experimentID, "logError", MESSAGES.USER_DATA_NOT_FOUND);
+    await writeLog(experimentID, "logError", MESSAGES.USER_DATA_NOT_FOUND, logContext);
     return;
   }
 
@@ -129,14 +139,14 @@ export const apiData = onRequest({ cors: true, memory: "512MiB", concurrency: 1 
   } catch (e) {
     const detail = e instanceof Error ? e.message : "Unknown error";
     res.status(500).json(MESSAGES.TOKEN_RESOLUTION_ERROR);
-    await writeLog(experimentID, "logError", {...MESSAGES.TOKEN_RESOLUTION_ERROR, detail});
+    await writeLog(experimentID, "logError", {...MESSAGES.TOKEN_RESOLUTION_ERROR, detail}, logContext);
     return;
   }
 
   if (!tokenResult.success) {
     const errorMessage = MESSAGES[tokenResult.error as keyof typeof MESSAGES] || MESSAGES.TOKEN_RESOLUTION_ERROR;
     res.status(400).json(errorMessage);
-    await writeLog(experimentID, "logError", {...errorMessage, detail: tokenResult.detail});
+    await writeLog(experimentID, "logError", {...errorMessage, detail: tokenResult.detail}, logContext);
     return;
   }
 
@@ -161,7 +171,7 @@ export const apiData = onRequest({ cors: true, memory: "512MiB", concurrency: 1 
       // participant's raw data never made it to OSF, so scheduled-pending-recovery
       // salvages it later instead of losing it outright.
       res.status(400).json(metadataResponse);
-      await writeLog(experimentID, "logError", {...MESSAGES.METADATA_ERROR, detail: metadataResponse.message});
+      await writeLog(experimentID, "logError", {...MESSAGES.METADATA_ERROR, detail: metadataResponse.message}, logContext);
       return;
     }
 
@@ -226,11 +236,17 @@ export const apiData = onRequest({ cors: true, memory: "512MiB", concurrency: 1 
         await exp_doc_ref.set({ sessions: FieldValue.increment(1) }, { merge: true });
         await cleanupPending(pendingPath); // queue-upload has its own copy
         res.status(202).json({...MESSAGES.OSF_UPLOAD_QUEUED, metadataMessage});
-        await writeLog(experimentID, "logError", {...MESSAGES.OSF_UPLOAD_EXCEPTION, detail: `Collision cache rehydration failed: ${detail}`});
+        // The submission is safe (queue-upload.ts holds an encrypted copy) but
+        // is not in the researcher's storage yet. Counted apart from both
+        // success and failure so that
+        //   failed = saveData - saveDataSucceeded - saveDataQueued
+        // holds exactly. See write-log.ts.
+        await writeLog(experimentID, "saveDataQueued", undefined, logContext);
+        await writeLog(experimentID, "logError", {...MESSAGES.OSF_UPLOAD_EXCEPTION, detail: `Collision cache rehydration failed: ${detail}`}, logContext);
         return;
       } catch {
         res.status(500).json({...MESSAGES.OSF_UPLOAD_EXCEPTION, metadataMessage});
-        await writeLog(experimentID, "logError", {...MESSAGES.OSF_UPLOAD_EXCEPTION, detail});
+        await writeLog(experimentID, "logError", {...MESSAGES.OSF_UPLOAD_EXCEPTION, detail}, logContext);
         return;
       }
     }
@@ -241,7 +257,7 @@ export const apiData = onRequest({ cors: true, memory: "512MiB", concurrency: 1 
     if (claimResult.reason === "duplicate") {
       await cleanupPending(pendingPath);
       res.status(400).json({...MESSAGES.OSF_FILE_EXISTS, metadataMessage});
-      await writeLog(experimentID, "logError", MESSAGES.OSF_FILE_EXISTS);
+      await writeLog(experimentID, "logError", MESSAGES.OSF_FILE_EXISTS, logContext);
       return;
     }
 
@@ -266,11 +282,12 @@ export const apiData = onRequest({ cors: true, memory: "512MiB", concurrency: 1 
       // is the identical hole.
       await queueDerivedFiles(derivedFiles, derivedTarget, "Collision cache rehydrating");
       res.status(202).json({...MESSAGES.OSF_UPLOAD_QUEUED, metadataMessage});
-      await writeLog(experimentID, "logError", {...MESSAGES.OSF_UPLOAD_EXCEPTION, detail: "Collision cache rehydrating"});
+      await writeLog(experimentID, "saveDataQueued", undefined, logContext);
+      await writeLog(experimentID, "logError", {...MESSAGES.OSF_UPLOAD_EXCEPTION, detail: "Collision cache rehydrating"}, logContext);
       return;
     } catch {
       res.status(500).json({...MESSAGES.OSF_UPLOAD_EXCEPTION, metadataMessage});
-      await writeLog(experimentID, "logError", {...MESSAGES.OSF_UPLOAD_EXCEPTION, detail: "Collision cache rehydrating"});
+      await writeLog(experimentID, "logError", {...MESSAGES.OSF_UPLOAD_EXCEPTION, detail: "Collision cache rehydrating"}, logContext);
       return;
     }
   }
@@ -307,6 +324,7 @@ export const apiData = onRequest({ cors: true, memory: "512MiB", concurrency: 1 
       // 44 loose raw sessions against 10 derived CSVs.
       await queueDerivedFiles(derivedFiles, derivedTarget, COMPACTION_HOLD_REASON, "CONTENTION");
       res.status(202).json({...MESSAGES.OSF_UPLOAD_QUEUED, metadataMessage});
+      await writeLog(experimentID, "saveDataQueued", undefined, logContext);
       return;
     } catch {
       res.status(500).json({...MESSAGES.OSF_UPLOAD_EXCEPTION, metadataMessage});
@@ -341,11 +359,12 @@ export const apiData = onRequest({ cors: true, memory: "512MiB", concurrency: 1 
       // OSF is unreachable, so queue the derived files alongside the raw data.
       await queueDerivedFiles(derivedFiles, derivedTarget, `Queued alongside data file: ${detail}`);
       res.status(202).json({...MESSAGES.OSF_UPLOAD_QUEUED, metadataMessage});
-      await writeLog(experimentID, "logError", {...MESSAGES.OSF_UPLOAD_EXCEPTION, detail});
+      await writeLog(experimentID, "saveDataQueued", undefined, logContext);
+      await writeLog(experimentID, "logError", {...MESSAGES.OSF_UPLOAD_EXCEPTION, detail}, logContext);
       return;
     } catch {
       res.status(500).json({...MESSAGES.OSF_UPLOAD_EXCEPTION, metadataMessage});
-      await writeLog(experimentID, "logError", {...MESSAGES.OSF_UPLOAD_EXCEPTION, detail});
+      await writeLog(experimentID, "logError", {...MESSAGES.OSF_UPLOAD_EXCEPTION, detail}, logContext);
       return;
     }
   }
@@ -359,11 +378,16 @@ export const apiData = onRequest({ cors: true, memory: "512MiB", concurrency: 1 
       // Logs are written BEFORE the response here (unlike other branches):
       // the disagreement entry is the dual-run's whole audit trail, and
       // responding first races observers of the log against the write.
-      await writeLog(experimentID, "logError", MESSAGES.OSF_FILE_EXISTS);
+      await writeLog(experimentID, "logError", MESSAGES.OSF_FILE_EXISTS, logContext);
       await writeLog(experimentID, "logError", {
+        // Carries an `error` code like every other entry so it lands in its
+        // own errorsByCode bucket instead of the UNCODED catch-all -- a
+        // dual-run disagreement is exactly the kind of thing worth counting
+        // per provider. The boolean stays for the existing audit trail.
+        error: "COLLISION_CACHE_DISAGREEMENT",
         collisionCacheDisagreement: true,
         direction: "cache-free-provider-conflict",
-      });
+      }, logContext);
       await cleanupPending(pendingPath);
       res.status(400).json({...MESSAGES.OSF_FILE_EXISTS, metadataMessage});
       return;
@@ -385,11 +409,12 @@ export const apiData = onRequest({ cors: true, memory: "512MiB", concurrency: 1 
       // same provider error code, since it's the same provider write path.
       await queueDerivedFiles(derivedFiles, derivedTarget, `Queued alongside data file: OSF error ${result.providerStatus}`, result.error);
       res.status(202).json({...MESSAGES.OSF_UPLOAD_QUEUED, metadataMessage});
-      await writeLog(experimentID, "logError", {...MESSAGES.OSF_UPLOAD_ERROR, osfStatus: result.providerStatus, osfStatusText: result.providerMessage});
+      await writeLog(experimentID, "saveDataQueued", undefined, logContext);
+      await writeLog(experimentID, "logError", {...MESSAGES.OSF_UPLOAD_ERROR, osfStatus: result.providerStatus, osfStatusText: result.providerMessage}, logContext);
       return;
     } catch {
       res.status(400).json({...MESSAGES.OSF_UPLOAD_ERROR, metadataMessage});
-      await writeLog(experimentID, "logError", {...MESSAGES.OSF_UPLOAD_ERROR, osfStatus: result.providerStatus, osfStatusText: result.providerMessage});
+      await writeLog(experimentID, "logError", {...MESSAGES.OSF_UPLOAD_ERROR, osfStatus: result.providerStatus, osfStatusText: result.providerMessage}, logContext);
       return;
     }
   }
@@ -397,6 +422,10 @@ export const apiData = onRequest({ cors: true, memory: "512MiB", concurrency: 1 
   // Successful write — confirm the claim (best-effort; a confirm failure
   // must not fail a request that already succeeded against the provider).
   await confirmClaim(experimentID, claimName, claimToken);
+
+  // The participant's file is in the researcher's storage. This is the only
+  // place in this handler that is true.
+  await writeLog(experimentID, "saveDataSucceeded", undefined, logContext);
 
   await exp_doc_ref.set({ sessions: FieldValue.increment(1) }, { merge: true });
 

--- a/functions/src/create-experiment.ts
+++ b/functions/src/create-experiment.ts
@@ -209,6 +209,35 @@ export const createExperiment = onRequest({ cors: true }, async (req, res) => {
       storageProvider: provider,
       providerContainer,
     });
+    // Seed logs/{id} in the batch that was already being committed, so the
+    // document exists with an owner from the moment the experiment does.
+    //
+    // Two reasons this is worth the field:
+    //
+    // 1. firestore.rules gates log reads on `resource.data.owner ==
+    //    request.auth.uid`. Nothing ever wrote that field, so the rule could
+    //    never pass and no researcher has ever been able to read their own
+    //    error log. Writing it on every log write (write-log.ts) fixes it for
+    //    an experiment that receives traffic; seeding it here fixes it for one
+    //    that has not received any yet.
+    //
+    // 2. `createdAt` is what makes `lastRequestAt` legible -- "no requests
+    //    since March" and "created yesterday, no requests yet" are different
+    //    situations. It also stands in for a firstRequestAt field, which would
+    //    have cost a read of this document on every submission to maintain.
+    //
+    // The counters are seeded at zero so that a log document is never a
+    // half-populated shape: an experiment with no submissions reads as
+    // saveData: 0, not as a missing field.
+    batch.set(db.collection("logs").doc(experimentID), {
+      owner: uid,
+      storageProvider: provider,
+      createdAt: FieldValue.serverTimestamp(),
+      saveData: 0,
+      saveBase64Data: 0,
+      getCondition: 0,
+      logError: 0,
+    });
     // set+merge (not update) -- a freshly-signed-up user may have no
     // Firestore doc yet, same rationale as connect-provider.ts's
     // set()+mergeFields for connectedAccounts.

--- a/functions/src/interfaces.ts
+++ b/functions/src/interfaces.ts
@@ -256,6 +256,61 @@ export interface ExperimentData {
     providerContainer?: ContainerRef;
   }
 
+  /**
+   * logs/{experimentID} — the per-experiment activity record. Written only by
+   * functions/src/write-log.ts (and seeded by create-experiment.ts); read by
+   * the experiment dashboard and by service-health queries.
+   *
+   * Every field is optional because a document written before this shape
+   * existed has almost none of them, and the backfill script only restores
+   * `owner`/`storageProvider`. Read defensively.
+   */
+  export interface ExperimentLog {
+    // Identity. `owner` is what firestore.rules checks; `storageProvider` is
+    // denormalized from the experiment so that per-provider failure rates are
+    // a query rather than a scan.
+    owner?: string;
+    storageProvider?: StorageProviderId;
+
+    // Request attempts, counted only for requests that reached a real
+    // experiment.
+    saveData?: number;
+    saveBase64Data?: number;
+    getCondition?: number;
+
+    // Outcomes. There is no ...Failed counter by design:
+    //   failed = saveData - saveDataSucceeded - saveDataQueued
+    saveDataSucceeded?: number;
+    saveDataQueued?: number;
+    saveBase64DataSucceeded?: number;
+    saveBase64DataQueued?: number;
+
+    // Errors: a total, a tally by api-messages.ts code, and the most recent
+    // MAX_ERROR_ENTRIES entries. `errors` is capped, so its length is NOT the
+    // total — `logError` is.
+    logError?: number;
+    errorsByCode?: Record<string, number>;
+    errors?: ExperimentLogError[];
+
+    // Activity window. `createdAt` is set once, when the experiment is
+    // created; `lastRequestAt` moves on every logged request.
+    createdAt?: FirebaseFirestore.Timestamp;
+    lastRequestAt?: FirebaseFirestore.Timestamp;
+  }
+
+  export interface ExperimentLogError {
+    // The api-messages.ts code, when the entry came from one. Absent on older
+    // entries and on entries that predate the code being carried.
+    error?: string;
+    message?: string;
+    detail?: string;
+    // A Timestamp on entries written after this change; a preformatted en-GB
+    // string on the ones already in the array when it landed. Consumers must
+    // handle both until the cap has rotated the old entries out.
+    time?: FirebaseFirestore.Timestamp | string;
+    [key: string]: unknown;
+  }
+
   export interface OSFFile{
     id: string;
     attributes: {

--- a/functions/src/metadata-derived-upload.ts
+++ b/functions/src/metadata-derived-upload.ts
@@ -88,6 +88,11 @@ export async function queueDerivedFiles(
   failureReason: string,
   providerErrorCode?: ProviderErrorCode,
 ): Promise<void> {
+  // The target already carries the two fields logs/{id} needs to identify
+  // itself (write-log.ts) -- it is built from the experiment document in
+  // api-data.ts.
+  const logContext = { owner: target.owner, storageProvider: target.storageProvider };
+
   for (const file of files) {
     try {
       await queueUpload({
@@ -104,10 +109,10 @@ export async function queueDerivedFiles(
         sessionIncremented: true,
         failureReason,
       });
-      await writeLog(target.experimentID, "logError", {...MESSAGES.OSF_UPLOAD_QUEUED, detail: `derived file ${file.filename}: ${failureReason}`});
+      await writeLog(target.experimentID, "logError", {...MESSAGES.OSF_UPLOAD_QUEUED, detail: `derived file ${file.filename}: ${failureReason}`}, logContext);
     } catch (e) {
       const detail = e instanceof Error ? e.message : "Unknown error";
-      await writeLog(target.experimentID, "logError", {...MESSAGES.OSF_UPLOAD_ERROR, detail: `derived file ${file.filename} could not be queued: ${detail}`});
+      await writeLog(target.experimentID, "logError", {...MESSAGES.OSF_UPLOAD_ERROR, detail: `derived file ${file.filename} could not be queued: ${detail}`}, logContext);
     }
   }
 }

--- a/functions/src/write-log.ts
+++ b/functions/src/write-log.ts
@@ -1,39 +1,187 @@
 import { db } from "./app.js";
 import { FieldValue, Timestamp } from "firebase-admin/firestore";
+import { StorageProviderId } from "./providers/types.js";
 
-export default async function writeLog(experimentID: string, action: "saveData" | "saveBase64Data" | "getCondition" | "getSession" | "logError", error? : object) {
+/**
+ * logs/{experimentID} — the per-experiment activity record.
+ *
+ * Two audiences read this document, and they want different things from it:
+ *
+ *  - The researcher, through the experiment dashboard, wants to know whether
+ *    submissions are being rejected and why.
+ *  - The service operator wants to answer cross-experiment questions — which
+ *    storage providers are failing, how often, and which experiments are still
+ *    live — without scanning every experiment's data.
+ *
+ * WHAT CHANGED AND WHY
+ *
+ * 1. `owner` is now written on every log write. It was never written at all,
+ *    while firestore.rules gates reads on `resource.data.owner ==
+ *    request.auth.uid` — so the rule could never pass and NO researcher ever
+ *    saw their own error log. The dashboard subscription failed silently and
+ *    ErrorPanel simply never rendered. Log documents created before this
+ *    change still have no owner; functions/scripts/backfill-log-owner.mjs
+ *    exists to fix those once.
+ *
+ * 2. `storageProvider` is denormalized here. Counting experiments per provider
+ *    is better done against the experiments collection (that is the source of
+ *    truth, and a count() aggregation answers it directly). What experiments
+ *    cannot answer is the per-provider FAILURE rate, which needs the provider
+ *    name and the error tallies in the same document.
+ *
+ * 3. `errors` is capped at MAX_ERROR_ENTRIES. It grew by arrayUnion with no
+ *    bound, inside a document with a 1 MB ceiling. An experiment that errors
+ *    on every submission would eventually make every write to this document
+ *    fail — taking the counters down with it. The cap costs one read per error
+ *    (the transaction below); error paths are the exceptional case, and the
+ *    counter paths still take no read at all.
+ *
+ * 4. `time` on an error entry is a real Timestamp, not a preformatted en-GB
+ *    string. The string could not be sorted, filtered, or aged out. It is
+ *    Timestamp.now() rather than serverTimestamp() because Firestore rejects
+ *    sentinel values inside an array — so this is the function's clock, not
+ *    the server's, and may differ by milliseconds.
+ *
+ * 5. The counter and the error entry are written in ONE operation. They used
+ *    to be two separate non-atomic set() calls, which left the document with
+ *    `logError > 0` and no `errors` field in between — a state the dashboard
+ *    had to defend against (see components/dashboard/ErrorPanel.js).
+ *
+ * 6. `errorsByCode` tallies errors by their api-messages.ts code. Combined
+ *    with `storageProvider` this is what makes "which provider is failing and
+ *    how" a query rather than a scan, and it is a fixed-size map rather than
+ *    an unbounded array.
+ *
+ * WHAT IS DELIBERATELY NOT HERE
+ *
+ * `firstRequestAt`. Recording it needs a read of this document on the hot
+ * submission path just to discover whether the field is already set, and
+ * Firestore has no set-if-absent sentinel. `createdAt` — seeded by
+ * create-experiment.ts in a batch it was already committing, so it costs
+ * nothing — answers the same question, and `lastRequestAt` covers recency.
+ *
+ * A per-request event trail. One document per submission would multiply
+ * writes by the request rate. The counters plus the last MAX_ERROR_ENTRIES
+ * rejections are what the dashboard and the health queries actually read.
+ */
+
+// One increment per API call that reached a real experiment. These count
+// ATTEMPTS: `saveData` is incremented after the experiment document is
+// confirmed to exist, so a request carrying a garbage experiment ID no longer
+// inflates the count (or creates a log document that nobody can ever read).
+export type LogCounter = "saveData" | "saveBase64Data" | "getCondition";
+
+// One increment per request that reached a definite non-failure outcome.
+// "Succeeded" means the file is in the researcher's storage now; "Queued"
+// means DataPipe holds it and will retry (an HTTP 202).
+//
+// There is no ...Failed counter: failures are every remaining attempt, so
+//   failed = saveData - saveDataSucceeded - saveDataQueued
+// exactly, and a counter that has to be incremented at nineteen separate
+// return points is a counter that will drift the first time a branch is added.
+export type LogOutcome =
+  | "saveDataSucceeded"
+  | "saveDataQueued"
+  | "saveBase64DataSucceeded"
+  | "saveBase64DataQueued";
+
+export type LogAction = LogCounter | LogOutcome | "logError";
+
+// Identity for the log document, taken from the experiment the request
+// resolved to. Every call site that has already read the experiment passes
+// this; the ones that could not (the experiment does not exist) pass nothing,
+// and the fields are simply omitted rather than written as undefined, which
+// Firestore rejects.
+export interface LogContext {
+  owner?: string;
+  storageProvider?: StorageProviderId | string;
+}
+
+// Chosen against the 1 MB document limit with room to spare: an error entry
+// carrying a long provider message runs a few hundred bytes, so fifty of them
+// is tens of kilobytes. The dashboard shows twenty.
+export const MAX_ERROR_ENTRIES = 50;
+
+// Bucket for an error entry with no api-messages.ts code of its own.
+export const UNCODED_ERROR = "UNCODED";
+
+function identityFields(context?: LogContext): Record<string, unknown> {
+  const fields: Record<string, unknown> = {};
+  if (context?.owner) fields.owner = context.owner;
+  if (context?.storageProvider) fields.storageProvider = context.storageProvider;
+  return fields;
+}
+
+// Firestore map keys cannot contain . / ~ * [ ]. Every code in
+// api-messages.ts is already [A-Z_]+, so this only ever fires on an entry
+// that invented its own code — but a rejected write here would take the
+// counter down with it, and a log write must never be the thing that fails.
+function safeCodeKey(code: string): string {
+  const cleaned = code.replace(/[./~*[\]]/g, "_").slice(0, 100);
+  return cleaned.length > 0 ? cleaned : UNCODED_ERROR;
+}
+
+function errorCodeOf(error?: object): string {
+  const code = (error as { error?: unknown } | undefined)?.error;
+  return typeof code === "string" && code.length > 0
+    ? safeCodeKey(code)
+    : UNCODED_ERROR;
+}
+
+export default async function writeLog(
+  experimentID: string,
+  action: LogAction,
+  error?: object,
+  context?: LogContext
+): Promise<boolean> {
   try {
     const log_doc_ref = db.collection("logs").doc(experimentID);
-    if (action === "saveData") {
+
+    // Counters and outcomes: a single merge, no read.
+    if (action !== "logError") {
       await log_doc_ref.set(
-        { saveData: FieldValue.increment(1) },
+        {
+          ...identityFields(context),
+          [action]: FieldValue.increment(1),
+          lastRequestAt: FieldValue.serverTimestamp(),
+        },
         { merge: true }
       );
+      return true;
     }
-    if (action === "saveBase64Data") {
-      await log_doc_ref.set(
-        { saveBase64Data: FieldValue.increment(1) },
+
+    // ISSUE #76. The transaction is what makes the cap possible: arrayUnion
+    // can append but cannot trim, so the tail has to be computed from the
+    // current value. It also collapses what used to be two non-atomic writes
+    // into one.
+    const entry = { ...error, time: Timestamp.now() };
+    const code = errorCodeOf(error);
+
+    await db.runTransaction(async (t) => {
+      const snap = await t.get(log_doc_ref);
+      const existing = snap.exists ? snap.get("errors") : undefined;
+      const errors: unknown[] = Array.isArray(existing) ? existing : [];
+      // Oldest entries fall off the front. slice(-N) on an array shorter than
+      // N returns the whole array, so this is also correct while filling up.
+      const trimmed = [...errors, entry].slice(-MAX_ERROR_ENTRIES);
+
+      t.set(
+        log_doc_ref,
+        {
+          ...identityFields(context),
+          logError: FieldValue.increment(1),
+          // Nested map, not an "errorsByCode.CODE" dotted key: set() with
+          // merge treats a dot in a key as part of the field NAME, unlike
+          // update(). The increment sentinel applies correctly inside a
+          // nested map under merge.
+          errorsByCode: { [code]: FieldValue.increment(1) },
+          errors: trimmed,
+          lastRequestAt: FieldValue.serverTimestamp(),
+        },
         { merge: true }
       );
-    }
-    if (action === "getCondition") {
-      await log_doc_ref.set(
-        { getCondition: FieldValue.increment(1) },
-        { merge: true }
-      );
-    }
-    if (action === "logError") {  // ISSUE #76
-      await log_doc_ref.set(
-        { logError: FieldValue.increment(1)},
-        { merge: true }
-      );
-      const date = new Date(Timestamp.now().toDate());
-      const shortDate = new Intl.DateTimeFormat( 'en-GB', { dateStyle: 'short', timeStyle: 'long'} ).format(date);
-      await log_doc_ref.set( 
-      { errors: FieldValue.arrayUnion({...error, time: shortDate})},
-      { merge: true }
-      )
-    }
+    });
+
     return true;
   } catch (error) {
     console.error(`writeLog failed for experiment ${experimentID}, action ${action}:`, error instanceof Error ? error.message : error);

--- a/pages/admin/[experiment_id].js
+++ b/pages/admin/[experiment_id].js
@@ -259,7 +259,13 @@ function ExperimentPageDashboard({ experiment_id }) {
 
           {showResolved && <UploadsResolvedNotice />}
 
-          {showErrorPanel && <ErrorPanel errors={errorLog} />}
+          {/* `uploadError` is logs/{id}.logError -- the lifetime count. It is
+              passed alongside the array because write-log.ts caps the array
+              at 50 entries, so its length is a floor on the real number, not
+              the number itself. */}
+          {showErrorPanel && (
+            <ErrorPanel errors={errorLog} totalCount={uploadError} />
+          )}
 
           {queueEntries.length > 0 && (
             <QueuePanel entries={queueEntries} experimentId={experiment_id} />

--- a/pages/docs/privacy.js
+++ b/pages/docs/privacy.js
@@ -217,9 +217,13 @@ export default function PrivacyPage() {
               Your experiment&apos;s configuration and its log.
             </Text>{" "}
             The log records how many requests of each kind the experiment
-            received, plus a list of errors with timestamps. No participant data
-            is written to it. An error entry can, however, contain the filename
-            your experiment chose and the error message your storage provider
+            received and how they turned out, which storage provider it is
+            configured for, when it was created, when it last received a
+            request, a tally of errors by type, and the fifty most recent
+            errors with timestamps. Older error entries are discarded as newer
+            ones arrive; the tallies are not. No participant data is written to
+            it. An error entry can, however, contain the filename your
+            experiment chose and the error message your storage provider
             returned.
           </List.Item>
           <List.Item>


### PR DESCRIPTION
## The bug nobody could see

`firestore.rules:206` gates log reads on `resource.data.owner == request.auth.uid`. **No revision of `write-log.ts` has ever written an `owner` field**, so that rule could never pass for any document in the collection. The dashboard's `logs/{id}` subscription failed silently, `logs` came back `null`, and `ErrorPanel` never rendered — researchers have not been able to see their own rejected submissions at all.

`owner` is now written on every log write and seeded by `create-experiment.ts`. `functions/scripts/backfill-log-owner.mjs` repairs documents already in production (dry run by default, `--apply` to write, same shape as the other scripts in that directory).

## What the document holds now

```
logs/{experimentID}
  owner              ← NEW (the fix above)
  storageProvider    ← NEW
  createdAt          ← NEW (seeded at experiment creation)
  lastRequestAt      ← NEW
  saveData / saveBase64Data / getCondition        attempts
  saveDataSucceeded / saveDataQueued              ← NEW
  saveBase64DataSucceeded / saveBase64DataQueued  ← NEW
  logError           lifetime total
  errorsByCode: { EXPERIMENT_NOT_FOUND: 3, ... }  ← NEW
  errors: [ { error, message, detail, time: Timestamp } ]  capped at 50
```

## Structural fixes

**`errors` is capped at 50.** It grew by `arrayUnion` with no bound inside a document with a 1 MB ceiling — an experiment erroring on every submission would eventually make *every* write to the document fail, counters included. `arrayUnion` cannot trim, so the cap needs the current value and goes through a transaction. That also collapses what were two non-atomic `set()` calls into one, closing the `logError > 0` with no `errors` field window that `ErrorPanel` had to defend against.

**`time` is a real `Timestamp`**, not a preformatted en-GB string, so entries can be sorted and filtered. `Timestamp.now()` rather than `serverTimestamp()` because Firestore rejects sentinels inside an array. Entries written before this change keep their string; `ErrorPanel` renders both until the cap rotates them out.

**Attempts are counted after the experiment-exists check.** Counting first meant any POST with a garbage ID inflated the request totals and created an ownerless document nobody could ever read.

## Two judgment calls

**No `saveDataFailed` counter.** Failures are `saveData − saveDataSucceeded − saveDataQueued`, exactly. A counter needing increments at nineteen separate return points would drift the first time someone added a branch. `saveDataQueued` exists as a third outcome so the arithmetic closes — a queued submission is neither stored nor refused.

**`createdAt` instead of `firstRequestAt`.** Maintaining `firstRequestAt` needs a read of the log document on every submission just to discover whether the field is already set (Firestore has no set-if-absent sentinel). Seeding `createdAt` in a batch `create-experiment` was already committing costs nothing and answers the same question alongside `lastRequestAt`.

## Explicitly not in scope

Counting experiments per storage provider. `experiments.storageProvider` is the source of truth and a `count()` aggregation answers it directly — denormalizing it into logs for that purpose would be sync burden for a query that already works. What `experiments` *cannot* answer is the per-provider **failure rate**, which is what `storageProvider` + `errorsByCode` in the same document are for.

## Docs

`pages/docs/privacy.js` now describes what the log keeps and the 50-entry rotation.

## Testing

`npx firebase emulators:exec --project datapipe-test 'npm run test-ci'` → **1074 / 1075 pass**.

The single failure is `oauth-connect-emulator` case 4, a pre-existing cross-suite race: `mockTokenServer.getLastRequest()` picks up a request from `oauth-connect-refresh-emulator`, which shares the same mock server. It passes in isolation and touches nothing in this change.

`tsc`, `next build`, and `npm run lint` are clean.

New coverage: `errorsByCode` tallying, `Timestamp` stamping, the 50-entry cap evicting oldest-first while `logError` keeps climbing, `owner`/`storageProvider` on both API paths, the seeded log document at experiment creation, and a regression test that a nonexistent experiment ID no longer increments `saveData`.

## Deploy note

Run `node functions/scripts/backfill-log-owner.mjs` (dry run first) after deploying, or dormant experiments' logs stay unreadable to their owners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SHZNijLwUhn26yCbYbn1UN
