### PR TITLE
Stop a validation checkbox from flipping the switch above it

### DIFF
--- a/__tests__/experiment-validation.test.jsx
+++ b/__tests__/experiment-validation.test.jsx
@@ -160,3 +160,77 @@ describe("ExperimentValidation — required fields", () => {
     expect(screen.queryByText("Required fields")).not.toBeInTheDocument();
   });
 });
+
+const masterSwitch = () =>
+  screen.getByRole("checkbox", { name: /Check submissions before storing/i });
+
+// Regression: the format checkboxes render as SettingsRow's `children`, and
+// those children used to sit inside the row's `Field.Root`. Ark hands every
+// Switch AND Checkbox in a Field the same hidden-input id
+// (`ids: { hiddenInput: field?.ids.control }`), and `Checkbox.Root` is itself
+// a `<label htmlFor>` -- so clicking "Allow CSV" resolved to the FIRST element
+// carrying that id, which is the master switch above it. Validation silently
+// turned itself off and the whole block collapsed out from under the click.
+//
+// These click the LABELS, not the inputs: clicking an input directly never
+// went through the broken path, so a test that does that passes either way.
+describe("ExperimentValidation — format checkboxes", () => {
+  it("does not touch the master switch when a format is unticked", async () => {
+    renderWithChakra(<ExperimentValidation data={experiment()} />);
+
+    expect(masterSwitch()).toBeChecked();
+
+    fireEvent.click(screen.getByText("Allow CSV"));
+
+    await waitFor(() => expect(setDocMock).toHaveBeenCalledTimes(1));
+
+    expect(masterSwitch()).toBeChecked();
+    expect(setDocMock.mock.calls[0][1]).toEqual({
+      allowJSON: true,
+      allowCSV: false,
+      requiredFields: ["trial_type"],
+    });
+  });
+
+  it("keeps the dependent controls on screen after a click", async () => {
+    renderWithChakra(<ExperimentValidation data={experiment()} />);
+
+    fireEvent.click(screen.getByText("Allow JSON"));
+
+    await waitFor(() => expect(setDocMock).toHaveBeenCalledTimes(1));
+    expect(screen.getByText("Required fields")).toBeInTheDocument();
+    expect(screen.getByText("Allow CSV")).toBeInTheDocument();
+  });
+
+  it("gives the switch and each checkbox its own input id", () => {
+    renderWithChakra(<ExperimentValidation data={experiment()} />);
+
+    const ids = screen
+      .getAllByRole("checkbox")
+      .map((el) => el.getAttribute("id"));
+
+    expect(ids).toHaveLength(3);
+    expect(new Set(ids).size).toBe(3);
+  });
+});
+
+describe("ExperimentValidation — master switch", () => {
+  it("hides the format checkboxes when validation is off", () => {
+    renderWithChakra(
+      <ExperimentValidation data={experiment({ useValidation: false })} />
+    );
+    expect(screen.queryByText("Allow CSV")).not.toBeInTheDocument();
+  });
+
+  it("writes only useValidation when the switch is flipped", async () => {
+    renderWithChakra(
+      <ExperimentValidation data={experiment({ useValidation: false })} />
+    );
+
+    fireEvent.click(masterSwitch());
+
+    await waitFor(() => expect(setDocMock).toHaveBeenCalledTimes(1));
+    expect(setDocMock.mock.calls[0][1]).toEqual({ useValidation: true });
+    expect(screen.getByText("Allow CSV")).toBeInTheDocument();
+  });
+});

