### PR TITLE
Keep the mail TTL policy from being deleted by every deploy

### DIFF
--- a/docs/deploy-contact-email.md
+++ b/docs/deploy-contact-email.md
@@ -326,42 +326,72 @@ Run order:
    backfill has already cleared most of the population that would otherwise
    hit the gate on their very next visit.
 
-## 4. Mail retention: the TTL policy is now a MANUAL step
+## 4. Mail retention: the TTL policy lives in `firestore.indexes.json`
 
 `mail` documents hold a researcher's address (in `to`) and, after delivery, the
 audit trail `mail-delivery.ts` writes (`delivery.state`, `delivery.attempts`,
 `delivery.error`, `delivery.info`). They should not accumulate indefinitely.
 
-**This is the one thing the extension used to configure for you and now nobody
-does.** There is no install step that creates the TTL policy any more, and
-`mail-delivery.ts` cannot create one — a TTL policy is project configuration,
-not something an SDK write can set. If this step is skipped, `mail` grows
-unbounded forever, holding researcher addresses, and nothing else will catch
-it. Create it by hand, once per project:
+The extension used to configure this for you. `mail-delivery.ts` cannot — a TTL
+policy is project configuration, not something an SDK write can set. So it is
+declared in `firestore.indexes.json` and deployed with everything else:
+
+```json
+"fieldOverrides": [
+  {
+    "collectionGroup": "mail",
+    "fieldPath": "delivery.expireAt",
+    "ttl": true,
+    "indexes": [
+      { "order": "ASCENDING",  "queryScope": "COLLECTION" },
+      { "order": "DESCENDING", "queryScope": "COLLECTION" },
+      { "arrayConfig": "CONTAINS", "queryScope": "COLLECTION" }
+    ]
+  }
+]
+```
+
+**DO NOT create this by hand with `gcloud`, and do not remove it from this
+file.** An earlier version of this section said to run
+`gcloud firestore fields ttls update` once per project. That is worse than
+useless, and here is what actually happened when someone followed it:
 
 ```
-gcloud firestore fields ttls update 'delivery.expireAt' \
-  --collection-group=mail \
-  --enable-ttl \
-  --database='(default)' \
-  --project=osf-relay
+14:51  gcloud ... --enable-ttl --project=datapipe-test   → ACTIVE
+15:02  PR merged to `test`
+15:04  firestore: Deleting 1 field overrides...          ← the deploy
+15:10  TTL gone
 ```
 
-(Console equivalent: Firestore → **Time-to-live (TTL)** → *Create policy* →
-collection group `mail`, timestamp field **`delivery.expireAt`** — the same
-field as the command above, NOT `delivery.endTime`. An earlier draft of this
-line said `endTime`, which would have been silently wrong in the expensive
-direction: native TTL deletes as soon as the timestamp passes, and `endTime` is
-set the instant an outcome turns terminal, so that policy reaps every mail
-document the moment it is delivered. No debugging window, and nothing anywhere
-saying it happened. See the first bullet below.) Repeat with
-`--project=datapipe-test`. Confirm afterwards with:
+The deploy step is `firebase deploy --only firestore,functions,hosting
+--force`, and `--only firestore` **reconciles** field overrides against this
+file. With `"fieldOverrides": []` in it, a hand-made TTL is not merely
+un-managed — it is something the deploy is actively instructed to delete. The
+`--force` flag suppresses the confirmation prompt that would otherwise say so,
+and the deploy reports success. A manual TTL therefore survives exactly until
+the next deploy of any kind, silently, and the retention promise quietly stops
+being kept while the runbook says it is.
+
+The three default single-field indexes in the block above are deliberate. A
+`fieldOverride` replaces the field's whole index configuration, so writing
+`"indexes": []` would additionally turn OFF single-field indexing for
+`delivery.expireAt` — a second, unrelated change nobody asked for. The block
+above is what `firebase firestore:indexes` emits for a field with TTL on and
+default indexing, so it round-trips.
+
+Confirm after a deploy with either:
 
 ```
+gcloud firestore fields ttls list --collection-group=mail --project=datapipe-test
 gcloud firestore fields ttls list --collection-group=mail --project=osf-relay
 ```
 
-Three things about this policy that are worth knowing before you run it:
+`state: ACTIVE` is what you want. `CREATING` means the field-level backfill is
+still running — it takes several minutes regardless of collection size, because
+it is a control-plane operation, not a data one. `Listed 0 items` after a deploy
+means this block is missing from `firestore.indexes.json`.
+
+Three things about this policy that are worth knowing:
 
 - **`delivery.endTime` is set only on a TERMINAL outcome** — `SUCCESS`, or an
   `ERROR` that will not be retried. A document in a retryable error state has

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -69,5 +69,25 @@
       ]
     }
   ],
