### PR TITLE
Refuse to untick the last allowed submission format

### DIFF
--- a/__tests__/experiment-validation.test.jsx
+++ b/__tests__/experiment-validation.test.jsx
@@ -202,6 +202,60 @@ describe("ExperimentValidation — format checkboxes", () => {
     expect(screen.getByText("Allow CSV")).toBeInTheDocument();
   });
 
+  // With validation on and neither format allowed, api-data.ts skips both
+  // validators and every submission takes the 400 -- the experiment stops
+  // collecting and the log blames the participant's data. The control refuses
+  // rather than saving it.
+  it("refuses to untick the last remaining format", async () => {
+    renderWithChakra(
+      <ExperimentValidation data={experiment({ allowJSON: false })} />
+    );
+
+    const csv = screen.getByRole("checkbox", { name: "Allow CSV" });
+    expect(csv).toBeChecked();
+
+    fireEvent.click(screen.getByText("Allow CSV"));
+    await act(async () => {});
+
+    expect(csv).toBeChecked();
+    expect(setDocMock).not.toHaveBeenCalled();
+    expect(screen.getByText(/at least one format has to stay allowed/i))
+      .toBeInTheDocument();
+  });
+
+  it("still allows unticking a format when the other one is on", async () => {
+    renderWithChakra(<ExperimentValidation data={experiment()} />);
+
+    fireEvent.click(screen.getByText("Allow CSV"));
+
+    await waitFor(() => expect(setDocMock).toHaveBeenCalledTimes(1));
+    expect(setDocMock.mock.calls[0][1].allowCSV).toBe(false);
+    expect(
+      screen.queryByText(/at least one format has to stay allowed/i)
+    ).not.toBeInTheDocument();
+  });
+
+  it("lets the refused format be re-ticked afterwards", async () => {
+    renderWithChakra(
+      <ExperimentValidation data={experiment({ allowJSON: false })} />
+    );
+
+    // Refused: the box stays ticked, so the next click is an untick again.
+    fireEvent.click(screen.getByText("Allow CSV"));
+    await act(async () => {});
+    expect(setDocMock).not.toHaveBeenCalled();
+
+    // The refusal must not have wedged the group -- adding the other format
+    // still saves.
+    fireEvent.click(screen.getByText("Allow JSON"));
+    await waitFor(() => expect(setDocMock).toHaveBeenCalledTimes(1));
+    expect(setDocMock.mock.calls[0][1]).toEqual({
+      allowJSON: true,
+      allowCSV: true,
+      requiredFields: ["trial_type"],
+    });
+  });
+
   it("gives the switch and each checkbox its own input id", () => {
     renderWithChakra(<ExperimentValidation data={experiment()} />);
 

--- a/components/dashboard/ExperimentValidation.js
+++ b/components/dashboard/ExperimentValidation.js
@@ -1,4 +1,4 @@
-import { HStack, Stack, Checkbox, CheckboxGroup } from "@chakra-ui/react";
+import { HStack, Stack, Text, Checkbox, CheckboxGroup } from "@chakra-ui/react";
 
 import { useEffect, useRef, useState } from "react";
 
@@ -10,6 +10,7 @@ import SettingsRow, {
   useTrackedSave,
 } from "../ui/SettingsRow";
 import TagListInput, { normalizeList } from "../ui/TagListInput";
+import useTransientNotice from "../ui/useTransientNotice";
 import { SwitchTable } from "./SectionPanel";
 
 function writeExperiment(expId, fields) {
@@ -46,6 +47,69 @@ export default function ExperimentValidation({ data }) {
       "submissions against the previous rules -- check your connection and " +
       "try again."
   );
+
+  const { notice: formatNotice, say: sayFormatNotice } = useTransientNotice();
+
+  const formatGroupRef = useRef(null);
+
+  /**
+   * Refuses to untick the last remaining format.
+   *
+   * With validation on and neither format allowed, `api-data.ts` cannot reach
+   * either validator: `valid` starts false, both branches are skipped, and
+   * every submission takes the 400. The experiment silently stops collecting,
+   * and the error the researcher eventually finds in the log says the DATA is
+   * invalid -- pointing at the participant's submission, when the submission
+   * never mattered.
+   *
+   * There is no legitimate reading of "validate submissions, accept nothing",
+   * so the control declines rather than saving it. Declining means simply not
+   * calling `setValidationSettings`: the group is controlled, so the tick mark
+   * never moves and the save effect never fires. The notice is what stops that
+   * from looking like a dead checkbox.
+   *
+   * This is a UI floor, not a guarantee. The server is unchanged, so a
+   * document that already holds the state -- or one written any other way --
+   * still behaves as before. Deliberate: see the PR discussion.
+   */
+  const handleFormatChange = (values) => {
+    if (values.length === 0) {
+      sayFormatNotice(
+        "At least one format has to stay allowed. With neither, every " +
+          "submission would be rejected."
+      );
+      resyncFormatInputs();
+      return;
+    }
+    setValidationSettings(values);
+  };
+
+  /**
+   * Puts the native checkbox inputs back in agreement with our state after a
+   * refusal.
+   *
+   * Ark has already flipped the real `<input>` by the time `onValueChange`
+   * runs. Refusing leaves `validationSettings` untouched, so React re-renders
+   * with the same `checked` prop it rendered last time and does not reset the
+   * node. What the researcher SEES is still right -- the tick mark is drawn
+   * from the controlled group value, so it never moved -- but the hidden input
+   * is what the accessibility tree reads, and it now says unchecked. A
+   * screen-reader user would be told the box they just refused had been
+   * unticked, which is the opposite of what happened and worse than no
+   * feedback at all.
+   *
+   * `queueMicrotask` so this lands after React has finished the render the
+   * notice triggers; setting the property during the handler is undone by it.
+   */
+  function resyncFormatInputs() {
+    queueMicrotask(() => {
+      const inputs =
+        formatGroupRef.current?.querySelectorAll('input[type="checkbox"]') ?? [];
+      inputs.forEach((input) => {
+        input.checked = validationSettings.includes(input.value);
+      });
+    });
+  }
 
   // The last values Firestore is known to hold, so a failed write can put the
   // form back to the truth rather than leaving it showing rules that are not
@@ -136,40 +200,58 @@ export default function ExperimentValidation({ data }) {
                 right of the block, holding its width, rather than mounting a
                 line under the textarea and shoving the section below down
                 every time a checkbox is ticked. */}
-            <HStack
-              justify="space-between"
-              alignItems="center"
-              w="100%"
-              gap={4}
-            >
-              <CheckboxGroup
-                value={validationSettings}
-                onValueChange={(values) => {
-                  setValidationSettings(values);
-                }}
+            {/* gap={2}, so the message line reads as attached to the
+                checkboxes rather than as a third item in the gap={4} column
+                the block is laid out in. */}
+            <Stack gap={2} w="100%">
+              <HStack
+                justify="space-between"
+                alignItems="center"
+                w="100%"
+                gap={4}
               >
-                <Stack gap={6} direction="row">
-                  <Checkbox.Root value="json" colorPalette="brandGreen">
-                    <Checkbox.HiddenInput />
-                    <Checkbox.Control>
-                      <Checkbox.Indicator />
-                    </Checkbox.Control>
-                    <Checkbox.Label>Allow JSON</Checkbox.Label>
-                  </Checkbox.Root>
-                  <Checkbox.Root value="csv" colorPalette="brandGreen">
-                    <Checkbox.HiddenInput />
-                    <Checkbox.Control>
-                      <Checkbox.Indicator />
-                    </Checkbox.Control>
-                    <Checkbox.Label>Allow CSV</Checkbox.Label>
-                  </Checkbox.Root>
-                </Stack>
-              </CheckboxGroup>
-              <SavedFlag
-                saved={detailSave.saved}
-                savedLabel="Validation rules saved"
-              />
-            </HStack>
+                <CheckboxGroup
+                  value={validationSettings}
+                  onValueChange={handleFormatChange}
+                >
+                  <Stack gap={6} direction="row" ref={formatGroupRef}>
+                    <Checkbox.Root value="json" colorPalette="brandGreen">
+                      <Checkbox.HiddenInput />
+                      <Checkbox.Control>
+                        <Checkbox.Indicator />
+                      </Checkbox.Control>
+                      <Checkbox.Label>Allow JSON</Checkbox.Label>
+                    </Checkbox.Root>
+                    <Checkbox.Root value="csv" colorPalette="brandGreen">
+                      <Checkbox.HiddenInput />
+                      <Checkbox.Control>
+                        <Checkbox.Indicator />
+                      </Checkbox.Control>
+                      <Checkbox.Label>Allow CSV</Checkbox.Label>
+                    </Checkbox.Root>
+                  </Stack>
+                </CheckboxGroup>
+                <SavedFlag
+                  saved={detailSave.saved}
+                  savedLabel="Validation rules saved"
+                />
+              </HStack>
+              {/* ONE line, always exactly one line's worth of box, whether it
+                  is holding guidance or the refusal -- same slot discipline as
+                  TagListInput's message line, and for the same reason: a
+                  message that mounts underneath would push the required-fields
+                  control and the save-error block down a row every time a
+                  checkbox is clicked. */}
+              <Text
+                fontSize="sm"
+                maxW="70ch"
+                color={formatNotice ? "brandOrange.fg" : "fg.muted"}
+                aria-live="polite"
+              >
+                {formatNotice ||
+                  "A submission is accepted if it matches either allowed format."}
+              </Text>
+            </Stack>
             {/* The old control was a Textarea holding a comma-separated
                 string, parsed on blur. Two things were wrong with it, and only
                 one was cosmetic. The cosmetic one: `color="gray"` on the

--- a/components/ui/TagListInput.js
+++ b/components/ui/TagListInput.js
@@ -1,6 +1,7 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback } from "react";
 import { TagsInput, Text } from "@chakra-ui/react";
 import { X } from "lucide-react";
+import useTransientNotice from "./useTransientNotice";
 
 /**
  * TagListInput
@@ -85,11 +86,6 @@ import { X } from "lucide-react";
  *   highlighted pill, or double-click).
  */
 
-// How long a rejection notice holds the message slot before the helper text
-// comes back. Matches SettingsRow's SAVED_VISIBLE_MS -- the two pieces of
-// transient feedback on this page should not linger for different durations.
-const NOTICE_VISIBLE_MS = 3000;
-
 // Quote characters a researcher can plausibly paste around a field name:
 // straight pairs from source code, curly pairs from a document or a chat
 // client, and backticks from a Markdown span. `"trial_type"` copied out of a
@@ -160,31 +156,10 @@ export default function TagListInput({
     if (!onChange) console.error("TagListInput: `onChange` is required.");
   }
 
-  const [notice, setNotice] = useState(null);
-
-  // The rejection notice is transient. Keyed on a counter rather than the
-  // message text so that the same rejection twice in a row restarts the timer
-  // instead of letting the first one's timeout clear the second one early.
-  const [noticeKey, setNoticeKey] = useState(0);
-  const mounted = useRef(true);
-  useEffect(() => {
-    mounted.current = true;
-    return () => {
-      mounted.current = false;
-    };
-  }, []);
-  useEffect(() => {
-    if (!notice) return undefined;
-    const timer = setTimeout(() => {
-      if (mounted.current) setNotice(null);
-    }, NOTICE_VISIBLE_MS);
-    return () => clearTimeout(timer);
-  }, [notice, noticeKey]);
-
-  const say = useCallback((message) => {
-    setNotice(message);
-    setNoticeKey((k) => k + 1);
-  }, []);
+  // Shared with the format checkboxes in ExperimentValidation, which refuse
+  // the same way for the same reason: the write never happened, and the
+  // researcher is owed the reason.
+  const { notice, say, clear: clearNotice } = useTransientNotice();
 
   const committed = normalizeList(value);
 
@@ -196,10 +171,10 @@ export default function TagListInput({
       // "rt," adds nothing once the empty is dropped. Writing in that case
       // would be a Firestore round trip for no change.
       if (sameList(next, committed)) return;
-      setNotice(null);
+      clearNotice();
       onChange(next);
     },
-    [committed, onChange]
+    [committed, onChange, clearNotice]
   );
 
   /**

--- a/components/ui/useTransientNotice.js
+++ b/components/ui/useTransientNotice.js
@@ -1,0 +1,67 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+/**
+ * useTransientNotice
+ *
+ * A short message that explains why an input REFUSED something, and then gets
+ * out of the way.
+ *
+ * This is the third piece of transient feedback in the dashboard, after
+ * `SettingsRow`'s "Saved" chip and the save-error block. It covers the case
+ * neither of those does: the write never happened, and not because anything
+ * failed -- the control declined to make the change, and a control that
+ * declines silently is indistinguishable from one that is broken. Both call
+ * sites exist to remove that ambiguity (`TagListInput` when a pill would be a
+ * duplicate, `ExperimentValidation` when unticking a format would leave none),
+ * so they should say it the same way and for the same length of time.
+ *
+ * Pair it with a message slot that is ALWAYS one line tall -- steady-state
+ * helper text swapped for the notice, not a message that mounts underneath.
+ * See the note in TagListInput: a notice that appears and disappears in the
+ * layout pushes everything below it down and back on every rejected keystroke.
+ *
+ * @param {number} [visibleMs] - How long the notice holds the slot.
+ * @returns {{notice: string|null, say: (message: string) => void,
+ *   clear: () => void}}
+ */
+
+// Matches SettingsRow's SAVED_VISIBLE_MS. The transient feedback on a page
+// should not linger for different durations depending on which control
+// produced it.
+const DEFAULT_VISIBLE_MS = 3000;
+
+export default function useTransientNotice(visibleMs = DEFAULT_VISIBLE_MS) {
+  const [notice, setNotice] = useState(null);
+
+  // The timer is keyed on a counter rather than the message text so that the
+  // same rejection twice in a row restarts it, instead of letting the first
+  // one's timeout clear the second one early.
+  const [noticeKey, setNoticeKey] = useState(0);
+
+  const mounted = useRef(true);
+  useEffect(() => {
+    mounted.current = true;
+    return () => {
+      mounted.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!notice) return undefined;
+    const timer = setTimeout(() => {
+      if (mounted.current) setNotice(null);
+    }, visibleMs);
+    return () => clearTimeout(timer);
+  }, [notice, noticeKey, visibleMs]);
+
+  const say = useCallback((message) => {
+    setNotice(message);
+    setNoticeKey((k) => k + 1);
+  }, []);
+
+  const clear = useCallback(() => setNotice(null), []);
+
+  return { notice, say, clear };
+}
+
+export { DEFAULT_VISIBLE_MS };


### PR DESCRIPTION
Follow-up to #209. Option 1 from the discussion there, UI only — no server change.

## Why

With validation on and neither format allowed, `functions/src/api-data.ts:86-104` cannot reach either validator:

```ts
let valid: boolean = false;
if (exp_data.allowJSON) { /* ... */ }
if (exp_data.allowCSV && !valid) { /* ... */ }
if (!valid) { res.status(400).json(MESSAGES.INVALID_DATA); ... }
```

Every submission takes the 400, `requiredFields` is never consulted, and the experiment silently stops collecting. The error the researcher eventually finds in the log says `"The data are not valid according to the validation parameters set for this experiment."` — pointing at the participant's submission, when the submission never mattered.

It's two clicks in a panel that gives no sign the second one means something categorically different from the first.

## What changed

The checkbox group declines to go empty, the way `TagListInput` declines a duplicate. Declining is just not calling `setValidationSettings` — the group is controlled, so the tick mark never moves and the save effect never fires.

Two things that weren't free:

**The refusal needs a voice.** A control that declines silently is indistinguishable from one that is broken, so the checkboxes gain the same always-one-line message slot `TagListInput` uses — steady-state guidance swapped for the reason, never a block that mounts underneath and pushes the rest of the panel down on every click. The transient-notice machinery is extracted to `useTransientNotice` and shared by both, so the two refusals in this panel say their piece for the same duration. `TagListInput`'s 25 tests pass unchanged across that extraction.

**The refusal needs to reach the accessibility tree.** Ark has already flipped the real `<input>` by the time `onValueChange` runs; refusing leaves React state untouched, so React re-renders with the same `checked` prop and never resets the node. What the researcher *sees* stays correct — the tick is drawn from the controlled group value — but the hidden input is what a screen reader reads, and it now says unchecked: the opposite of what happened. `resyncFormatInputs` puts the property back. This was caught by `toBeChecked()`, which reads the property rather than the attribute.

## Scope

This is a UI floor, not a guarantee. The server is unchanged, so a document that already holds the state — or one written any other way — behaves exactly as it did. That was a deliberate call, not an oversight.

## Tests

Three cases added. Two fail with the guard disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SHZNijLwUhn26yCbYbn1UN