--- a/components/ui/SettingsRow.js
+++ b/components/ui/SettingsRow.js
@@ -340,47 +340,68 @@ export default function SettingsRow({
   };
 
   return (
-    <Field.Root>
-      <Stack w="100%" gap={0}>
-        <HStack justify="space-between" alignItems="center" w="100%" gap={4}>
-          <HStack gap={2} alignItems="center" minW={0}>
-            <Field.Label fontWeight="normal" mb={0} color="fg">
-              {label}
-            </Field.Label>
-            {badge}
+    <Stack w="100%" gap={0}>
+      {/* The Field wraps ONLY the switch and its label. It must not wrap
+          `children`, and that is not a stylistic preference.
+
+          Ark's `useSwitch` and `useCheckbox` both take their hidden input's
+          id from the surrounding Field context -- literally
+          `ids: { hiddenInput: field?.ids.control }`. So a Checkbox rendered
+          inside this row's Field.Root was handed the SAME DOM id as the
+          switch's hidden input. `Checkbox.Root` is itself a
+          `<label htmlFor={thatId}>`, and the browser resolves a label to the
+          FIRST element in the document carrying that id -- the switch, which
+          renders above. Ticking "Allow CSV" in the validation panel therefore
+          flipped the row's switch instead: validation turned itself off and
+          the dependent block collapsed out from under the click. The label
+          ids collided the same way.
+
+          Dependent controls open their own fields (the numeric inputs in
+          ExperimentActive, the required-fields box in ExperimentValidation),
+          so nothing below needs this context -- and anything that inherits it
+          is broken by it. */}
+      <Field.Root>
+        <Stack w="100%" gap={0}>
+          <HStack justify="space-between" alignItems="center" w="100%" gap={4}>
+            <HStack gap={2} alignItems="center" minW={0}>
+              <Field.Label fontWeight="normal" mb={0} color="fg">
+                {label}
+              </Field.Label>
+              {badge}
+            </HStack>
+            {/* The confirmation rides in the same group as the switch, on the
+                switch's left, so it reads as belonging to THIS row. It holds
+                its width whether or not it is showing, which is what keeps
+                the switch from sliding sideways when a save lands. */}
+            <HStack gap={3} alignItems="center" flexShrink={0}>
+              <SavedFlag saved={saved} savedLabel={savedLabel} />
+              <Switch.Root
+                colorPalette="brandGreen"
+                size="md"
+                checked={value}
+                disabled={disabled}
+                onCheckedChange={(e) => handleChange(e.checked)}
+              >
+                <Switch.HiddenInput />
+                <Switch.Control>
+                  <Switch.Thumb />
+                </Switch.Control>
+              </Switch.Root>
+            </HStack>
           </HStack>
-          {/* The confirmation rides in the same group as the switch, on the
-              switch's left, so it reads as belonging to THIS row. It holds
-              its width whether or not it is showing, which is what keeps the
-              switch from sliding sideways when a save lands. */}
-          <HStack gap={3} alignItems="center" flexShrink={0}>
-            <SavedFlag saved={saved} savedLabel={savedLabel} />
-            <Switch.Root
-              colorPalette="brandGreen"
-              size="md"
-              checked={value}
-              disabled={disabled}
-              onCheckedChange={(e) => handleChange(e.checked)}
-            >
-              <Switch.HiddenInput />
-              <Switch.Control>
-                <Switch.Thumb />
-              </Switch.Control>
-            </Switch.Root>
-          </HStack>
-        </HStack>
 
-        {description && <GuidanceLine mt={2}>{description}</GuidanceLine>}
+          {description && <GuidanceLine mt={2}>{description}</GuidanceLine>}
+        </Stack>
+      </Field.Root>
 
-        <SaveError error={error} />
+      <SaveError error={error} />
 
-        {children && (
-          <Box w="100%" mt={3}>
-            {children}
-          </Box>
-        )}
-      </Stack>
-    </Field.Root>
+      {children && (
+        <Box w="100%" mt={3}>
+          {children}
+        </Box>
+      )}
+    </Stack>
   );
 }
 


### PR DESCRIPTION
## The bug

In `/admin/<experiment>`, ticking **Allow CSV** or **Allow JSON** turned data validation **off** and collapsed the block the checkbox lives in. The click did the opposite of what it said, and the setting it silently changed is the one that decides whether malformed submissions are rejected before they reach the researcher's storage provider.

## Cause

An id collision, not anything in the validation logic.

Ark derives a control's hidden-input id from the surrounding Field context — `useSwitch` and `useCheckbox` both do:

```js
ids: { label: field?.ids.label, hiddenInput: field?.ids.control }
```

`SettingsRow` rendered its `children` inside the row's own `Field.Root`, so both checkboxes were handed the **same DOM id** as the master switch's hidden input. `Checkbox.Root` is itself a `<label htmlFor={thatId}>`, and the browser resolves a label to the **first** element in the document carrying that id — the switch, which renders above. So clicking the checkbox activated the switch.

## Fix

The `Field.Root` now wraps only the switch and its label/description; `SaveError` and `children` move out to an enclosing `Stack`.

Dependent controls elsewhere (the numeric inputs in `ExperimentActive`, the required-fields input in `ExperimentValidation`) each open their own `Field.Root` already, so they were never affected and stay unaffected. Only controls that *inherited* the row's field were broken by it — which is why the fix belongs in `SettingsRow` rather than in any one call site.

## Tests

Five cases added to `__tests__/experiment-validation.test.jsx`. They click the **labels**, not the inputs: clicking an input directly never went through the broken path, so a test that does that passes either way. Three of the five fail against the previous `SettingsRow` and pass now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SHZNijLwUhn26yCbYbn1UN