-  "fieldOverrides": []
+  "fieldOverrides": [
+    {
+      "collectionGroup": "mail",
+      "fieldPath": "delivery.expireAt",
+      "ttl": true,
+      "indexes": [
+        {
+          "order": "ASCENDING",
+          "queryScope": "COLLECTION"
+        },
+        {
+          "order": "DESCENDING",
+          "queryScope": "COLLECTION"
+        },
+        {
+          "arrayConfig": "CONTAINS",
+          "queryScope": "COLLECTION"
+        }
+      ]
+    }
+  ]
 }

--- a/functions/src/mail-delivery.ts
+++ b/functions/src/mail-delivery.ts
@@ -26,7 +26,7 @@
 // `delivery.endTime`, `delivery.error`, `delivery.info.messageId`. Every
 // downstream decision that was ever going to be made from an extension-shaped
 // document still works -- including the Firestore TTL policy, which keys on
-// `delivery.endTime` (docs/deploy-contact-email.md §4). Nothing new is added
+// `delivery.expireAt` (docs/deploy-contact-email.md §4). Nothing new is added
 // at the top level of the document, so purge-user-data.ts's
 // `datapipe.owner == uid` query is untouched: everything here lives under
 // `delivery`.
@@ -762,9 +762,10 @@ export async function deliverMailDocument(docId: string): Promise<DeliveryOutcom
       "delivery.leaseExpiresAt": Timestamp.fromMillis(now.toMillis() + LEASE_MS),
       "delivery.error": null,
       "delivery.retryable": null,
-      // The TTL policy keys on endTime (docs/deploy-contact-email.md §4).
-      // Explicitly null while in flight so a document being retried cannot be
-      // reaped out from under the retry.
+      // endTime is not itself the TTL key -- delivery.expireAt is
+      // (docs/deploy-contact-email.md §4) -- but expireAt is only ever written
+      // alongside a terminal endTime, so clearing this is what keeps a
+      // document being retried out of the reaper's reach.
       "delivery.endTime": null,
     };
     // startTime is when delivery FIRST began, so a retry does not move it --


### PR DESCRIPTION
The TTL on `mail/delivery.expireAt` was created by hand with `gcloud`, as runbook §4 instructed. **The next deploy deleted it.**

```
14:51  gcloud ... --enable-ttl --project=datapipe-test   → ACTIVE
15:02  PR #211 merged to `test`
15:04  firestore: Deleting 1 field overrides...          ← the deploy
15:10  TTL gone
```

That middle line is from the [deploy log](https://github.com/jspsych/datapipe/actions/runs/33259154605), verbatim.

## Why

`firebase deploy --only firestore` **reconciles** field overrides against `firestore.indexes.json`, and that file said `"fieldOverrides": []` — an explicit assertion that no field overrides should exist. So a hand-made TTL wasn't merely unmanaged; it was something the deploy was actively instructed to delete. `--force` suppressed the confirmation prompt that would have said so, and the deploy reported success.

A manual TTL therefore survives exactly until the next deploy of any kind, silently. The retention promise stops being kept while the runbook says it is — and the only symptom is a `mail` collection quietly accumulating researcher email addresses forever.

**This currently affects prod too.** `osf-relay`'s TTL is `ACTIVE` right now, but the next deploy to `main` removes it by the same mechanism.

## The fix

Declared in `firestore.indexes.json`, so it's version-controlled and *created* by the same deploy that was deleting it. Merging this restores the `datapipe-test` policy automatically — no `gcloud` needed — and protects prod ahead of its next deploy.

Two details that aren't arbitrary:

- **The block is not hand-written.** It's what `firebase firestore:indexes` emits, read off `osf-relay` while its policy was still active, so it round-trips rather than being a guess at the schema.
- **The three default single-field indexes are deliberate.** A `fieldOverride` replaces the field's *entire* index configuration, so `"indexes": []` would additionally turn off single-field indexing for `delivery.expireAt` — an unrelated second change nobody asked for.

## Also

- **Runbook §4 rewritten** around the declarative mechanism, keeping the timeline above in it. Following the old instructions produced a policy that survived until the next deploy; that's worth not having to rediscover.
- **Two comments in `mail-delivery.ts` corrected** — they said the TTL keys on `delivery.endTime`. It keys on `delivery.expireAt`; `endTime` only gates whether `expireAt` gets written. That same confusion is what put the wrong field in §4's console instructions, fixed in #211.

## Checked for wider drift

No real indexes are at risk. Local `firestore.indexes.json` has one `uploadQueue` index (`experimentID, status, providerErrorCode`) that prod lacks — a *create* on next deploy, not a delete. Nothing deployed is missing from the file.

## Verifying after merge

```
gcloud firestore fields ttls list --collection-group=mail --project=datapipe-test
```

`state: ACTIVE` is the goal. `CREATING` means the field backfill is still running — several minutes regardless of collection size, since it's a control-plane operation. `Listed 0 items` would mean this didn't take.

🤖 Generated with [Claude Code](https://claude.com/claude-code)